### PR TITLE
Finalize 1.9.3 changelog with Retry-After hardening details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - Cleared entry runtime data when platform forwarding fails to avoid leaving a partially initialized state.
 - Hardened `forecast_days` parsing during coordinator and sensor setup to tolerate malformed stored values without crashing.
 - Improved test isolation by avoiding unconditional replacement of the global `aiohttp` module stub.
+- Accepted numeric-string RGB channels from API color payloads by relying on shared
+  channel normalization, while still ignoring non-numeric strings.
+- Hardened HTTP 429 backoff by validating `Retry-After` values (rejecting non-finite,
+  negative, and stale date-based delays) and clamping retry sleep to a safe bounded
+  range.
 
 ### Changed
 - Switched sensor setup iteration to use a validated local data snapshot for

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import random
 from typing import Any
 
@@ -40,12 +41,15 @@ class GooglePollenApiClient:
         """Translate a Retry-After header into a delay in seconds."""
 
         try:
-            return float(retry_after_raw)
+            parsed = float(retry_after_raw)
+            if math.isfinite(parsed) and parsed > 0:
+                return parsed
+            return 2.0
         except (TypeError, ValueError):
             retry_at = dt_util.parse_http_date(retry_after_raw)
             if retry_at is not None:
                 delay = (retry_at - dt_util.utcnow()).total_seconds()
-                if delay > 0:
+                if math.isfinite(delay) and delay > 0:
                     return delay
 
         return 2.0
@@ -118,7 +122,8 @@ class GooglePollenApiClient:
                             delay = 2.0
                             if retry_after_raw:
                                 delay = self._parse_retry_after(retry_after_raw)
