### PR TITLE
Improve config validation logging and test robustness

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -214,7 +214,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except Exception as err:  # defensive
             _LOGGER.exception(
-                "Unexpected error: %s",
+                "Unexpected error in Pollen Levels config flow while validating input: %s",
                 redact_api_key(err, user_input.get(CONF_API_KEY)),
             )
             errors["base"] = "cannot_connect"

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -463,6 +463,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     await asyncio.sleep(delay)
                     continue
                 msg = redact_api_key(err, self.api_key)
+                if not msg:
+                    msg = "Google Pollen API call timed out"
                 raise UpdateFailed(f"Timeout: {msg}") from err
 
             except aiohttp.ClientError as err:
@@ -478,6 +480,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     await asyncio.sleep(delay)
                     continue
                 msg = redact_api_key(err, self.api_key)
+                if not msg:
+                    msg = "Network error while calling the Google Pollen API"
                 raise UpdateFailed(msg) from err
 
             except Exception as err:  # Keep previous behavior for unexpected errors


### PR DESCRIPTION
### **User description**
## Summary
- clarify unexpected error logging during config flow input validation
- add fallback messages for coordinator network errors when redacted output is empty
- document and harden the AST-based translation key extraction test with clearer failure handling

## Testing
- ruff check --fix --select I
- ruff check
- black tests/test_translations.py
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295c27456c83248c938c6dbf2a6491)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Clarify error messages in config flow and sensor updates

- Add fallback messages when redacted output is empty

- Harden AST-based translation key extraction test with clearer failure handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Flow Error Handling"] -- "clarify message" --> B["Enhanced Logging"]
  C["Sensor Update Errors"] -- "add fallback messages" --> D["Redaction Safety"]
  E["Translation Tests"] -- "harden AST parsing" --> F["Better Failure Messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Clarify config flow validation error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/config_flow.py

<ul><li>Enhanced exception logging message to clarify context of validation <br>errors<br> <li> Message now explicitly states "Pollen Levels config flow while <br>validating input"</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/42/files#diff-2bf60984f3b03936f7c2154da3fc3848c4b334d79c13751db9d20ef3d453d646">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Add fallback messages for redacted API errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/sensor.py

<ul><li>Add fallback message for timeout errors when redacted output is empty<br> <li> Add fallback message for network errors when redacted output is empty<br> <li> Ensures meaningful error messages are always provided to users</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/42/files#diff-3311ba763cd5f09436a51b51118ab46e6993406e864791cd56a3b83f4b881cb4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_translations.py</strong><dd><code>Harden AST translation test with explicit failure handling</code></dd></summary>
<hr>

tests/test_translations.py

<ul><li>Add comprehensive docstring explaining AST-based translation key <br>extraction approach<br> <li> Introduce <code>_fail_unexpected_ast()</code> helper function for consistent <br>failure messages<br> <li> Replace silent returns with explicit failures for unsupported AST <br>shapes<br> <li> Add validation checks for schema call arguments and key wrappers<br> <li> Add pytest import for failure handling</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/42/files#diff-d9a672881d7474830ca33650cb894b8b261793f04823dc93fe5f902d40b690b2">+28/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

