### PR TITLE
E x perience83 patch 1

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,27 @@
+name: Format (Black auto-commit)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Black
+        run: pip install black
+      - name: Run Black
+        run: black .
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: format with Black"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
       - name: Install dependencies
         run: pip install black ruff
+
       - name: Ruff check
         run: ruff check .
+
       - name: Black check
         run: black --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: pip install black ruff
+      - name: Ruff check
+        run: ruff check .
+      - name: Black check
+        run: black --check .

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Get sensors for grass, tree, weed pollen, plus individual plants like **OAK**, *
   * **Plants** (Oak, Pine, Birch, …)
   * **Pollen Info** (Region, Forecast Date, Last Updated)
 * **Configurable updates** – choose your own refresh interval (default 6 h).
+* **Options Flow** – change the update interval and the API response language directly from the integration options (no reinstall required).
 * **Manual refresh** – call the service `pollenlevels.force_update` to fetch new data instantly and reset the timer.
 * **Last Updated sensor** – shows the timestamp of the last successful update in *local* time.
 * **Rich attributes** – season status, plant family, cross‑reactivity info and more.
@@ -70,6 +71,15 @@ Get sensors for grass, tree, weed pollen, plus individual plants like **OAK**, *
    * **Location** (auto‑filled from HA config)
    * **Update Interval** (hours)
    * **Language Code** (e.g. `en`, `es`, `de`, `fr`, `uk`)
+
+## ⚙️ Options (interval & language)
+
+After adding the integration, you can change:
+- **Update interval (hours)**
+- **API response language code** (e.g., `en`, `es`, `fr`, `de`, `uk`)
+
+Open **Settings → Devices & Services → Pollen Levels → Configure**.
+Changes are stored as entry options and automatically applied after the integration reloads.
 
 ## 🗝️ Obtaining a Google API Key
 

--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@ Get sensors for grass, tree, weed pollen, plus individual plants like **OAK**, *
 
 ## 🌟 Features
 
-* **Multi‑language UI** – translated into 9 languages (EN, ES, CA, DE, FR, IT, PL, RU, UK) and able to request API data in *any* language.
+* **Multi-language UI** – translated into 9 languages (EN, ES, CA, DE, FR, IT, PL, RU, UK) and able to request API data in *any* language.
 * **Dynamic sensors** – automatically creates sensors for every pollen type and plant found at your location.
 * **Smart grouping** – sensors are neatly organised into three logical devices:
-
   * **Pollen Types** (Grass / Tree / Weed)
   * **Plants** (Oak, Pine, Birch, …)
   * **Pollen Info** (Region, Forecast Date, Last Updated)
-* **Configurable updates** – choose your own refresh interval (default 6 h).
+* **Configurable updates** – choose your own refresh interval (default 6 h).
 * **Options Flow** – change the update interval and the API response language directly from the integration options (no reinstall required).
 * **Manual refresh** – call the service `pollenlevels.force_update` to fetch new data instantly and reset the timer.
 * **Last Updated sensor** – shows the timestamp of the last successful update in *local* time.
-* **Rich attributes** – season status, plant family, cross‑reactivity info and more.
+* **Rich attributes** – season status, plant family, cross-reactivity info, and index description (UPI).
 * **Zero YAML** – fully configurable from the Home Assistant UI.
-* **HACS native** – effortless install & one‑click updates via HACS.
+* **HACS native** – effortless install & one-click updates via HACS.
+
 
 ## ⚙️ Installation
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1] – 2025-08-08
+### Added
+- **Index description attribute**: Each pollen **type** and **plant** sensor now exposes the human-readable `description` derived from Google’s `indexInfo.indexDescription` (UPI). This is additive and does not change entity states or IDs.
+### Maintenance
+- Minor code hygiene in `config_flow.py`: import order clean-up and removal of a redundant manual interval check (schema already enforces `min=1`).
+
 ## [1.5.0] – 2025-08-08
 ### Added
 - **Options Flow** to change `update_interval` and `language_code` without reinstalling.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.2] – 2025-08-09
