### PR TITLE
Align config-flow validation with GooglePollenApiClient, add quota exception, bump to v1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.9.5] - 2026-02-27
+### Changed
+- Aligned config-flow validation with runtime client semantics by using
+  `GooglePollenApiClient` for setup checks, mapping auth/quota/connectivity
+  errors consistently, and removing duplicate HTTP/JSON parsing from the flow.
+- Expanded config-flow regression coverage to validate client-based setup
+  behavior, including normalized request arguments and timeout/client-error
+  handling parity.
+- Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.
+- Replaced fragile text-based HTTP 429 detection in setup validation with a
+  dedicated client quota exception so `quota_exceeded` mapping remains stable.
+
 ## [1.9.4] - 2026-02-24
 ### Changed
 - Updated release packaging automation for HACS `zip_release` by validating the

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -30,6 +30,10 @@ def _format_http_message(status: int, raw_message: str | None) -> str:
     return f"HTTP {status}"
 
 
+class PollenQuotaExceededError(UpdateFailed):
+    """Raised when Google Pollen API quota limits are exceeded (HTTP 429)."""
+
+
 class GooglePollenApiClient:
     """Thin async client wrapper for the Google Pollen API."""
 
@@ -136,7 +140,7 @@ class GooglePollenApiClient:
                             await extract_error_message(resp, default=""), self._api_key
                         )
                         message = _format_http_message(resp.status, raw_message or None)
-                        raise UpdateFailed(message)
+                        raise PollenQuotaExceededError(message)
 
                     if 500 <= resp.status <= 599:
                         if attempt < max_retries:

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -13,16 +13,16 @@ IMPORTANT:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
 
