### PR TITLE
fix(migration): harden cleanup and normalize stored forecast mode values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@
   associated helper functions have been moved from sensor.py to a new,
   dedicated coordinator.py module. This significantly improves modularity and
   separation of concerns within the component.
-- Removed optional HTTP Referer (website restriction) support to simplify configuration, as it is not suitable for server-side integrations.
+- Removed optional HTTP Referer (website restriction) support to simplify configuration,
+  as it is not suitable for server-side integrations (existing entries are
+  migrated to remove legacy `http_referer` values).
 - Documented the 1–24 update interval range in the README options list.
 
 ### Fixed

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -530,6 +530,26 @@ def test_migrate_entry_normalizes_invalid_mode_in_options() -> None:
     assert entry.version == 3
 
 
+def test_migrate_entry_normalizes_invalid_mode_in_options_when_version_current() -> (
+    None
+):
+    """Migration should normalize invalid mode values even at the target version."""
+    entry = _FakeEntry(
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+        },
+        options={integration.CONF_CREATE_FORECAST_SENSORS: "invalid-value"},
+        version=integration.TARGET_ENTRY_VERSION,
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
+    assert entry.options[integration.CONF_CREATE_FORECAST_SENSORS] == "none"
+    assert entry.version == integration.TARGET_ENTRY_VERSION
+
+
 def test_migrate_entry_marks_version_when_no_changes() -> None:
     """Migration should still bump the version when no changes are needed."""
     entry = _FakeEntry(


### PR DESCRIPTION
### **User description**
### Motivation
- Make config entry migration idempotent to avoid repeated updates on startup by normalizing and comparing primitives.
- Ensure invalid or non-string stored per-day forecast mode values are normalized even when `entry.version` is already at the target.
- Remove leftover legacy `http_referer` values from both `data` and `options` during migration.

### Description
- Use defensive `existing_data = entry.data or {}` and `existing_options = entry.options or {}` and build `new_data/new_options` from those normalized mappings.
- Detect `cleanup_needed` by checking legacy keys and by normalizing stored option values after coercing the raw value to a primitive string using `getattr(..., "value", ...)` and `str()` before calling `normalize_sensor_mode`.
- Prefer options over data when reading `CONF_CREATE_FORECAST_SENSORS`, always remove the legacy key from `data`, and set `new_version = max(current_version, target_version)` to avoid downgrades.
- Compare `new_data`/`new_options` against the normalized `existing_data`/`existing_options` to decide whether to update `data/options` or only bump the version.

### Testing
- Added unit test `test_migrate_entry_normalizes_invalid_mode_in_options_when_version_current` to cover normalization when `version == TARGET_ENTRY_VERSION` and it passes under `pytest -q`.
- Ran `pytest -q` which succeeded (`89 passed`).
- Ran `ruff check --fix --select I` and `ruff check` with no issues and formatted with `black` successfully.
- Verified `python -m compileall custom_components/pollenlevels` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be808eb3083248137572ba4209ec1)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Harden config entry migration to be idempotent and normalize forecast mode values

- Add defensive null checks for `entry.data` and `entry.options` to prevent errors

- Normalize stored forecast mode values even when entry version is already at target

- Ensure invalid mode values are coerced to strings before normalization

- Add unit test for normalization at target version

- Clarify changelog documentation for HTTP Referer removal migration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Entry"] --> B["Defensive Null Checks"]
  B --> C["Detect Cleanup Needed"]
  C --> D["Normalize Mode Values"]
  D --> E["Coerce to String"]
  E --> F["Compare & Update"]
  F --> G["Updated Entry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Harden migration with defensive checks and value normalization</code></dd></summary>
<hr>

custom_components/pollenlevels/__init__.py

<ul><li>Add defensive <code>existing_data = entry.data or {}</code> to safely handle null <br>data<br> <li> Normalize stored forecast mode values by coercing to string with <code>str()</code> <br>before normalization<br> <li> Detect cleanup needed by checking normalized mode against raw stored <br>value<br> <li> Compare normalized <code>new_data</code>/<code>new_options</code> against <br><code>existing_data</code>/<code>existing_options</code> for idempotency<br> <li> Use <code>max(current_version, target_version)</code> to prevent version downgrades</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/61/files#diff-d98e826e701b9b826f100d2c6dc976b1f324f863279b7bc274eaecef5a006c40">+13/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_init.py</strong><dd><code>Add test for normalization at target version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_init.py

<ul><li>Add new test <br><code>test_migrate_entry_normalizes_invalid_mode_in_options_when_version_current</code> <br>to verify normalization occurs even when version equals target version<br> <li> Test validates that invalid mode values are normalized to valid <br>defaults<br> <li> Ensures version remains unchanged when only normalization is needed</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/61/files#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599e">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Clarify HTTP Referer removal migration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Clarify HTTP Referer removal migration behavior in changelog<br> <li> Document that existing entries are migrated to remove legacy <br><code>http_referer</code> values<br> <li> Improve readability with line wrapping for better formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/61/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