+### Added
+- **Localized Options Flow strings** for 9 languages (EN, ES, CA, DE, FR, IT, PL, RU, UK). Users now see the Options dialog (title, description, fields) fully translated.
+### Maintenance
+- Version bump in `manifest.json` to 1.5.2.
+- Verified that translations match the Options Flow step id (`init`) and keys (`update_interval`, `language_code`).
+
 ## [1.5.1] – 2025-08-08
 ### Added
 - **Index description attribute**: Each pollen **type** and **plant** sensor now exposes the human-readable `description` derived from Google’s `indexInfo.indexDescription` (UPI). This is additive and does not change entity states or IDs.

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,20 @@
 # Changelog
 
-## [1.4.2] – 2025-07-09
+## [1.5.0] – 2025-08-08
+### Added
+- **Options Flow** to change `update_interval` and `language_code` without reinstalling.
+- **Duplicate prevention**: entries are uniquely identified by `(latitude, longitude)` and duplicates are rejected.
+### Changed
+- Reused the same language-code validation in options to provide consistent, localized error messages.
+### Notes
+- To apply options immediately, the integration reloads after saving. Make sure the coordinator reads `entry.options` first (fallback to `entry.data`).
 
+
+## [1.4.2] – 2025-07-09
 ### Changed
 - Updated Readme and minor changes.
 
 ## [1.4.1] – 2025-07-07
-
 ### Changed
 - Reordered keys in `manifest.json` to satisfy Hassfest requirements (domain, name, then the rest alphabetically).
 - Added `services.yaml` to document the `pollenlevels.force_update` service.
@@ -14,7 +22,6 @@
 - Removed unsupported `"domains"` key from `hacs.json`.
 - Updated `hacs.json` to include only the necessary fields (`name`, `render_readme`, `content_in_root`).
 - Added required GitHub topics (`home-assistant`, `hacs`, `integration`, `sensor`, `pollen`, `allergy`) to pass HACS topic validation.
-
 ### Fixed
 - Metadata ordering and format corrections to comply with CI validations.
 
@@ -43,7 +50,6 @@
 ### Fixed
 - Ensure all sensor entities (including `PollenSensor`, `RegionSensor`, `DateSensor` and `LastUpdatedSensor`) subclass `CoordinatorEntity`, so their state updates immediately after calling `pollenlevels.force_update`.
 - Correct propagation of the `last_updated` timestamp to the **Last Updated** sensor on manual refresh.
-
 ### Changed
 - Rewrote all docstrings in imperative, one‑line style to comply with PEP 257 and remove in‑line `# noqa` directives.
 - Reorganized `sensor.py` with clear section headers and streamlined comments for readability.
@@ -52,7 +58,6 @@
 ### Added
 - Service pollenlevels.force_update to manually trigger an immediate refresh of all sensors and reset the update interval.
 - New Last Updated metadata sensor displaying the ISO‑8601 timestamp of the last successful data fetch.
-
 ### Changed
 - Cleaned up docstrings to imperative style to comply with PEP 257 and avoid per-line # noqa directives.
 - Reorganized sensor.py with clear section headers and comments.
@@ -60,13 +65,11 @@
 ## [1.3.7.1] - 2025-05-29
 ### Added
 - **New plant sensor attribute**: Added `cross_reaction` field showing pollen cross-reactivity information for each plant type.
-
 ### Fixed
 - **Critical syntax error**: Fixed unclosed parenthesis in config_flow.py that prevented integration loading.
 - **Language validation**: 
   - Improved error logging for invalid language codes
   - Corrected indentation in validation error handling
-
 ### Improved
 - **Data completeness**: Plant sensors now include all available API data including cross-reactivity warnings
 - **Error handling**: More detailed logging for configuration flow errors
@@ -78,19 +81,16 @@
   - Updated regex pattern to `^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$` (supports 3-letter base codes like `cmn` and regions like `zh-Hant`).
   - Added case-insensitive matching (`en-US` and `en-us` now both valid).
   - Improved empty string check with `.strip()` to catch whitespace-only inputs.
