### PR TITLE
Add approximate location to diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [1.8.3-rc3] - 2025-11-23
+### Fixed
+- Keep the approximate diagnostics location visible by renaming rounded coordinates to dedicated
+  keys and reducing precision to a single decimal place for better privacy.
+
 ## [1.8.3-rc2] - 2025-11-22
 ### Changed
 - Added an approximate, rounded location to diagnostics so support can review rough geography

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -65,14 +65,14 @@ async def async_get_config_entry_diagnostics(
     # coordinates. This should not be redacted.
     def _rounded(value: Any) -> float | None:
         try:
-            return round(float(value), 2)
+            return round(float(value), 1)
         except (TypeError, ValueError):
             return None
 
     approx_location = {
         "label": "approximate_location (rounded)",
-        "latitude": _rounded(data.get(CONF_LATITUDE)),
-        "longitude": _rounded(data.get(CONF_LONGITUDE)),
+        "latitude_rounded": _rounded(data.get(CONF_LATITUDE)),
+        "longitude_rounded": _rounded(data.get(CONF_LONGITUDE)),
     }
 
     # --- Build a safe params example (no network I/O) ----------------------

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-  "version": "1.8.3-rc2"
+  "version": "1.8.3-rc3"
 }


### PR DESCRIPTION
### **User description**
## Summary
- add rounded, non-redacted approximate location details to diagnostics for support review
- update changelog with the new 1.8.3-rc2 release date and bump manifest version

## Testing
- ruff check custom_components/pollenlevels/diagnostics.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dac6e67483248c618067f122a0cf)


___

### **PR Type**
Enhancement


___

### **Description**
- Add rounded approximate location to diagnostics for support review

- Implement `_rounded()` helper to obfuscate precise coordinates to 2 decimals

- Include `approximate_location` field in diagnostics output

- Update changelog and bump manifest version to 1.8.3-rc2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Entry Data<br/>latitude, longitude"] -->|"_rounded() to 2 decimals"| B["Approximate Location<br/>rounded coordinates"]
  B -->|"included in"| C["Diagnostics Output<br/>with redacted exact values"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>diagnostics.py</strong><dd><code>Add rounded location to diagnostics output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/diagnostics.py

<ul><li>Add <code>_rounded()</code> helper function to round float values to 2 decimal <br>places<br> <li> Create <code>approx_location</code> dictionary with rounded latitude and longitude<br> <li> Include <code>approximate_location</code> field in diagnostics output dictionary<br> <li> Preserve exact coordinates as redacted while exposing rounded values <br>for support</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/35/files#diff-b1ea3cc1db108888c50fab5ffb54a1fb1dc5ef2f8065b39643c4e77def883f15">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 1.8.3-rc2 release with location feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add new section for version 1.8.3-rc2 with release date 2025-11-22<br> <li> Document the addition of approximate rounded location to diagnostics<br> <li> Explain the privacy-preserving approach of exposing rough geography</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/35/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update manifest version to 1.8.3-rc2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/manifest.json

- Bump version from 1.8.3-rc1 to 1.8.3-rc2


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/35/files#diff-c669441e47d06d4aaed40b66e7e0b60fead7fc8092057d212dcf08b4bcf92d6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