-                            delay = min(delay, 5.0) + random.uniform(0.0, 0.4)
+                            delay = delay + random.uniform(0.0, 0.4)
+                            delay = max(0.0, min(delay, 5.0))
                             _LOGGER.warning(
                                 "Pollen API 429 — retrying in %.2fs (attempt %d/%d)",
                                 delay,

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -48,20 +48,13 @@ def _rgb_from_api(color: dict[str, Any] | None) -> tuple[int, int, int] | None:
     """Build an (R, G, B) tuple from API color dict.
 
     Rules:
-    - If color is not a dict, or an empty dict, or has no numeric channels at all,
-      return None (meaning "no color provided by API").
+    - If color is not a dict, or an empty dict, return None
+      (meaning "no color provided by API").
     - If only some channels are present, missing ones are treated as 0 (black baseline)
       but ONLY when at least one channel exists. This preserves partial colors like
       {green, blue} without inventing a color for {}.
     """
     if not isinstance(color, dict) or not color:
-        return None
-
-    # Check if any of the channels is actually provided as numeric
-    has_any_channel = any(
-        isinstance(color.get(k), (int, float)) for k in ("red", "green", "blue")
-    )
-    if not has_any_channel:
         return None
 
     r = _normalize_channel(color.get("red"))

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1093,6 +1093,106 @@ def test_plant_forecast_matches_codes_case_insensitively() -> None:
     assert entry["tomorrow_value"] == 4
 
 
+def test_coordinator_accepts_numeric_string_color_channels() -> None:
+    """Numeric string channels should be normalized into RGB/hex values."""
+
+    payload = {
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 7, "day": 1},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": 1,
+                            "category": "LOW",
+                            "color": {"red": "1", "green": "0", "blue": "0"},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    fake_session = FakeSession(payload)
+    client = client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert data["type_grass"]["color_hex"] == "#FF0000"
+    assert data["type_grass"]["color_rgb"] == [255, 0, 0]
+
+
+def test_coordinator_ignores_invalid_string_color_channels() -> None:
+    """Non-numeric string channels should not emit RGB/hex values."""
+
+    payload = {
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 7, "day": 1},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": 1,
+                            "category": "LOW",
+                            "color": {"red": "foo"},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    fake_session = FakeSession(payload)
+    client = client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert data["type_grass"]["color_hex"] is None
+    assert data["type_grass"]["color_rgb"] is None
+
+
 def test_coordinator_ignores_nonfinite_color_channels() -> None:
     """Non-finite color channel values should not crash or emit invalid colors."""
 
@@ -1458,6 +1558,81 @@ def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> N
 
     assert session.calls == 2
     assert delays == [5.0]
+
+
+@pytest.mark.parametrize(
+    ("retry_after", "now"),
+    [
+        ("-10", None),
+        ("nan", None),
+        ("inf", None),
+        (
+            "Wed, 10 Dec 2025 12:00:00 GMT",
+            datetime.datetime(2025, 12, 10, 12, 0, 5, tzinfo=datetime.UTC),
+        ),
+    ],
+)
+def test_coordinator_retry_after_invalid_values_use_safe_default(
+    monkeypatch: pytest.MonkeyPatch,
+    retry_after: str,
+    now: datetime.datetime | None,
+) -> None:
+    """Invalid Retry-After values should fall back to a safe finite delay."""
+
+    session = SequenceSession(
+        [
+            ResponseSpec(
+                status=429,
+                payload={"error": {"message": "Quota exceeded"}},
+                headers={"Retry-After": retry_after},
+            ),
+            ResponseSpec(
+                status=429,
+                payload={"error": {"message": "Quota exceeded"}},
+                headers={"Retry-After": retry_after},
+            ),
+        ]
+    )
+    delays: list[float] = []
+
+    async def _fast_sleep(delay: float) -> None:
+        assert isinstance(delay, float)
+        assert delay == delay
+        assert delay != float("inf")
+        assert delay != float("-inf")
+        delays.append(delay)
+
+    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    if now is not None:
+        monkeypatch.setattr(client_mod.dt_util, "utcnow", lambda: now)
+
+    client = client_mod.GooglePollenApiClient(session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
+
+    try:
+        with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert session.calls == 2
+    assert delays == [2.0]
 
 
 def test_coordinator_retries_then_raises_on_server_errors(


### PR DESCRIPTION
### **User description**
### Motivation
- Ensure the 1.9.3 release notes explicitly document the HTTP 429 backoff hardening so the changelog accurately reflects the shipped behavior.

### Description
- Added a `### Fixed` bullet in `CHANGELOG.md` under `1.9.3` describing validation of `Retry-After` values (rejecting non-finite, negative, and stale date-based values) and clamping retry sleep to a safe bounded range.

### Testing
- Programmatically edited `CHANGELOG.md` with a short Python script and confirmed the diff via `git diff`, both completed successfully.
- Committed the change with `git commit -m "Update 1.9.3 changelog with Retry-After hardening note"` and verified the file head with `nl -ba CHANGELOG.md | sed -n '1,40p'`, all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aba7436948324b7e8591806e80cca)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Hardened HTTP 429 backoff by validating `Retry-After` header values
  - Reject non-finite, negative, and stale date-based delays
  - Clamp retry sleep to safe bounded range (0.0–5.0 seconds)

- Accept numeric-string RGB color channels from API payloads
  - Normalize string values like "1" to integers via shared logic
  - Ignore non-numeric strings without crashing

- Added comprehensive test coverage for retry-after validation
  - Test invalid values (negative, NaN, infinity, stale dates)
  - Test numeric string color channel handling

- Simplified color channel validation logic in coordinator


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTP 429 Response"] -->|"Extract Retry-After"| B["Parse & Validate"]
  B -->|"Non-finite/negative/stale"| C["Use safe default 2.0s"]
  B -->|"Valid delay"| D["Clamp to 0.0–5.0s"]
  D --> E["Add jitter & retry"]
  C --> E
  F["API Color Payload"] -->|"Numeric strings"| G["Normalize to int"]
  F -->|"Non-numeric strings"| H["Ignore, return None"]
  G --> I["Build RGB/hex"]
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Validate and clamp Retry-After header values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/client.py

<ul><li>Added <code>math</code> import for <code>isfinite()</code> checks<br> <li> Enhanced <code>_parse_retry_after()</code> to validate parsed float is finite and <br>positive<br> <li> Added <code>isfinite()</code> check for date-based delay calculations<br> <li> Refactored delay clamping logic to ensure result is always in [0.0, <br>5.0] range<br> <li> Moved jitter addition before clamping for clearer intent</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/69/files#diff-db3bec85a0825f26ef8be9eaef5dd550d26d4f97a685b9a665a01d982645a740">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>coordinator.py</strong><dd><code>Simplify color channel validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/coordinator.py

<ul><li>Removed redundant <code>has_any_channel</code> check in <code>_rgb_from_api()</code><br> <li> Simplified logic to rely on <code>_normalize_channel()</code> for type validation<br> <li> Improved docstring formatting for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/69/files#diff-9c3c329127851c48439eca9a2435527a4f6734e15ad0acef7bbd54e935051538">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sensor.py</strong><dd><code>Add tests for Retry-After validation and color channels</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_sensor.py

<ul><li>Added <code>test_coordinator_accepts_numeric_string_color_channels()</code> to <br>verify string-to-int conversion<br> <li> Added <code>test_coordinator_ignores_invalid_string_color_channels()</code> to <br>verify non-numeric strings are rejected<br> <li> Added parametrized <br><code>test_coordinator_retry_after_invalid_values_use_safe_default()</code> <br>covering negative, NaN, infinity, and stale date values<br> <li> All new tests verify safe fallback behavior and prevent crashes</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/69/files#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330">+175/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 1.9.3 fixes for Retry-After and colors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added two bullet points under <code>### Fixed</code> for version 1.9.3<br> <li> Documented numeric-string RGB channel acceptance with non-numeric <br>string rejection<br> <li> Documented HTTP 429 backoff hardening with <code>Retry-After</code> validation and <br>delay clamping</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/69/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