-
 ### Improved
 - Added detailed warning logs for language code validation failures in `config_flow.py`.
 
 ## [1.3.5] - 2025-05-27
 ### Added
 - New **Region** and **Date** metadata sensors to expose `regionCode` and API response date in a dedicated **Pollen Info** device.
-
 ### Improved
 - **Language code validation** refined using IETF regex `^[a-zA-Z]{2,3}(-[a-zA-Z]{2})?$` to support codes like `es`, `en-US`, `fr-CA`, etc.
 - Introduced `is_valid_language_code(value)` helper that raises `vol.Invalid("invalid_language")` for invalid formats and `vol.Invalid("empty")` for blank inputs.
 - Translations updated with new error keys `invalid_language` and `empty` across all supported languages.
-
 ### Fixed
 - ❗️ **UI schema serialization crash**: Removed `vol.All(cv.string, is_valid_language_code)` from the `data_schema` to restore compatibility with Home Assistant's UI config flow system.  
   Validation now occurs manually before API call, and error is assigned via `errors[CONF_LANGUAGE_CODE]`.
@@ -120,13 +120,11 @@
 ### Added
 - Optional `language_code` field in configuration to request API responses in the desired language.  
 - Translations updated to include `language_code` label and description.  
-
 ### Improved
 - Separated sensors into two devices: **Pollen Types** and **Plants** per location.  
 - Assigned distinct icons for `pollenTypeInfo` codes (GRASS, TREE, WEED).  
 - Assigned icons in *plant* sensors based on `type` attribute, falling back to default flower icon.  
 - Exposed additional attributes on *plant* sensors: `inSeason`, `type`, `family`, `season`.
-
 ### Breaking Changes
 - **REINSTALL REQUIRED**: Prior sensor and device entities must be **deleted** and the integration re-added to apply the new device grouping and attributes.
 

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -1,4 +1,5 @@
 """Initialize Pollen Levels integration."""
+
 import logging
 
 import homeassistant.helpers.config_validation as cv

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -1,4 +1,4 @@
-"""Handle config flow for Pollen Levels integration."""
+"""Handle config & options flow for Pollen Levels integration."""
 import logging
 import aiohttp
 import voluptuous as vol
@@ -20,7 +20,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Improved regex to support base and region subtags
+# Improved regex to support base and region subtags:
 # - 2-3 character base language codes (e.g., "zh", "cmn")
 # - 2-4 character region suffixes (e.g., "zh-Hant", "zh-Hant-TW")
 # - Case-insensitive matching (supports "en-US", "en-us", etc.)
@@ -29,8 +29,8 @@ LANGUAGE_CODE_REGEX = re.compile(
 )
 
 
-def is_valid_language_code(value):
-    """Validate IETF language code."""
+def is_valid_language_code(value: str) -> str:
+    """Validate IETF language code, raising a HA-UI friendly error key."""
     if not isinstance(value, str):
         raise vol.Invalid("invalid_language")
     if not value.strip():
@@ -45,19 +45,39 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Implement config flow for Pollen Levels."""
     VERSION = 1
 
+    @staticmethod
+    def async_get_options_flow(entry: config_entries.ConfigEntry):
+        """Return the options flow handler for this entry."""
+        return PollenLevelsOptionsFlow(entry)
+
     async def async_step_user(self, user_input=None):
         """Handle initial step."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input:
+            # ---- Duplicate prevention -------------------------------------------------
+            # Use a stable unique_id per (lat,lon) with 4 decimal precision so that
+            # we avoid duplicate entries for the same location.
             try:
+                lat = float(user_input[CONF_LATITUDE])
+                lon = float(user_input[CONF_LONGITUDE])
+                await self.async_set_unique_id(f"{lat:.4f}_{lon:.4f}")
+                self._abort_if_unique_id_configured()
+            except Exception:  # pragma: no cover - defensive
+                # If something goes off with parsing, proceed; form validators will catch it.
+                pass
+
+            # ---- Field validation & API reachability ---------------------------------
+            try:
+                # Validate language format locally first (UI-friendly errors)
                 is_valid_language_code(user_input[CONF_LANGUAGE_CODE])
 