-import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from aiohttp import ClientError
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     LocationSelector,
@@ -37,7 +37,9 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .client import GooglePollenApiClient, PollenQuotaExceededError
 from .const import (
     CONF_API_KEY,
     CONF_CREATE_FORECAST_SENSORS,
@@ -56,10 +58,8 @@ from .const import (
     POLLEN_API_KEY_URL,
     POLLEN_API_TIMEOUT,
     RESTRICTING_API_KEYS_URL,
-    is_invalid_api_key_message,
 )
 from .util import (
-    extract_error_message,
     normalize_sensor_mode,
     redact_api_key,
     safe_parse_int,
@@ -398,71 +398,25 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lang = is_valid_language_code(lang)
 
             session = async_get_clientsession(self.hass)
-            params = {
-                "key": api_key,
-                "location.latitude": f"{lat:.6f}",
-                "location.longitude": f"{lon:.6f}",
-                "days": 1,
-            }
-            if lang:
-                params["languageCode"] = lang
+            client = GooglePollenApiClient(session, api_key)
+            data = await client.async_fetch_pollen_data(
+                latitude=lat,
+                longitude=lon,
+                days=1,
+                language_code=lang or None,
+            )
 
-            url = "https://pollen.googleapis.com/v1/forecast:lookup"
+            daily_info = data.get("dailyInfo") if isinstance(data, dict) else None
+            daily_is_valid = isinstance(daily_info, list) and bool(daily_info)
+            if daily_is_valid:
+                daily_is_valid = all(isinstance(item, dict) for item in daily_info)
 
-            _LOGGER.debug("Validating Pollen API (days=%s, lang_set=%s)", 1, bool(lang))
-
-            async with session.get(
-                url,
-                params=params,
-                timeout=aiohttp.ClientTimeout(total=POLLEN_API_TIMEOUT),
-            ) as resp:
-                status = resp.status
-                if status != 200:
-                    _LOGGER.debug("Validation HTTP %s (body omitted)", status)
-                    raw_msg = await extract_error_message(resp, f"HTTP {status}")
-                    placeholders["error_message"] = redact_api_key(raw_msg, api_key)
-                    if status == 401:
-                        errors["base"] = "invalid_auth"
-                    elif status == 403:
-                        if is_invalid_api_key_message(raw_msg):
-                            errors["base"] = "invalid_auth"
-                        else:
-                            errors["base"] = "cannot_connect"
-                    elif status == 429:
-                        errors["base"] = "quota_exceeded"
-                    else:
-                        errors["base"] = "cannot_connect"
-                else:
-                    raw = await resp.read()
-                    try:
-                        body_str = raw.decode()
-                    except Exception:
-                        body_str = str(raw)
-                    _LOGGER.debug(
-                        "Validation HTTP %s — %s",
-                        status,
-                        redact_api_key(body_str, api_key),
-                    )
-                    try:
-                        data = json.loads(body_str) if body_str else {}
-                    except Exception:
-                        data = {}
-
-                    daily_info = (
-                        data.get("dailyInfo") if isinstance(data, dict) else None
-                    )
-                    daily_is_valid = isinstance(daily_info, list) and bool(daily_info)
-                    if daily_is_valid:
-                        daily_is_valid = all(
-                            isinstance(item, dict) for item in daily_info
-                        )
-
-                    if not daily_is_valid:
-                        _LOGGER.warning("Validation: 'dailyInfo' missing or invalid")
-                        errors["base"] = "cannot_connect"
-                        placeholders["error_message"] = (
-                            "API response missing expected pollen forecast information."
-                        )
+            if not daily_is_valid:
+                _LOGGER.warning("Validation: 'dailyInfo' missing or invalid")
+                errors["base"] = "cannot_connect"
+                placeholders["error_message"] = (
+                    "API response missing expected pollen forecast information."
+                )
 
             if errors:
                 return errors, None
@@ -478,6 +432,21 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors[CONF_LANGUAGE_CODE] = _language_error_to_form_key(ve)
             placeholders.pop("error_message", None)
+        except ConfigEntryAuthFailed as err:
+            errors["base"] = "invalid_auth"
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+        except PollenQuotaExceededError as err:
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+            errors["base"] = "quota_exceeded"
+        except UpdateFailed as err:
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+            errors["base"] = "cannot_connect"
         except TimeoutError as err:
             _LOGGER.warning(
                 "Validation timeout (%ss): %s",
@@ -490,7 +459,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 redacted
                 or f"Validation request timed out ({POLLEN_API_TIMEOUT} seconds)."
             )
-        except aiohttp.ClientError as err:
+        except ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
                 redact_api_key(err, api_key),

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.4"
+    "version": "1.9.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.4"
+version = "1.9.5"
 # Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -44,6 +44,16 @@ _force_module("custom_components.pollenlevels", pollenlevels_pkg)
 ha_mod = ModuleType("homeassistant")
 _force_module("homeassistant", ha_mod)
 
+exceptions_mod = ModuleType("homeassistant.exceptions")
+
+
+class _StubConfigEntryAuthFailed(Exception):
+    pass
+
+
+exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
+_force_module("homeassistant.exceptions", exceptions_mod)
+
 config_entries_mod = ModuleType("homeassistant.config_entries")
 
 
@@ -97,6 +107,16 @@ _force_module("homeassistant.const", const_mod)
 
 helpers_mod = ModuleType("homeassistant.helpers")
 _force_module("homeassistant.helpers", helpers_mod)
+
+update_coordinator_mod = ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class _StubUpdateFailed(Exception):
+    pass
+
+
+update_coordinator_mod.UpdateFailed = _StubUpdateFailed
+_force_module("homeassistant.helpers.update_coordinator", update_coordinator_mod)
 
 config_validation_mod = ModuleType("homeassistant.helpers.config_validation")
 
@@ -298,6 +318,34 @@ vol_mod.Range = lambda *args, **kwargs: None
 vol_mod.In = lambda *args, **kwargs: None
 _force_module("voluptuous", vol_mod)
 
+
+client_mod = ModuleType("custom_components.pollenlevels.client")
+
+
+class _StubGooglePollenApiClient:
+    def __init__(self, session, api_key: str) -> None:
+        self._session = session
+        self._api_key = api_key
+
+    async def async_fetch_pollen_data(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+        days: int,
+        language_code: str | None,
+    ) -> dict:
+        return {"dailyInfo": [{"day": "D0"}]}
+
+
+class _StubPollenQuotaExceededError(_StubUpdateFailed):
+    pass
+
+
+client_mod.GooglePollenApiClient = _StubGooglePollenApiClient
+client_mod.PollenQuotaExceededError = _StubPollenQuotaExceededError
+_force_module("custom_components.pollenlevels.client", client_mod)
+
 from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LOCATION,
@@ -331,32 +379,66 @@ class _StubResponse:
         self.status = status
         self._body = body or b"{}"
 
-    async def __aenter__(self):  # pragma: no cover - trivial
-        return self
 
-    async def __aexit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
-        return None
+class _StubValidationClient:
+    def __init__(self, responses: list[_StubResponse], api_key: str) -> None:
+        self._responses = responses
+        self._api_key = api_key
+        self.calls: list[dict[str, object]] = []
 
-    async def read(self) -> bytes:
-        return self._body
+    async def async_fetch_pollen_data(
+        self,
+        *,
+        latitude: float,
+        longitude: float,
+        days: int,
+        language_code: str | None,
+    ) -> dict:
+        self.calls.append(
+            {
+                "latitude": latitude,
+                "longitude": longitude,
+                "days": days,
+                "language_code": language_code,
+            }
+        )
+        response = self._responses.pop(0)
 
-    async def json(self):
+        if response.status == 401:
+            raise cf.ConfigEntryAuthFailed("HTTP 401: API key *** not valid")
+
+        if response.status == 403:
+            body_text = response._body.decode()
+            if "API key not valid" in body_text:
+                raise cf.ConfigEntryAuthFailed(f"HTTP 403: {body_text}")
+            raise cf.UpdateFailed(f"HTTP 403: {body_text}")
+
+        if response.status == 429:
+            raise cf.PollenQuotaExceededError("HTTP 429: Quota exceeded")
+
+        if response.status != 200:
+            raise cf.UpdateFailed(f"HTTP {response.status}: backend error")
+
         import json as _json
 
-        return _json.loads(self._body.decode())
-
-    async def text(self) -> str:
-        return self._body.decode()
+        return _json.loads(response._body.decode())
 
 
-class _SequenceSession:
-    def __init__(self, responses: list[_StubResponse]) -> None:
-        self.responses = responses
-        self.calls: list[tuple[tuple, dict]] = []
+class _PatchedClientFactory:
+    def __init__(self, responses: list[_StubResponse]):
+        self._responses = responses
+        self.instances: list[_StubValidationClient] = []
 
-    def get(self, *args, **kwargs):
-        self.calls.append((args, kwargs))
-        return self.responses.pop(0)
+    @property
+    def calls(self) -> list[dict[str, object]]:
+        if not self.instances:
+            return []
+        return self.instances[0].calls
+
+    def __call__(self, session, api_key: str) -> _StubValidationClient:
+        client = _StubValidationClient(self._responses, api_key)
+        self.instances.append(client)
+        return client
 
 
 def _collect_error_keys_from_config_flow() -> set[str]:
@@ -555,9 +637,11 @@ def test_validate_input_non_dict_location() -> None:
 
 
 def _patch_client_session(monkeypatch: pytest.MonkeyPatch, response: _StubResponse):
-    session = _SequenceSession([response])
+    session = object()
     monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
-    return session
+    factory = _PatchedClientFactory([response])
+    monkeypatch.setattr(cf, "GooglePollenApiClient", factory)
+    return factory
 
 
 def _base_user_input() -> dict:
@@ -825,6 +909,60 @@ def test_validate_input_http_429_sets_quota_exceeded(
 
     assert session.calls
     assert errors == {"base": "quota_exceeded"}
+    assert normalized is None
+
+
+def test_validate_input_client_timeout_maps_to_cannot_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeouts bubbling from the API client should map to cannot_connect."""
+
+    class _TimeoutClient:
+        def __init__(self, session, api_key: str) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def async_fetch_pollen_data(self, **kwargs) -> dict:
+            self.calls.append(kwargs)
+            raise TimeoutError("timed out")
+
+    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: object())
+    monkeypatch.setattr(cf, "GooglePollenApiClient", _TimeoutClient)
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(_base_user_input(), check_unique_id=False)
+    )
+
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+
+
+def test_validate_input_client_error_maps_to_cannot_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Client transport errors should map to cannot_connect."""
+
+    class _ClientErroringClient:
+        def __init__(self, session, api_key: str) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        async def async_fetch_pollen_data(self, **kwargs) -> dict:
+            self.calls.append(kwargs)
+            raise cf.ClientError("network down")
+
+    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: object())
+    monkeypatch.setattr(cf, "GooglePollenApiClient", _ClientErroringClient)
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(_base_user_input(), check_unique_id=False)
+    )
+
+    assert errors == {"base": "cannot_connect"}
     assert normalized is None
 
 
@@ -1104,8 +1242,11 @@ def test_validate_input_happy_path_sets_unique_id_and_normalizes(
     """Successful validation should normalize data and set unique ID."""
 
     body = b'{"dailyInfo": [{"day": "D0"}]}'
-    session = _SequenceSession([_StubResponse(200, body), _StubResponse(200, body)])
-    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
+    factory = _PatchedClientFactory(
+        [_StubResponse(200, body), _StubResponse(200, body)]
+    )
+    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: object())
+    monkeypatch.setattr(cf, "GooglePollenApiClient", factory)
 
     class _TrackingFlow(PollenLevelsConfigFlow):
         def __init__(self) -> None:
@@ -1135,7 +1276,9 @@ def test_validate_input_happy_path_sets_unique_id_and_normalizes(
         flow._async_validate_input(user_input, check_unique_id=True)
     )
 
-    assert session.calls
+    assert factory.calls
+    assert factory.calls[0]["days"] == 1
+    assert factory.calls[0]["language_code"] == "es"
     assert errors == {}
     assert normalized is not None
     assert normalized[CONF_LATITUDE] == pytest.approx(1.0)
@@ -1151,8 +1294,11 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
     """Unique-id format should match legacy 4-decimal duplicate detection."""
 
     body = b'{"dailyInfo": [{"day": "D0"}]}'
-    session = _SequenceSession([_StubResponse(200, body), _StubResponse(200, body)])
-    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
+    factory = _PatchedClientFactory(
+        [_StubResponse(200, body), _StubResponse(200, body)]
+    )
+    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: object())
+    monkeypatch.setattr(cf, "GooglePollenApiClient", factory)
 
     class _TrackingFlow(PollenLevelsConfigFlow):
         def __init__(self) -> None:
