### PR TITLE
Handle missing source in device info

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -798,6 +798,14 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         """Return device info with translation support for the group."""
         info = self.coordinator.data.get(self.code, {}) or {}
         group = info.get("source")
+        if not group:
+            if self.code.startswith("type_"):
+                group = "type"
+            elif self.code.startswith(("plant_", "plants_")):
+                group = "plant"
+            else:
+                group = "meta"
+
         device_id = f"{self.coordinator.entry_id}_{group}"
         translation_keys = {"type": "types", "plant": "plants", "meta": "info"}
         translation_key = translation_keys.get(group, "info")


### PR DESCRIPTION
### **User description**
## Summary
- derive pollen sensor device grouping from the sensor code when API source is missing
- keep device identifiers and translation keys stable by falling back to type/plant/meta groups

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d5bcc38a88324b949d6be5722aaf3)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Derive pollen sensor device grouping from sensor code when API source is missing

- Fallback to type/plant/meta groups based on code prefix

- Maintain stable device identifiers and translation keys


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API source missing"] -->|Check code prefix| B{Code starts with?}
  B -->|type_| C["group = type"]
  B -->|plant_/plants_| D["group = plant"]
  B -->|other| E["group = meta"]
  C --> F["Generate stable device_id"]
  D --> F
  E --> F
  F --> G["Return device info"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Add fallback device grouping logic for missing source</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/sensor.py

<ul><li>Added fallback logic to derive device grouping from sensor code when <br>API source is missing<br> <li> Checks code prefix to determine group: <code>type_</code> maps to "type", <br><code>plant_</code>/<code>plants_</code> maps to "plant", others map to "meta"<br> <li> Ensures stable device identifiers and translation keys by using <br>consistent fallback groups</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/48/files#diff-3311ba763cd5f09436a51b51118ab46e6993406e864791cd56a3b83f4b881cb4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