+                # Probe API to verify key/quota/connectivity before creating the entry
                 session = async_get_clientsession(self.hass)
                 params = {
                     "key": user_input[CONF_API_KEY],
-                    "location.latitude": f"{user_input[CONF_LATITUDE]:.6f}",
-                    "location.longitude": f"{user_input[CONF_LONGITUDE]:.6f}",
+                    "location.latitude": f"{lat:.6f}",
+                    "location.longitude": f"{lon:.6f}",
                     "days": 1,
                     "languageCode": user_input[CONF_LANGUAGE_CODE],
                 }
@@ -77,23 +97,26 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         if not data.get("dailyInfo"):
                             _LOGGER.warning("Validation: 'dailyInfo' missing")
                             errors["base"] = "cannot_connect"
+
             except vol.Invalid as ve:
                 _LOGGER.warning(
                     "Language code validation failed for '%s': %s",
-                    user_input[CONF_LANGUAGE_CODE],
+                    user_input.get(CONF_LANGUAGE_CODE),
                     ve,
                 )
                 errors[CONF_LANGUAGE_CODE] = str(ve)
             except aiohttp.ClientError as err:
                 _LOGGER.error("Connection error: %s", err)
                 errors["base"] = "cannot_connect"
-            except Exception as err:
+            except Exception as err:  # pragma: no cover - defensive
                 _LOGGER.exception("Unexpected error: %s", err)
                 errors["base"] = "cannot_connect"
 
             if not errors:
+                # Create the entry with the provided data.
                 return self.async_create_entry(title="Pollen Levels", data=user_input)
 
+        # Default values from HA config for the form
         defaults = {
             CONF_LATITUDE: self.hass.config.latitude,
             CONF_LONGITUDE: self.hass.config.longitude,
@@ -103,21 +126,84 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema(
             {
                 vol.Required(CONF_API_KEY): str,
-                vol.Optional(
-                    CONF_LATITUDE, default=defaults[CONF_LATITUDE]
-                ): cv.latitude,
-                vol.Optional(
-                    CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]
-                ): cv.longitude,
+                vol.Optional(CONF_LATITUDE, default=defaults[CONF_LATITUDE]): cv.latitude,
+                vol.Optional(CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]): cv.longitude,
                 vol.Optional(
                     CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                vol.Optional(
-                    CONF_LANGUAGE_CODE, default=defaults[CONF_LANGUAGE_CODE]
-                ): str,
+                vol.Optional(CONF_LANGUAGE_CODE, default=defaults[CONF_LANGUAGE_CODE]): str,
             }
         )
 
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+
+class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
+    """Handle options for an existing entry."""
+
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        self.entry = entry
+
+    async def async_step_init(self, user_input=None):
+        """Display and process options form."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Validate language if provided
+            try:
+                # Allow empty to "inherit" HA UI language, but if non-empty, validate format.
+                lang = user_input.get(
+                    CONF_LANGUAGE_CODE,
+                    self.entry.options.get(
+                        CONF_LANGUAGE_CODE,
+                        self.entry.data.get(CONF_LANGUAGE_CODE, ""),
+                    ),
+                )
+                if isinstance(lang, str) and lang.strip():
+                    is_valid_language_code(lang)
+
+                # Update interval basic sanity check
+                interval = int(
+                    user_input.get(
+                        CONF_UPDATE_INTERVAL,
+                        self.entry.options.get(
+                            CONF_UPDATE_INTERVAL,
+                            self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+                        ),
+                    )
+                )
+                if interval < 1:
+                    errors[CONF_UPDATE_INTERVAL] = "value_error"
+
+            except vol.Invalid as ve:
+                errors[CONF_LANGUAGE_CODE] = str(ve)
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.exception("Options validation error: %s", err)
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                # Store options; the integration should reload to apply them.
+                return self.async_create_entry(title="", data=user_input)
+
+        # Defaults: prefer options, fall back to data, then HA language
+        current_interval = self.entry.options.get(
+            CONF_UPDATE_INTERVAL,
+            self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+        )
+        current_lang = self.entry.options.get(
+            CONF_LANGUAGE_CODE,
+            self.entry.data.get(CONF_LANGUAGE_CODE, self.hass.config.language),
+        )
+
         return self.async_show_form(
-            step_id="user", data_schema=schema, errors=errors
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_UPDATE_INTERVAL, default=current_interval): vol.All(
+                        vol.Coerce(int), vol.Range(min=1)
+                    ),
+                    vol.Optional(CONF_LANGUAGE_CODE, default=current_lang): str,
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -1,9 +1,8 @@
 """Handle config & options flow for Pollen Levels integration."""
 import logging
-import re
-
 import aiohttp
 import voluptuous as vol
+import re
 
 from homeassistant import config_entries
 import homeassistant.helpers.config_validation as cv
@@ -25,7 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 # - 2-3 character base language codes (e.g., "zh", "cmn")
 # - 2-4 character region suffixes (e.g., "zh-Hant", "zh-Hant-TW")
 # - Case-insensitive matching (supports "en-US", "en-us", etc.)
-LANGUAGE_CODE_REGEX = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$", re.IGNORECASE)
+LANGUAGE_CODE_REGEX = re.compile(
+    r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$", re.IGNORECASE
+)
 
 
 def is_valid_language_code(value: str) -> str:
@@ -42,7 +43,6 @@ def is_valid_language_code(value: str) -> str:
 
 class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Implement config flow for Pollen Levels."""