@@ -1185,7 +1331,7 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
         flow._async_validate_input(second, check_unique_id=True)
     )
 
-    assert session.calls
+    assert factory.calls
     assert first_errors == {}
     assert second_errors == {}
     assert first_normalized is not None


### PR DESCRIPTION
### **User description**
### Motivation
- Align config-flow setup validation with the runtime client behavior to ensure consistent parsing and error semantics.
- Replace fragile text-based HTTP 429 detection with a dedicated client exception so `quota_exceeded` mapping is stable.
- Improve maintainability by removing duplicate HTTP/JSON parsing from the flow and centralizing network logic in the client.
- Prepare a release bump and document changes in `CHANGELOG.md` and package metadata.

### Description
- Added `PollenQuotaExceededError` in `custom_components/pollenlevels/client.py` and raise it when the API returns HTTP 429 instead of a text-based `UpdateFailed`.
- Rewrote validation in `custom_components/pollenlevels/config_flow.py` to call `GooglePollenApiClient.async_fetch_pollen_data` and map `ConfigEntryAuthFailed`, `PollenQuotaExceededError`, `UpdateFailed`, `TimeoutError`, and `ClientError` to form error keys (`invalid_auth`, `quota_exceeded`, `cannot_connect`, etc.).
- Updated unit test scaffolding in `tests/test_config_flow.py` to stub `GooglePollenApiClient`, add tests for client-timeout and client-transport error mapping, adapt helper factories, and validate that request args (like `days` and `language_code`) are normalized.
- Bumped the integration version to `1.9.5` in `manifest.json` and `pyproject.toml`, and added the corresponding `CHANGELOG.md` entry.

