### PR TITLE
Fix tests to import and use extracted coordinator module

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -262,6 +262,9 @@ def _load_module(module_name: str, relative_path: str):
 
 
 const = _load_module("custom_components.pollenlevels.const", "const.py")
+coordinator_mod = _load_module(
+    "custom_components.pollenlevels.coordinator", "coordinator.py"
+)
 sensor = _load_module("custom_components.pollenlevels.sensor", "sensor.py")
 client_mod = importlib.import_module("custom_components.pollenlevels.client")
 
@@ -440,7 +443,7 @@ def test_type_sensor_preserves_source_with_single_day(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -476,7 +479,7 @@ def test_coordinator_clamps_forecast_days_low() -> None:
     client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = sensor.PollenDataUpdateCoordinator(
+        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -503,7 +506,7 @@ def test_coordinator_clamps_forecast_days_negative() -> None:
     client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = sensor.PollenDataUpdateCoordinator(
+        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -530,7 +533,7 @@ def test_coordinator_clamps_forecast_days_high() -> None:
     client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = sensor.PollenDataUpdateCoordinator(
+        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -557,7 +560,7 @@ def test_coordinator_keeps_forecast_days_within_range() -> None:
     client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = sensor.PollenDataUpdateCoordinator(
+        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -630,7 +633,7 @@ def test_type_sensor_uses_forecast_metadata_when_today_missing(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -740,7 +743,7 @@ def test_plant_sensor_includes_forecast_attributes(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -830,7 +833,7 @@ def test_coordinator_raises_auth_failed() -> None:
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -859,7 +862,7 @@ def test_coordinator_handles_forbidden() -> None:
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -889,7 +892,7 @@ def test_coordinator_invalid_key_message_triggers_reauth() -> None:
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -941,7 +944,7 @@ def test_coordinator_retries_then_raises_on_rate_limit(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1000,7 +1003,7 @@ def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> N
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1044,7 +1047,7 @@ def test_coordinator_retries_then_raises_on_server_errors(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1086,7 +1089,7 @@ def test_coordinator_retries_then_wraps_timeout(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1133,7 +1136,7 @@ def test_coordinator_retries_then_wraps_client_error(
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="secret",
         lat=1.0,
@@ -1204,7 +1207,7 @@ async def test_device_info_uses_default_title_when_blank(
 
     client = client_mod.GooglePollenApiClient(FakeSession({}), "key")
     clean_title = sensor.DEFAULT_ENTRY_TITLE
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="key",
         lat=1.0,
@@ -1259,7 +1262,7 @@ async def test_device_info_trims_custom_title(
 
     client = client_mod.GooglePollenApiClient(FakeSession({}), "key")
     clean_title = config_entry.title.strip()
-    coordinator = sensor.PollenDataUpdateCoordinator(
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="key",
         lat=1.0,


### PR DESCRIPTION
### **User description**
### Motivation
- The `PollenDataUpdateCoordinator` was moved out of `sensor.py` into `coordinator.py`, causing existing tests to reference the wrong module.
- Update the test harness so tests import the coordinator from its new location and continue to validate coordinator behavior.

### Description
- Load the new module in the test harness with `_load_module("custom_components.pollenlevels.coordinator", "coordinator.py")` (assigned to `coordinator_mod`).
- Replace occurrences of `sensor.PollenDataUpdateCoordinator` with `coordinator_mod.PollenDataUpdateCoordinator` in `tests/test_sensor.py`.
- No test logic or assertions were changed; only import and qualifier adjustments were applied.

### Testing
- Ran `black tests/test_sensor.py` — formatting completed successfully.
- Ran `ruff check --fix --select I tests/test_sensor.py` — import-order fixes applied and passed.
- Ran `ruff check tests/test_sensor.py` — lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945cfbfc8b48324b29503e14b29c4fa)


___

### **PR Type**
Tests


___

### **Description**
- Load coordinator module in test harness with `_load_module()`

- Replace all `sensor.PollenDataUpdateCoordinator` references with `coordinator_mod.PollenDataUpdateCoordinator`

- Update 16 test functions to use correct coordinator import location

- No test logic or assertions were modified


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["tests/test_sensor.py"] -->|Load coordinator module| B["coordinator_mod"]
  A -->|Replace references| C["coordinator_mod.PollenDataUpdateCoordinator"]
  C -->|Used in 16 tests| D["Test functions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sensor.py</strong><dd><code>Update coordinator references to use extracted module</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_sensor.py

<ul><li>Added module loading for <code>custom_components.pollenlevels.coordinator</code> <br>assigned to <code>coordinator_mod</code><br> <li> Replaced 16 occurrences of <code>sensor.PollenDataUpdateCoordinator</code> with <br><code>coordinator_mod.PollenDataUpdateCoordinator</code> across multiple test <br>functions<br> <li> Updated tests: <code>test_type_sensor_preserves_source_with_single_day</code>, <br><code>test_coordinator_clamps_forecast_days_low</code>, <br><code>test_coordinator_clamps_forecast_days_negative</code>, <br><code>test_coordinator_clamps_forecast_days_high</code>, <br><code>test_coordinator_keeps_forecast_days_within_range</code>, <br><code>test_type_sensor_uses_forecast_metadata_when_today_missing</code>, <br><code>test_plant_sensor_includes_forecast_attributes</code>, <br><code>test_coordinator_raises_auth_failed</code>, <br><code>test_coordinator_handles_forbidden</code>, <br><code>test_coordinator_invalid_key_message_triggers_reauth</code>, and <br>retry-related tests<br> <li> No changes to test logic, assertions, or test structure</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/53/files#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330">+20/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