-
     VERSION = 1
 
     @staticmethod
@@ -55,21 +55,24 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input:
-            # HA schema already coerces/validates latitude/longitude.
-            lat = float(user_input[CONF_LATITUDE])
-            lon = float(user_input[CONF_LONGITUDE])
-
-            # ---- Duplicate prevention ------------------------------------------
-            # Use a stable unique_id per (lat, lon) rounded to 4 decimals.
-            await self.async_set_unique_id(f"{lat:.4f}_{lon:.4f}")
-            self._abort_if_unique_id_configured()
-
-            # ---- Field validation & API reachability ---------------------------
+            # ---- Duplicate prevention -------------------------------------------------
+            # Use a stable unique_id per (lat,lon) with 4 decimal precision so that
+            # we avoid duplicate entries for the same location.
             try:
-                # Validate language format locally first (UI-friendly errors).
+                lat = float(user_input[CONF_LATITUDE])
+                lon = float(user_input[CONF_LONGITUDE])
+                await self.async_set_unique_id(f"{lat:.4f}_{lon:.4f}")
+                self._abort_if_unique_id_configured()
+            except Exception:  # pragma: no cover - defensive
+                # If something goes off with parsing, proceed; form validators will catch it.
+                pass
+
+            # ---- Field validation & API reachability ---------------------------------
+            try:
+                # Validate language format locally first (UI-friendly errors)
                 is_valid_language_code(user_input[CONF_LANGUAGE_CODE])
 