### Testing
- Ran `pytest tests/test_config_flow.py` to exercise config-flow validation and client stubs, and the test suite passed.
- Exercised new/updated assertions for HTTP 429 mapping (`quota_exceeded`), client `TimeoutError` mapping to `cannot_connect`, client transport errors mapping to `cannot_connect`, and the happy-path normalization, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a141d267088324a75b505542b1f585)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `PollenQuotaExceededError` exception for dedicated HTTP 429 handling

- Refactored config-flow validation to use `GooglePollenApiClient` directly

- Centralized error mapping for auth, quota, timeout, and connectivity failures

- Expanded test coverage with client-based validation and error scenarios

- Bumped version to 1.9.5 with changelog documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Config Flow Validation"] -->|"uses"| B["GooglePollenApiClient"]
  B -->|"raises"| C["PollenQuotaExceededError"]
  B -->|"raises"| D["ConfigEntryAuthFailed"]
  B -->|"raises"| E["UpdateFailed"]
  C -->|"maps to"| F["quota_exceeded"]
  D -->|"maps to"| G["invalid_auth"]
  E -->|"maps to"| H["cannot_connect"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add dedicated quota exceeded exception</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/client.py

<ul><li>Added <code>PollenQuotaExceededError</code> exception class inheriting from <br><code>UpdateFailed</code><br> <li> Modified HTTP 429 handling to raise <code>PollenQuotaExceededError</code> instead <br>of generic <code>UpdateFailed</code></ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-db3bec85a0825f26ef8be9eaef5dd550d26d4f97a685b9a665a01d982645a740">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Refactor validation to use GooglePollenApiClient</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/config_flow.py

<ul><li>Removed manual HTTP request handling and JSON parsing from validation<br> <li> Replaced with direct calls to <br><code>GooglePollenApiClient.async_fetch_pollen_data</code><br> <li> Added exception handlers for <code>ConfigEntryAuthFailed</code>, <br><code>PollenQuotaExceededError</code>, <code>UpdateFailed</code>, <code>TimeoutError</code>, and <code>ClientError</code><br> <li> Simplified error mapping logic by delegating to client exceptions<br> <li> Removed unused imports (<code>json</code>, <code>aiohttp</code>, <code>extract_error_message</code>, <br><code>is_invalid_api_key_message</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-2bf60984f3b03936f7c2154da3fc3848c4b334d79c13751db9d20ef3d453d646">+38/-69</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_config_flow.py</strong><dd><code>Update tests for client-based validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_config_flow.py

<ul><li>Added stub modules for <code>homeassistant.exceptions</code> and <br><code>homeassistant.helpers.update_coordinator</code><br> <li> Created <code>_StubGooglePollenApiClient</code> and <code>_StubPollenQuotaExceededError</code> <br>for testing<br> <li> Replaced <code>_SequenceSession</code> with <code>_StubValidationClient</code> and <br><code>_PatchedClientFactory</code> for client-based testing<br> <li> Added test cases for client timeout mapping and client error mapping <br>to <code>cannot_connect</code><br> <li> Updated existing tests to verify normalized request arguments (<code>days</code>, <br><code>language_code</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667">+171/-25</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 1.9.5 release changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added version 1.9.5 release notes documenting alignment of config-flow <br>with client semantics<br> <li> Documented removal of duplicate HTTP/JSON parsing and centralized <br>error mapping<br> <li> Listed expanded test coverage for client-based setup validation</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump integration version to 1.9.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/manifest.json

- Bumped version from 1.9.4 to 1.9.5


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-c669441e47d06d4aaed40b66e7e0b60fead7fc8092057d212dcf08b4bcf92d6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump package version to 1.9.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 1.9.4 to 1.9.5


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/76/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

