### PR TITLE
Harden release workflow to build and upload deterministic pollenlevels.zip asset

### DIFF
--- a/.github/workflows/release-asset.yml
+++ b/.github/workflows/release-asset.yml
@@ -1,0 +1,46 @@
+name: Release ZIP Asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-asset-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload-zip-asset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Resolve archive ref
+        id: archive_ref
+        run: |
+          if [ -n "${{ github.event.release.tag_name }}" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release archive
+        run: |
+          git archive --format=zip \
+            --output=pollenlevels.zip \
+            "${{ steps.archive_ref.outputs.ref }}" \
+            custom_components/pollenlevels
+
+      - name: Verify ZIP structure
+        run: |
+          unzip -l pollenlevels.zip | grep -q "custom_components/pollenlevels/manifest.json"
+
+      - name: Upload pollenlevels.zip
+        uses: softprops/action-gh-release@v2
+        with:
+          files: pollenlevels.zip
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,8 @@
   "name": "Pollen Levels",
   "homeassistant": "2025.3.0",
   "content_in_root": false,
+  "zip_release": true,
+  "filename": "pollenlevels.zip",
   "render_readme": true,
   "hacs": "2.0.0"
 }


### PR DESCRIPTION
### **User description**
### Motivation
- Ensure HACS can read a real GitHub Release asset `download_count` by automatically attaching a deterministic ZIP named `pollenlevels.zip` to each published release. 
- Prevent incorrect assets, missing downloads, or duplicate uploads by making the archive deterministic and the workflow robust to retries.

### Description
- Added a GitHub Actions workflow `/.github/workflows/release-asset.yml` that triggers on `release` (types: `[published]`) and `workflow_dispatch` for manual reruns. 
- The workflow uses minimal permissions (`contents: write`) and a concurrency guard `release-asset-${{ github.event.release.tag_name || github.ref }}` with `cancel-in-progress: true` to avoid duplicate uploads. 
- The job checks out via `actions/checkout@v5`, resolves an archive ref using `release.tag_name` with fallback to `GITHUB_SHA`, and uses `git archive` to produce `pollenlevels.zip` containing only `custom_components/pollenlevels`. 
- A ZIP sanity check verifies `custom_components/pollenlevels/manifest.json` is present before uploading with `softprops/action-gh-release@v2`, explicitly targeting the release tag and preserving the exact asset filename `pollenlevels.zip`, and `hacs.json` contains `"zip_release": true` and `"filename": "pollenlevels.zip"` to match HACS expectations. 

### Testing
- Ran `ruff check --fix --select I .` and it completed successfully. 
- Ran `ruff check .` and it completed successfully. 
- Ran `black .` and formatting completed with no changes required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c020c28ec83248244ec89bd54b1a3)


___

### **PR Type**
Enhancement


___

### **Description**
- Automate deterministic ZIP asset creation and upload for GitHub Releases

- Configure HACS integration to recognize and track release downloads

- Implement concurrency guards and sanity checks for robust retry handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Published"] -->|"Triggers workflow"| B["Checkout Repository"]
  B -->|"Resolve ref"| C["Build ZIP Archive"]
  C -->|"Verify structure"| D["Sanity Check"]
  D -->|"Upload asset"| E["GitHub Release"]
  F["HACS Config"] -->|"Enable tracking"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-asset.yml</strong><dd><code>GitHub Actions workflow for automated release ZIP creation</code></dd></summary>
<hr>

.github/workflows/release-asset.yml

<ul><li>Created new GitHub Actions workflow triggered on release publication <br>and manual dispatch<br> <li> Implements concurrency guard to prevent duplicate uploads with <br>tag-based grouping<br> <li> Uses <code>git archive</code> to build deterministic <code>pollenlevels.zip</code> containing <br>only <code>custom_components/pollenlevels</code><br> <li> Includes ZIP structure verification step checking for <code>manifest.json</code> <br>presence before upload<br> <li> Uploads asset to GitHub Release with explicit tag targeting via <br><code>softprops/action-gh-release@v2</code></ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/71/files#diff-e1b5f16f666f177511372d2b93daabc53b0928cd85e00244557de45ac89f8c29">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hacs.json</strong><dd><code>Configure HACS for release asset download tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hacs.json

<ul><li>Added <code>"zip_release": true</code> flag to enable HACS release asset tracking<br> <li> Added <code>"filename": "pollenlevels.zip"</code> to specify expected asset <br>filename for HACS</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/71/files#diff-2004f3033aaa650b74a155b56a1e6110e85583824c83f3cb5a0c2856bd00483f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