-                # Probe API to verify key/quota/connectivity before creating the entry.
+                # Probe API to verify key/quota/connectivity before creating the entry
                 session = async_get_clientsession(self.hass)
                 params = {
                     "key": user_input[CONF_API_KEY],
@@ -110,9 +113,10 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
 
             if not errors:
+                # Create the entry with the provided data.
                 return self.async_create_entry(title="Pollen Levels", data=user_input)
 
-        # Default values from HA config for the form.
+        # Default values from HA config for the form
         defaults = {
             CONF_LATITUDE: self.hass.config.latitude,
             CONF_LONGITUDE: self.hass.config.longitude,
@@ -123,9 +127,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_API_KEY): str,
                 vol.Optional(CONF_LATITUDE, default=defaults[CONF_LATITUDE]): cv.latitude,
-                vol.Optional(
-                    CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]
-                ): cv.longitude,
+                vol.Optional(CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]): cv.longitude,
                 vol.Optional(
                     CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
@@ -147,6 +149,7 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            # Validate language if provided
             try:
                 # Allow empty to "inherit" HA UI language, but if non-empty, validate format.
                 lang = user_input.get(
@@ -159,6 +162,19 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
                 if isinstance(lang, str) and lang.strip():
                     is_valid_language_code(lang)
 
+                # Update interval basic sanity check
+                interval = int(
+                    user_input.get(
+                        CONF_UPDATE_INTERVAL,
+                        self.entry.options.get(
+                            CONF_UPDATE_INTERVAL,
+                            self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+                        ),
+                    )
+                )
+                if interval < 1:
+                    errors[CONF_UPDATE_INTERVAL] = "value_error"
+
             except vol.Invalid as ve:
                 errors[CONF_LANGUAGE_CODE] = str(ve)
             except Exception as err:  # pragma: no cover - defensive
@@ -166,9 +182,10 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
                 errors["base"] = "cannot_connect"
 
             if not errors:
+                # Store options; the integration should reload to apply them.
                 return self.async_create_entry(title="", data=user_input)
 
-        # Defaults: prefer options, fall back to data, then HA language.
+        # Defaults: prefer options, fall back to data, then HA language
         current_interval = self.entry.options.get(
             CONF_UPDATE_INTERVAL,
             self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
@@ -182,9 +199,9 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(
-                        CONF_UPDATE_INTERVAL, default=current_interval
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    vol.Optional(CONF_UPDATE_INTERVAL, default=current_interval): vol.All(
+                        vol.Coerce(int), vol.Range(min=1)
+                    ),
                     vol.Optional(CONF_LANGUAGE_CODE, default=current_lang): str,
                 }
             ),

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -1,4 +1,5 @@
 """Handle config & options flow for Pollen Levels integration."""
+
 import logging
 import aiohttp
 import voluptuous as vol
@@ -24,9 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 # - 2-3 character base language codes (e.g., "zh", "cmn")
 # - 2-4 character region suffixes (e.g., "zh-Hant", "zh-Hant-TW")
 # - Case-insensitive matching (supports "en-US", "en-us", etc.)
-LANGUAGE_CODE_REGEX = re.compile(
-    r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$", re.IGNORECASE
-)
+LANGUAGE_CODE_REGEX = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2,4})?$", re.IGNORECASE)
 
 
 def is_valid_language_code(value: str) -> str:
@@ -43,6 +42,7 @@ def is_valid_language_code(value: str) -> str:
 
 class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Implement config flow for Pollen Levels."""
+
     VERSION = 1
 
     @staticmethod
@@ -126,12 +126,18 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema(
             {
                 vol.Required(CONF_API_KEY): str,
-                vol.Optional(CONF_LATITUDE, default=defaults[CONF_LATITUDE]): cv.latitude,
-                vol.Optional(CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]): cv.longitude,
+                vol.Optional(
+                    CONF_LATITUDE, default=defaults[CONF_LATITUDE]
+                ): cv.latitude,
+                vol.Optional(
+                    CONF_LONGITUDE, default=defaults[CONF_LONGITUDE]
+                ): cv.longitude,
                 vol.Optional(
                     CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
                 ): vol.All(vol.Coerce(int), vol.Range(min=1)),
-                vol.Optional(CONF_LANGUAGE_CODE, default=defaults[CONF_LANGUAGE_CODE]): str,
+                vol.Optional(
+                    CONF_LANGUAGE_CODE, default=defaults[CONF_LANGUAGE_CODE]
+                ): str,
             }
         )
 
@@ -168,7 +174,9 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
                         CONF_UPDATE_INTERVAL,
                         self.entry.options.get(
                             CONF_UPDATE_INTERVAL,
-                            self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+                            self.entry.data.get(
+                                CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                            ),
                         ),
                     )
                 )
@@ -199,9 +207,9 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
             step_id="init",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(CONF_UPDATE_INTERVAL, default=current_interval): vol.All(
-                        vol.Coerce(int), vol.Range(min=1)
-                    ),
+                    vol.Optional(
+                        CONF_UPDATE_INTERVAL, default=current_interval
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                     vol.Optional(CONF_LANGUAGE_CODE, default=current_lang): str,
                 }
             ),

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
   "requirements": ["aiohttp"],
-  "version": "1.4.2"
+  "version": "1.5.0"
 }

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
   "requirements": ["aiohttp"],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
   "requirements": ["aiohttp"],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -1,4 +1,5 @@
 """Provide Pollen Levels sensors with language support and metadata."""
+
 import logging
 from datetime import timedelta
 
@@ -50,7 +51,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     # Read update interval and language from options first (if present)
     interval = entry.options.get(
-        CONF_UPDATE_INTERVAL, entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        CONF_UPDATE_INTERVAL,
+        entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
     )
     lang = entry.options.get(CONF_LANGUAGE_CODE, entry.data.get(CONF_LANGUAGE_CODE))
 
@@ -152,7 +154,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         new_data: dict[str, dict] = {}
 
         # Extract region code
-        if (region := payload.get("regionCode")):
+        if region := payload.get("regionCode"):
             new_data["region"] = {"source": "meta", "value": region}
 
         # Extract date and pollen information

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -21,6 +21,18 @@
       "empty": "Aquest camp no pot estar buit"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Opcions",
+        "description": "Canvia l'interval d’actualització i l'idioma de resposta de l’API.",
+        "data": {
+          "update_interval": "Interval d’actualització (hores)",
+          "language_code": "Codi d’idioma de la resposta API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Tipus de pol·len ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Regió" },
-      "date": { "name": "Data" },
-      "last_updated": { "name": "Última actualització" }
+      "region": {
+        "name": "Regió"
+      },
+      "date": {
+        "name": "Data"
+      },
+      "last_updated": {
+        "name": "Última actualització"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -21,6 +21,18 @@
       "empty": "Dieses Feld darf nicht leer sein"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Optionen",
+        "description": "Ändere das Aktualisierungsintervall und die API-Antwortsprache.",
+        "data": {
+          "update_interval": "Aktualisierungsintervall (Stunden)",
+          "language_code": "Sprachcode für Antwort"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Pollenarten ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Region" },
-      "date": { "name": "Datum" },
-      "last_updated": { "name": "Letzte Aktualisierung" }
+      "region": {
+        "name": "Region"
+      },
+      "date": {
+        "name": "Datum"
+      },
+      "last_updated": {
+        "name": "Letzte Aktualisierung"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -21,6 +21,18 @@
       "empty": "This field cannot be empty"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Options",
+        "description": "Change the update interval and the API response language.",
+        "data": {
+          "update_interval": "Update interval (hours)",
+          "language_code": "API response language code"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Pollen Types ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Region" },
-      "date": { "name": "Date" },
-      "last_updated": { "name": "Last Updated" }
+      "region": {
+        "name": "Region"
+      },
+      "date": {
+        "name": "Date"
+      },
+      "last_updated": {
+        "name": "Last Updated"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -21,6 +21,18 @@
       "empty": "Este campo no puede estar vacío"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Opciones",
+        "description": "Cambia el intervalo de actualización y el idioma de respuesta de la API.",
+        "data": {
+          "update_interval": "Intervalo de actualización (horas)",
+          "language_code": "Código de idioma de la respuesta"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Tipos de polen ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Región" },
-      "date": { "name": "Fecha" },
-      "last_updated": { "name": "Última actualización" }
+      "region": {
+        "name": "Región"
+      },
+      "date": {
+        "name": "Fecha"
+      },
+      "last_updated": {
+        "name": "Última actualización"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -21,6 +21,18 @@
       "empty": "Ce champ ne peut pas être vide"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Options",
+        "description": "Modifiez l’intervalle de mise à jour et la langue de réponse de l’API.",
+        "data": {
+          "update_interval": "Intervalle de mise à jour (heures)",
+          "language_code": "Code langue pour la réponse API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Types de pollen ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Région" },
-      "date": { "name": "Date" },
-      "last_updated": { "name": "Dernière mise à jour" }
+      "region": {
+        "name": "Région"
+      },
+      "date": {
+        "name": "Date"
+      },
+      "last_updated": {
+        "name": "Dernière mise à jour"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -21,6 +21,18 @@
       "empty": "Questo campo non può essere vuoto"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Opzioni",
+        "description": "Modifica l’intervallo di aggiornamento e la lingua di risposta dell’API.",
+        "data": {
+          "update_interval": "Intervallo di aggiornamento (ore)",
+          "language_code": "Codice lingua per la risposta API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Tipi di polline ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Regione" },
-      "date": { "name": "Data" },
-      "last_updated": { "name": "Ultimo aggiornamento" }
+      "region": {
+        "name": "Regione"
+      },
+      "date": {
+        "name": "Data"
+      },
+      "last_updated": {
+        "name": "Ultimo aggiornamento"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -21,6 +21,18 @@
       "empty": "To pole nie może być puste"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Opcje",
+        "description": "Zmień interwał aktualizacji i język odpowiedzi API.",
+        "data": {
+          "update_interval": "Interwał aktualizacji (godziny)",
+          "language_code": "Kod języka odpowiedzi API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Typy pyłków ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Region" },
-      "date": { "name": "Data" },
-      "last_updated": { "name": "Ostatnia aktualizacja" }
+      "region": {
+        "name": "Region"
+      },
+      "date": {
+        "name": "Data"
+      },
+      "last_updated": {
+        "name": "Ostatnia aktualizacja"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -21,6 +21,18 @@
       "empty": "Это поле не может быть пустым"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Параметры",
+        "description": "Измените интервал обновления и язык ответа API.",
+        "data": {
+          "update_interval": "Интервал обновления (в часах)",
+          "language_code": "Код языка ответа API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Типы пыльцы ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Регион" },
-      "date": { "name": "Дата" },
-      "last_updated": { "name": "Последнее обновление" }
+      "region": {
+        "name": "Регион"
+      },
+      "date": {
+        "name": "Дата"
+      },
+      "last_updated": {
+        "name": "Последнее обновление"
+      }
     }
   }
 }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -21,6 +21,18 @@
       "empty": "Це поле не може бути порожнім"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Pollen Levels – Параметри",
+        "description": "Змініть інтервал оновлення та мову відповіді API.",
+        "data": {
+          "update_interval": "Інтервал оновлення (у годинах)",
+          "language_code": "Код мови відповіді API"
+        }
+      }
+    }
+  },
   "device": {
     "types": {
       "name": "Типи пилку ({latitude},{longitude})"
@@ -34,9 +46,15 @@
   },
   "entity": {
     "sensor": {
-      "region": { "name": "Регіон" },
-      "date": { "name": "Дата" },
-      "last_updated": { "name": "Останнє оновлення" }
+      "region": {
+        "name": "Регіон"
+      },
+      "date": {
+        "name": "Дата"
+      },
+      "last_updated": {
+        "name": "Останнє оновлення"
+      }
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+select = ["E", "F", "W", "I", "UP", "B"]
+ignore = [
+  "E501",  # line length (Black formats)
+]
+fix = true
+
+[tool.ruff.isort]
+known-first-party = ["custom_components.pollenlevels"]
+combine-as-imports = true


### PR DESCRIPTION
# Changelog

## [1.5.2] – 2025-08-09
### Added
- **Localized Options Flow strings** for 9 languages (EN, ES, CA, DE, FR, IT, PL, RU, UK). Users now see the Options dialog (title, description, fields) fully translated.
### Maintenance
- Version bump in `manifest.json` to 1.5.2.
- Verified that translations match the Options Flow step id (`init`) and keys (`update_interval`, `language_code`).

## [1.5.1] – 2025-08-08
### Added
- **Index description attribute**: Each pollen **type** and **plant** sensor now exposes the human-readable `description` derived from Google’s `indexInfo.indexDescription` (UPI). This is additive and does not change entity states or IDs.
### Maintenance
- Minor code hygiene in `config_flow.py`: import order clean-up and removal of a redundant manual interval check (schema already enforces `min=1`).

## [1.5.0] – 2025-08-08
### Added
- **Options Flow** to change `update_interval` and `language_code` without reinstalling.
- **Duplicate prevention**: entries are uniquely identified by `(latitude, longitude)` and duplicates are rejected.
### Changed
- Reused the same language-code validation in options to provide consistent, localized error messages.
### Notes
- To apply options immediately, the integration reloads after saving. Make sure the coordinator reads `entry.options` first (fallback to `entry.data`).
