### PR TITLE
Reuse GooglePollenApiClient for config-flow validation, improve error mapping, bump version to 1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.
 - Reused the shared Google Pollen API client for config-flow validation so setup now
   follows the same retries and HTTP error handling semantics as runtime updates.
+
+### Fixed
 - Restored user-facing fallback messages for setup timeout/network validation
   failures when upstream exception text is empty.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Ensured config-flow always provides non-empty `{error_message}` placeholders
   for auth and update validation failures with category-appropriate fallback text.
 - Classified setup quota errors via a dedicated client exception instead of
-  matching `"HTTP 429"` in error text, and clarified config-flow fallback
+  matching `"HTTP 429"` in the error message, and clarified config-flow fallback
   message selection logic for maintainability.
 - Trimmed redacted validation errors before fallback selection so whitespace-only
   messages no longer suppress user-facing setup error details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 - Restored user-facing fallback messages for setup timeout/network validation
   failures when upstream exception text is empty.
+- Ensured config-flow always provides non-empty `{error_message}` placeholders
+  for auth and update validation failures with category-appropriate fallback text.
 
 ## [1.9.4] - 2026-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   message selection logic for maintainability.
 - Trimmed redacted validation errors before fallback selection so whitespace-only
   messages no longer suppress user-facing setup error details.
+- Replaced code-only HTTP placeholders (for example `HTTP 429`/`HTTP 500`) with
+  friendly setup error fallbacks and normalized client HTTP message formatting for
+  whitespace-only API error text.
 
 ## [1.9.4] - 2026-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   failures when upstream exception text is empty.
 - Ensured config-flow always provides non-empty `{error_message}` placeholders
   for auth and update validation failures with category-appropriate fallback text.
+- Classified setup quota errors via a dedicated client exception instead of
+  matching `"HTTP 429"` in error text, and clarified config-flow fallback
+  message selection logic for maintainability.
 
 ## [1.9.4] - 2026-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Classified setup quota errors via a dedicated client exception instead of
   matching `"HTTP 429"` in error text, and clarified config-flow fallback
   message selection logic for maintainability.
+- Trimmed redacted validation errors before fallback selection so whitespace-only
+  messages no longer suppress user-facing setup error details.
 
 ## [1.9.4] - 2026-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.5] - 2026-02-27
+### Changed
+- Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.
+- Reused the shared Google Pollen API client for config-flow validation so setup now
+  follows the same retries and HTTP error handling semantics as runtime updates.
+
 ## [1.9.4] - 2026-02-24
 ### Changed
 - Updated release packaging automation for HACS `zip_release` by validating the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.
 - Reused the shared Google Pollen API client for config-flow validation so setup now
   follows the same retries and HTTP error handling semantics as runtime updates.
+- Restored user-facing fallback messages for setup timeout/network validation
+  failures when upstream exception text is empty.
 
 ## [1.9.4] - 2026-02-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.9.5] - 2026-02-27
+## [1.9.5] - 2026-03-02
 ### Changed
 - Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.
 - Reused the shared Google Pollen API client for config-flow validation so setup now

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -30,6 +30,10 @@ def _format_http_message(status: int, raw_message: str | None) -> str:
     return f"HTTP {status}"
 
 
+class PollenQuotaExceededError(UpdateFailed):
+    """Raised when the Google Pollen API quota is exceeded (HTTP 429)."""
+
+
 class GooglePollenApiClient:
     """Thin async client wrapper for the Google Pollen API."""
 
@@ -136,7 +140,7 @@ class GooglePollenApiClient:
                             await extract_error_message(resp, default=""), self._api_key
                         )
                         message = _format_http_message(resp.status, raw_message or None)
-                        raise UpdateFailed(message)
+                        raise PollenQuotaExceededError(message)
 
                     if 500 <= resp.status <= 599:
                         if attempt < max_retries:

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -31,7 +31,11 @@ def _format_http_message(status: int, raw_message: str | None) -> str:
 
 
 class PollenQuotaExceededError(UpdateFailed):
-    """Raised when the Google Pollen API quota is exceeded (HTTP 429)."""
+    """Raised when the Google Pollen API quota is exceeded (HTTP 429).
+
+    Inherits from UpdateFailed to stay compatible with existing client/coordinator
+    error handling while still allowing explicit quota classification in config flow.
+    """
 
 
 class GooglePollenApiClient:

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -25,8 +25,9 @@ _LOGGER = logging.getLogger(__name__)
 def _format_http_message(status: int, raw_message: str | None) -> str:
     """Format an HTTP status and optional message consistently."""
 
-    if raw_message:
-        return f"HTTP {status}: {raw_message}"
+    cleaned = raw_message.strip() if raw_message else ""
+    if cleaned:
+        return f"HTTP {status}: {cleaned}"
     return f"HTTP {status}"
 
 

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -435,15 +435,16 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.warning("Authentication failed during validation")
             errors["base"] = "invalid_auth"
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
+            placeholders["error_message"] = redacted or "Authentication failed."
         except UpdateFailed as err:
-            errors["base"] = (
-                "quota_exceeded" if "HTTP 429" in str(err) else "cannot_connect"
-            )
+            base = "quota_exceeded" if "HTTP 429" in str(err) else "cannot_connect"
+            errors["base"] = base
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
+            placeholders["error_message"] = redacted or (
+                "Quota exceeded."
+                if base == "quota_exceeded"
+                else "Failed to connect to the pollen service."
+            )
         except TimeoutError as err:
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -439,10 +439,14 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
             redacted = redact_api_key(err, api_key).strip()
+            if re.fullmatch(r"HTTP\s+429(?::)?", redacted, flags=re.IGNORECASE):
+                redacted = ""
             placeholders["error_message"] = redacted or "Quota exceeded."
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key).strip()
+            if re.fullmatch(r"HTTP\s+\d+(?::)?", redacted, flags=re.IGNORECASE):
+                redacted = ""
             placeholders["error_message"] = (
                 redacted or "Failed to connect to the pollen service."
             )

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -13,7 +13,6 @@ IMPORTANT:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any
@@ -23,6 +22,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     LocationSelector,
@@ -37,7 +37,9 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .client import GooglePollenApiClient
 from .const import (
     CONF_API_KEY,
     CONF_CREATE_FORECAST_SENSORS,
@@ -54,12 +56,9 @@ from .const import (
     MIN_FORECAST_DAYS,
     MIN_UPDATE_INTERVAL_HOURS,
     POLLEN_API_KEY_URL,
-    POLLEN_API_TIMEOUT,
     RESTRICTING_API_KEYS_URL,
-    is_invalid_api_key_message,
 )
 from .util import (
-    extract_error_message,
     normalize_sensor_mode,
     redact_api_key,
     safe_parse_int,
@@ -398,71 +397,25 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lang = is_valid_language_code(lang)
 
             session = async_get_clientsession(self.hass)
-            params = {
-                "key": api_key,
-                "location.latitude": f"{lat:.6f}",
-                "location.longitude": f"{lon:.6f}",
-                "days": 1,
-            }
-            if lang:
-                params["languageCode"] = lang
+            client = GooglePollenApiClient(session=session, api_key=api_key)
+            data = await client.async_fetch_pollen_data(
+                latitude=lat,
+                longitude=lon,
+                days=1,
+                language_code=lang or None,
+            )
 
-            url = "https://pollen.googleapis.com/v1/forecast:lookup"
+            daily_info = data.get("dailyInfo") if isinstance(data, dict) else None
+            daily_is_valid = isinstance(daily_info, list) and bool(daily_info)
+            if daily_is_valid:
+                daily_is_valid = all(isinstance(item, dict) for item in daily_info)
 
-            _LOGGER.debug("Validating Pollen API (days=%s, lang_set=%s)", 1, bool(lang))
-
-            async with session.get(
-                url,
-                params=params,
-                timeout=aiohttp.ClientTimeout(total=POLLEN_API_TIMEOUT),
-            ) as resp:
-                status = resp.status
-                if status != 200:
-                    _LOGGER.debug("Validation HTTP %s (body omitted)", status)
-                    raw_msg = await extract_error_message(resp, f"HTTP {status}")
-                    placeholders["error_message"] = redact_api_key(raw_msg, api_key)
-                    if status == 401:
-                        errors["base"] = "invalid_auth"
-                    elif status == 403:
-                        if is_invalid_api_key_message(raw_msg):
-                            errors["base"] = "invalid_auth"
-                        else:
-                            errors["base"] = "cannot_connect"
-                    elif status == 429:
-                        errors["base"] = "quota_exceeded"
-                    else:
-                        errors["base"] = "cannot_connect"
-                else:
-                    raw = await resp.read()
-                    try:
-                        body_str = raw.decode()
-                    except Exception:
-                        body_str = str(raw)
-                    _LOGGER.debug(
-                        "Validation HTTP %s — %s",
-                        status,
-                        redact_api_key(body_str, api_key),
-                    )
-                    try:
-                        data = json.loads(body_str) if body_str else {}
-                    except Exception:
-                        data = {}
-
-                    daily_info = (
-                        data.get("dailyInfo") if isinstance(data, dict) else None
-                    )
-                    daily_is_valid = isinstance(daily_info, list) and bool(daily_info)
-                    if daily_is_valid:
-                        daily_is_valid = all(
-                            isinstance(item, dict) for item in daily_info
-                        )
-
-                    if not daily_is_valid:
-                        _LOGGER.warning("Validation: 'dailyInfo' missing or invalid")
-                        errors["base"] = "cannot_connect"
-                        placeholders["error_message"] = (
-                            "API response missing expected pollen forecast information."
-                        )
+            if not daily_is_valid:
+                _LOGGER.warning("Validation: 'dailyInfo' missing or invalid")
+                errors["base"] = "cannot_connect"
+                placeholders["error_message"] = (
+                    "API response missing expected pollen forecast information."
+                )
 
             if errors:
                 return errors, None
@@ -478,18 +431,25 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors[CONF_LANGUAGE_CODE] = _language_error_to_form_key(ve)
             placeholders.pop("error_message", None)
-        except TimeoutError as err:
-            _LOGGER.warning(
-                "Validation timeout (%ss): %s",
-                POLLEN_API_TIMEOUT,
-                redact_api_key(err, api_key),
+        except ConfigEntryAuthFailed as err:
+            _LOGGER.warning("Authentication failed during validation")
+            errors["base"] = "invalid_auth"
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+        except UpdateFailed as err:
+            errors["base"] = (
+                "quota_exceeded" if "HTTP 429" in str(err) else "cannot_connect"
             )
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+        except TimeoutError as err:
+            _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key)
-            placeholders["error_message"] = (
-                redacted
-                or f"Validation request timed out ({POLLEN_API_TIMEOUT} seconds)."
-            )
+            if redacted:
+                placeholders["error_message"] = redacted
         except aiohttp.ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
@@ -497,9 +457,8 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key)
-            placeholders["error_message"] = (
-                redacted or "Network error while connecting to the pollen service."
-            )
+            if redacted:
+                placeholders["error_message"] = redacted
         except Exception as err:  # defensive
             _LOGGER.exception(
                 "Unexpected error in Pollen Levels config flow while validating input: %s",

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -439,19 +439,13 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
-            else:
-                placeholders["error_message"] = "Quota exceeded."
+            placeholders["error_message"] = redacted or "Quota exceeded."
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
-            else:
-                placeholders["error_message"] = (
-                    "Failed to connect to the pollen service."
-                )
+            placeholders["error_message"] = (
+                redacted or "Failed to connect to the pollen service."
+            )
         except TimeoutError as err:
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -434,22 +434,22 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ConfigEntryAuthFailed as err:
             _LOGGER.warning("Authentication failed during validation")
             errors["base"] = "invalid_auth"
-            redacted = redact_api_key(err, api_key)
+            redacted = redact_api_key(err, api_key).strip()
             placeholders["error_message"] = redacted or "Authentication failed."
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
-            redacted = redact_api_key(err, api_key)
+            redacted = redact_api_key(err, api_key).strip()
             placeholders["error_message"] = redacted or "Quota exceeded."
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key)
+            redacted = redact_api_key(err, api_key).strip()
             placeholders["error_message"] = (
                 redacted or "Failed to connect to the pollen service."
             )
         except TimeoutError as err:
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key)
+            redacted = redact_api_key(err, api_key).strip()
             placeholders["error_message"] = redacted or "Validation request timed out."
         except aiohttp.ClientError as err:
             _LOGGER.error(
@@ -457,7 +457,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 redact_api_key(err, api_key),
             )
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key)
+            redacted = redact_api_key(err, api_key).strip()
             placeholders["error_message"] = (
                 redacted or "Network error while connecting to the pollen service."
             )

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -448,8 +448,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
+            placeholders["error_message"] = redacted or "Validation request timed out."
         except aiohttp.ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
@@ -457,8 +456,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key)
-            if redacted:
-                placeholders["error_message"] = redacted
+            placeholders["error_message"] = (
+                redacted or "Network error while connecting to the pollen service."
+            )
         except Exception as err:  # defensive
             _LOGGER.exception(
                 "Unexpected error in Pollen Levels config flow while validating input: %s",

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .client import GooglePollenApiClient
+from .client import GooglePollenApiClient, PollenQuotaExceededError
 from .const import (
     CONF_API_KEY,
     CONF_CREATE_FORECAST_SENSORS,
@@ -436,15 +436,22 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "invalid_auth"
             redacted = redact_api_key(err, api_key)
             placeholders["error_message"] = redacted or "Authentication failed."
-        except UpdateFailed as err:
-            base = "quota_exceeded" if "HTTP 429" in str(err) else "cannot_connect"
-            errors["base"] = base
+        except PollenQuotaExceededError as err:
+            errors["base"] = "quota_exceeded"
             redacted = redact_api_key(err, api_key)
-            placeholders["error_message"] = redacted or (
-                "Quota exceeded."
-                if base == "quota_exceeded"
-                else "Failed to connect to the pollen service."
-            )
+            if redacted:
+                placeholders["error_message"] = redacted
+            else:
+                placeholders["error_message"] = "Quota exceeded."
+        except UpdateFailed as err:
+            errors["base"] = "cannot_connect"
+            redacted = redact_api_key(err, api_key)
+            if redacted:
+                placeholders["error_message"] = redacted
+            else:
+                placeholders["error_message"] = (
+                    "Failed to connect to the pollen service."
+                )
         except TimeoutError as err:
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.4"
+    "version": "1.9.5"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.4"
+version = "1.9.5"
 # Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -901,7 +901,7 @@ def test_validate_input_http_429_sets_quota_exceeded(
     """HTTP 429 during validation should map to quota_exceeded."""
 
     calls = _patch_client_fetch(
-        monkeypatch, error=UpdateFailed("HTTP 429 Too Many Requests")
+        monkeypatch, error=cf.PollenQuotaExceededError("HTTP 429 Too Many Requests")
     )
 
     flow = PollenLevelsConfigFlow()
@@ -1101,14 +1101,16 @@ def test_validate_input_auth_error_empty_message_uses_fallback_placeholder(
     assert placeholders.get("error_message") == "Authentication failed."
 
 
-def test_validate_input_http_429_maps_to_quota_exceeded(
+def test_validate_input_quota_error_maps_to_quota_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """UpdateFailed carrying HTTP 429 should map to quota_exceeded."""
+    """Dedicated quota errors should map to quota_exceeded."""
 
     calls = _patch_client_fetch(
         monkeypatch,
-        error=UpdateFailed("HTTP 429: API key not valid. Please pass a valid API key."),
+        error=cf.PollenQuotaExceededError(
+            "HTTP 429: API key not valid. Please pass a valid API key."
+        ),
     )
 
     flow = PollenLevelsConfigFlow()
@@ -1159,9 +1161,11 @@ def test_validate_input_update_failed_empty_message_uses_connect_fallback(
 def test_validate_input_http_429_empty_redacted_uses_quota_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Quota errors should use fallback text when redaction produces an empty string."""
+    """Quota-exceeded errors should use fallback text when redaction is empty."""
 
-    calls = _patch_client_fetch(monkeypatch, error=UpdateFailed("HTTP 429"))
+    calls = _patch_client_fetch(
+        monkeypatch, error=cf.PollenQuotaExceededError("HTTP 429")
+    )
     monkeypatch.setattr(cf, "redact_api_key", lambda *_args, **_kwargs: "")
 
     flow = PollenLevelsConfigFlow()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1104,6 +1104,58 @@ def test_validate_input_http_429_maps_to_quota_exceeded(
     assert "api key not valid" in placeholders.get("error_message", "").lower()
 
 
+def test_validate_input_timeout_sets_fallback_error_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimeoutError without a message should still provide a user-friendly fallback."""
+
+    calls = _patch_client_fetch(monkeypatch, error=TimeoutError())
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert placeholders.get("error_message") == "Validation request timed out."
+
+
+def test_validate_input_client_error_sets_fallback_error_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ClientError without details should still provide a network fallback message."""
+
+    calls = _patch_client_fetch(monkeypatch, error=cf.aiohttp.ClientError())
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert placeholders.get("error_message") == (
+        "Network error while connecting to the pollen service."
+    )
+
+
 def test_validate_input_redacts_api_key_in_error_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import email.utils
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -87,6 +89,16 @@ config_entries_mod.ConfigFlow = _StubConfigFlow
 config_entries_mod.OptionsFlow = _StubOptionsFlow
 config_entries_mod.ConfigEntry = _StubConfigEntry
 _force_module("homeassistant.config_entries", config_entries_mod)
+
+exceptions_mod = ModuleType("homeassistant.exceptions")
+
+
+class _StubConfigEntryAuthFailed(Exception):
+    pass
+
+
+exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
+_force_module("homeassistant.exceptions", exceptions_mod)
 
 const_mod = ModuleType("homeassistant.const")
 const_mod.CONF_LATITUDE = "latitude"
@@ -171,6 +183,55 @@ class _StubSession:
 
 aiohttp_client_mod.async_get_clientsession = lambda hass: _StubSession()
 _force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
+
+update_coordinator_mod = ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class _StubUpdateFailed(Exception):
+    pass
+
+
+class _StubDataUpdateCoordinator:
+    def __init__(self, *args, **kwargs):
+        self.hass = args[0] if args else None
+        self.data = None
+
+    async def async_refresh(self):
+        return None
+
+    async def async_request_refresh(self):
+        return None
+
+    async def async_config_entry_first_refresh(self):
+        return None
+
+
+class _StubCoordinatorEntity:
+    def __init__(self, coordinator=None):
+        self.coordinator = coordinator
+
+
+update_coordinator_mod.UpdateFailed = _StubUpdateFailed
+update_coordinator_mod.DataUpdateCoordinator = _StubDataUpdateCoordinator
+update_coordinator_mod.CoordinatorEntity = _StubCoordinatorEntity
+_force_module("homeassistant.helpers.update_coordinator", update_coordinator_mod)
+
+util_mod = ModuleType("homeassistant.util")
+dt_mod = ModuleType("homeassistant.util.dt")
+
+
+def _parse_http_date(value: str):
+    try:
+        return email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+
+
+dt_mod.parse_http_date = _parse_http_date
+dt_mod.utcnow = lambda: datetime.now(UTC)
+util_mod.dt = dt_mod
+_force_module("homeassistant.util", util_mod)
+_force_module("homeassistant.util.dt", dt_mod)
 
 selector_mod = ModuleType("homeassistant.helpers.selector")
 
@@ -270,8 +331,14 @@ class _StubClientTimeout:
         self.total = total
 
 
+class _StubClientSession:
+    pass
+
+
 aiohttp_mod.ClientError = _StubClientError
 aiohttp_mod.ClientTimeout = _StubClientTimeout
+aiohttp_mod.ClientSession = _StubClientSession
+aiohttp_mod.ContentTypeError = ValueError
 _force_module("aiohttp", aiohttp_mod)
 
 vol_mod = ModuleType("voluptuous")
@@ -304,6 +371,8 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_NAME,
 )
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.pollenlevels import config_flow as cf
 from custom_components.pollenlevels.config_flow import (
@@ -554,10 +623,26 @@ def test_validate_input_non_dict_location() -> None:
     assert normalized is None
 
 
-def _patch_client_session(monkeypatch: pytest.MonkeyPatch, response: _StubResponse):
-    session = _SequenceSession([response])
-    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
-    return session
+def _patch_client_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: dict | None = None,
+    error: Exception | None = None,
+) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    async def _fake_fetch(self, **kwargs):
+        calls.append(kwargs)
+        if error is not None:
+            raise error
+        return result or {"dailyInfo": [{"day": "D0"}]}
+
+    monkeypatch.setattr(
+        cf.GooglePollenApiClient,
+        "async_fetch_pollen_data",
+        _fake_fetch,
+    )
+    return calls
 
 
 def _base_user_input() -> dict:
@@ -722,7 +807,7 @@ def test_validate_input_update_interval_below_min_sets_error(
 ) -> None:
     """Sub-1 update intervals should surface a field error and skip I/O."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(200))
+    calls = _patch_client_fetch(monkeypatch)
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -735,7 +820,7 @@ def test_validate_input_update_interval_below_min_sets_error(
 
     assert errors == {CONF_UPDATE_INTERVAL: "invalid_update_interval"}
     assert normalized is None
-    assert not session.calls
+    assert not calls
 
 
 def test_validate_input_update_interval_float_string(
@@ -743,8 +828,9 @@ def test_validate_input_update_interval_float_string(
 ) -> None:
     """Float-like strings should coerce to int and allow validation to proceed."""
 
-    session = _patch_client_session(
-        monkeypatch, _StubResponse(200, b'{"dailyInfo": [{"indexInfo": []}]}')
+    calls = _patch_client_fetch(
+        monkeypatch,
+        result={"dailyInfo": [{"indexInfo": []}]},
     )
 
     flow = PollenLevelsConfigFlow()
@@ -759,7 +845,7 @@ def test_validate_input_update_interval_float_string(
     assert errors == {}
     assert normalized is not None
     assert normalized[CONF_UPDATE_INTERVAL] == 1
-    assert session.calls
+    assert calls
 
 
 def test_validate_input_update_interval_non_numeric_sets_error(
@@ -767,7 +853,7 @@ def test_validate_input_update_interval_non_numeric_sets_error(
 ) -> None:
     """Non-numeric update intervals should surface a field error and skip I/O."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(200))
+    calls = _patch_client_fetch(monkeypatch)
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -780,22 +866,22 @@ def test_validate_input_update_interval_non_numeric_sets_error(
 
     assert errors == {CONF_UPDATE_INTERVAL: "invalid_update_interval"}
     assert normalized is None
-    assert not session.calls
+    assert not calls
 
 
 @pytest.mark.parametrize(
-    ("status", "expected"),
+    ("error", "expected"),
     [
-        (401, {"base": "invalid_auth"}),
-        (403, {"base": "cannot_connect"}),
+        (ConfigEntryAuthFailed("HTTP 401"), {"base": "invalid_auth"}),
+        (UpdateFailed("HTTP 403"), {"base": "cannot_connect"}),
     ],
 )
 def test_validate_input_http_auth_errors_map_correctly(
-    monkeypatch: pytest.MonkeyPatch, status: int, expected: dict
+    monkeypatch: pytest.MonkeyPatch, error: Exception, expected: dict
 ) -> None:
     """HTTP auth failures during validation should map correctly."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(status))
+    calls = _patch_client_fetch(monkeypatch, error=error)
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -804,7 +890,7 @@ def test_validate_input_http_auth_errors_map_correctly(
         flow._async_validate_input(_base_user_input(), check_unique_id=False)
     )
 
-    assert session.calls
+    assert calls
     assert errors == expected
     assert normalized is None
 
@@ -814,7 +900,9 @@ def test_validate_input_http_429_sets_quota_exceeded(
 ) -> None:
     """HTTP 429 during validation should map to quota_exceeded."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(429))
+    calls = _patch_client_fetch(
+        monkeypatch, error=UpdateFailed("HTTP 429 Too Many Requests")
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -823,7 +911,7 @@ def test_validate_input_http_429_sets_quota_exceeded(
         flow._async_validate_input(_base_user_input(), check_unique_id=False)
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "quota_exceeded"}
     assert normalized is None
 
@@ -833,7 +921,9 @@ def test_validate_input_http_500_sets_cannot_connect(
 ) -> None:
     """Unexpected HTTP failures should map to cannot_connect."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(500))
+    calls = _patch_client_fetch(
+        monkeypatch, error=UpdateFailed("HTTP 500 Internal Server Error")
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -842,7 +932,7 @@ def test_validate_input_http_500_sets_cannot_connect(
         flow._async_validate_input(_base_user_input(), check_unique_id=False)
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
 
@@ -852,7 +942,9 @@ def test_validate_input_http_500_sets_error_message_placeholder(
 ) -> None:
     """HTTP 500 should populate the cannot_connect error_message placeholder."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(500))
+    calls = _patch_client_fetch(
+        monkeypatch, error=UpdateFailed("HTTP 500 Internal Server Error")
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -866,7 +958,7 @@ def test_validate_input_http_500_sets_error_message_placeholder(
         )
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
     assert placeholders.get("error_message")
@@ -877,7 +969,9 @@ def test_validate_input_clears_error_message_placeholder_on_validation_error(
 ) -> None:
     """Field-level validation errors should clear stale error_message placeholders."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(500))
+    calls = _patch_client_fetch(
+        monkeypatch, error=UpdateFailed("HTTP 500 Internal Server Error")
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -891,7 +985,7 @@ def test_validate_input_clears_error_message_placeholder_on_validation_error(
         )
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
     assert placeholders.get("error_message")
@@ -914,7 +1008,9 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
 ) -> None:
     """invalid_option_combo should clear stale error_message placeholders."""
 
-    session = _patch_client_session(monkeypatch, _StubResponse(500))
+    calls = _patch_client_fetch(
+        monkeypatch, error=UpdateFailed("HTTP 500 Internal Server Error")
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -928,14 +1024,12 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
         )
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
     assert placeholders.get("error_message")
 
-    _patch_client_session(
-        monkeypatch, _StubResponse(200, b'{"dailyInfo": [{"day": "D0"}]}')
-    )
+    _patch_client_fetch(monkeypatch, result={"dailyInfo": [{"day": "D0"}]})
 
     errors, normalized = asyncio.run(
         flow._async_validate_input(
@@ -954,13 +1048,15 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
     assert "error_message" not in placeholders
 
 
-def test_validate_input_http_403_sets_error_message_placeholder(
+def test_validate_input_auth_error_sets_error_message_placeholder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 403 should populate the cannot_connect error_message placeholder."""
+    """Auth failures should populate the invalid_auth error_message placeholder."""
 
-    body = b'{"error": {"message": "Forbidden for this project"}}'
-    session = _patch_client_session(monkeypatch, _StubResponse(status=403, body=body))
+    calls = _patch_client_fetch(
+        monkeypatch,
+        error=ConfigEntryAuthFailed("HTTP 401: Forbidden for this project"),
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -974,19 +1070,21 @@ def test_validate_input_http_403_sets_error_message_placeholder(
         )
     )
 
-    assert session.calls
-    assert errors == {"base": "cannot_connect"}
+    assert calls
+    assert errors == {"base": "invalid_auth"}
     assert normalized is None
     assert "Forbidden" in placeholders.get("error_message", "")
 
 
-def test_validate_input_http_403_invalid_key_maps_to_invalid_auth(
+def test_validate_input_http_429_maps_to_quota_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HTTP 403 invalid API key messages should behave like invalid_auth."""
+    """UpdateFailed carrying HTTP 429 should map to quota_exceeded."""
 
-    body = b'{"error": {"message": "API key not valid. Please pass a valid API key."}}'
-    session = _patch_client_session(monkeypatch, _StubResponse(status=403, body=body))
+    calls = _patch_client_fetch(
+        monkeypatch,
+        error=UpdateFailed("HTTP 429: API key not valid. Please pass a valid API key."),
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -1000,8 +1098,8 @@ def test_validate_input_http_403_invalid_key_maps_to_invalid_auth(
         )
     )
 
-    assert session.calls
-    assert errors == {"base": "invalid_auth"}
+    assert calls
+    assert errors == {"base": "quota_exceeded"}
     assert normalized is None
     assert "api key not valid" in placeholders.get("error_message", "").lower()
 
@@ -1011,8 +1109,10 @@ def test_validate_input_redacts_api_key_in_error_message(
 ) -> None:
     """Error placeholders should redact API keys returned by the service."""
 
-    body = b'{"error": {"message": "API key test-key not valid"}}'
-    session = _patch_client_session(monkeypatch, _StubResponse(status=401, body=body))
+    calls = _patch_client_fetch(
+        monkeypatch,
+        error=ConfigEntryAuthFailed("HTTP 401: API key test-key not valid"),
+    )
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -1029,7 +1129,7 @@ def test_validate_input_redacts_api_key_in_error_message(
         )
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "invalid_auth"}
     assert normalized is None
     error_message = placeholders.get("error_message", "")
@@ -1042,8 +1142,7 @@ def test_validate_input_http_200_non_list_dailyinfo_sets_cannot_connect(
 ) -> None:
     """A non-list dailyInfo in HTTP 200 should be treated as invalid."""
 
-    body = b'{"dailyInfo": "invalid"}'
-    session = _patch_client_session(monkeypatch, _StubResponse(status=200, body=body))
+    calls = _patch_client_fetch(monkeypatch, result={"dailyInfo": "invalid"})
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -1052,7 +1151,7 @@ def test_validate_input_http_200_non_list_dailyinfo_sets_cannot_connect(
         flow._async_validate_input(_base_user_input(), check_unique_id=False)
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
 
@@ -1062,8 +1161,7 @@ def test_validate_input_http_200_dailyinfo_with_non_dict_sets_cannot_connect(
 ) -> None:
     """A dailyInfo list with non-dict items should be treated as invalid."""
 
-    body = b'{"dailyInfo": ["invalid-item"]}'
-    session = _patch_client_session(monkeypatch, _StubResponse(status=200, body=body))
+    calls = _patch_client_fetch(monkeypatch, result={"dailyInfo": ["invalid-item"]})
 
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -1072,7 +1170,7 @@ def test_validate_input_http_200_dailyinfo_with_non_dict_sets_cannot_connect(
         flow._async_validate_input(_base_user_input(), check_unique_id=False)
     )
 
-    assert session.calls
+    assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
 
@@ -1103,9 +1201,7 @@ def test_validate_input_happy_path_sets_unique_id_and_normalizes(
 ) -> None:
     """Successful validation should normalize data and set unique ID."""
 
-    body = b'{"dailyInfo": [{"day": "D0"}]}'
-    session = _SequenceSession([_StubResponse(200, body), _StubResponse(200, body)])
-    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
+    calls = _patch_client_fetch(monkeypatch, result={"dailyInfo": [{"day": "D0"}]})
 
     class _TrackingFlow(PollenLevelsConfigFlow):
         def __init__(self) -> None:
@@ -1135,7 +1231,7 @@ def test_validate_input_happy_path_sets_unique_id_and_normalizes(
         flow._async_validate_input(user_input, check_unique_id=True)
     )
 
-    assert session.calls
+    assert calls
     assert errors == {}
     assert normalized is not None
     assert normalized[CONF_LATITUDE] == pytest.approx(1.0)
@@ -1150,9 +1246,7 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
 ) -> None:
     """Unique-id format should match legacy 4-decimal duplicate detection."""
 
-    body = b'{"dailyInfo": [{"day": "D0"}]}'
-    session = _SequenceSession([_StubResponse(200, body), _StubResponse(200, body)])
-    monkeypatch.setattr(cf, "async_get_clientsession", lambda hass: session)
+    calls = _patch_client_fetch(monkeypatch, result={"dailyInfo": [{"day": "D0"}]})
 
     class _TrackingFlow(PollenLevelsConfigFlow):
         def __init__(self) -> None:
@@ -1185,7 +1279,7 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
         flow._async_validate_input(second, check_unique_id=True)
     )
 
-    assert session.calls
+    assert calls
     assert first_errors == {}
     assert second_errors == {}
     assert first_normalized is not None

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1076,6 +1076,31 @@ def test_validate_input_auth_error_sets_error_message_placeholder(
     assert "Forbidden" in placeholders.get("error_message", "")
 
 
+def test_validate_input_auth_error_empty_message_uses_fallback_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auth failures with empty text should use the default placeholder message."""
+
+    calls = _patch_client_fetch(monkeypatch, error=ConfigEntryAuthFailed(""))
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "invalid_auth"}
+    assert normalized is None
+    assert placeholders.get("error_message") == "Authentication failed."
+
+
 def test_validate_input_http_429_maps_to_quota_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1102,6 +1127,59 @@ def test_validate_input_http_429_maps_to_quota_exceeded(
     assert errors == {"base": "quota_exceeded"}
     assert normalized is None
     assert "api key not valid" in placeholders.get("error_message", "").lower()
+
+
+def test_validate_input_update_failed_empty_message_uses_connect_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UpdateFailed with empty text should use cannot_connect fallback message."""
+
+    calls = _patch_client_fetch(monkeypatch, error=UpdateFailed(""))
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert (
+        placeholders.get("error_message") == "Failed to connect to the pollen service."
+    )
+
+
+def test_validate_input_http_429_empty_redacted_uses_quota_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Quota errors should use fallback text when redaction produces an empty string."""
+
+    calls = _patch_client_fetch(monkeypatch, error=UpdateFailed("HTTP 429"))
+    monkeypatch.setattr(cf, "redact_api_key", lambda *_args, **_kwargs: "")
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "quota_exceeded"}
+    assert normalized is None
+    assert placeholders.get("error_message") == "Quota exceeded."
 
 
 def test_validate_input_timeout_sets_fallback_error_message(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -895,6 +895,33 @@ def test_validate_input_http_auth_errors_map_correctly(
     assert normalized is None
 
 
+def test_validate_input_http_429_code_only_uses_quota_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Code-only quota messages should be replaced by a friendly fallback."""
+
+    calls = _patch_client_fetch(
+        monkeypatch, error=cf.PollenQuotaExceededError("HTTP 429")
+    )
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "quota_exceeded"}
+    assert normalized is None
+    assert placeholders.get("error_message") == "Quota exceeded."
+
+
 def test_validate_input_http_429_sets_quota_exceeded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -935,6 +962,33 @@ def test_validate_input_http_500_sets_cannot_connect(
     assert calls
     assert errors == {"base": "cannot_connect"}
     assert normalized is None
+
+
+def test_validate_input_http_code_only_uses_connect_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Code-only UpdateFailed messages should use a friendly connect fallback."""
+
+    calls = _patch_client_fetch(monkeypatch, error=UpdateFailed("HTTP 500"))
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert (
+        placeholders.get("error_message") == "Failed to connect to the pollen service."
+    )
 
 
 def test_validate_input_http_500_sets_error_message_placeholder(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1158,6 +1158,62 @@ def test_validate_input_update_failed_empty_message_uses_connect_fallback(
     )
 
 
+def test_validate_input_http_429_whitespace_redacted_uses_quota_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only redacted quota messages should still use fallback text."""
+
+    calls = _patch_client_fetch(
+        monkeypatch, error=cf.PollenQuotaExceededError("HTTP 429")
+    )
+    monkeypatch.setattr(cf, "redact_api_key", lambda *_args, **_kwargs: "   ")
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "quota_exceeded"}
+    assert normalized is None
+    assert placeholders.get("error_message") == "Quota exceeded."
+
+
+def test_validate_input_update_failed_whitespace_redacted_uses_connect_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace-only redacted UpdateFailed messages should use connect fallback."""
+
+    calls = _patch_client_fetch(monkeypatch, error=UpdateFailed("HTTP 500"))
+    monkeypatch.setattr(cf, "redact_api_key", lambda *_args, **_kwargs: "   ")
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            _base_user_input(),
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert (
+        placeholders.get("error_message") == "Failed to connect to the pollen service."
+    )
+
+
 def test_validate_input_http_429_empty_redacted_uses_quota_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1446,6 +1446,12 @@ def test_coordinator_invalid_key_message_triggers_reauth() -> None:
         loop.close()
 
 
+def test_format_http_message_ignores_whitespace_only_message() -> None:
+    """Whitespace-only raw messages should not add a trailing HTTP suffix."""
+
+    assert client_mod._format_http_message(429, "   ") == "HTTP 429"
+
+
 def test_client_raises_dedicated_quota_error_after_terminal_429(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1446,6 +1446,48 @@ def test_coordinator_invalid_key_message_triggers_reauth() -> None:
         loop.close()
 
 
+def test_client_raises_dedicated_quota_error_after_terminal_429(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Terminal HTTP 429 responses raise the dedicated quota exception."""
+
+    session = SequenceSession(
+        [
+            ResponseSpec(
+                status=429,
+                payload={"error": {"message": "Quota exceeded"}},
+                headers={"Retry-After": "2"},
+            ),
+            ResponseSpec(
+                status=429,
+                payload={"error": {"message": "Quota exceeded"}},
+                headers={"Retry-After": "2"},
+            ),
+        ]
+    )
+
+    async def _fast_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+
+    client = client_mod.GooglePollenApiClient(session, "test")
+
+    async def _run() -> None:
+        await client.async_fetch_pollen_data(
+            latitude=1.0,
+            longitude=2.0,
+            days=1,
+            language_code=None,
+        )
+
+    with pytest.raises(client_mod.PollenQuotaExceededError, match="Quota exceeded"):
+        asyncio.run(_run())
+
+    assert session.calls == 2
+
+
 def test_coordinator_retries_then_raises_on_rate_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### **User description**
### Motivation
- Unify config-flow validation with runtime behavior by reusing the shared Google Pollen API client to ensure consistent retries and HTTP error semantics. 
- Improve error handling during setup so authentication, quota, timeout, and other HTTP failures map to clearer config-flow errors and preserve redacted error messages. 
- Publish a patch release and reflect packaging/version metadata updates.

### Description
- Replaced manual HTTP request/response parsing in `custom_components/pollenlevels/config_flow.py` with calls to `GooglePollenApiClient.async_fetch_pollen_data` and adjusted validation to inspect the returned `dailyInfo`. 
- Added imports and exception handling for `ConfigEntryAuthFailed` and `UpdateFailed`, mapping them to `invalid_auth`, `quota_exceeded`, or `cannot_connect` as appropriate, and preserved redacted `error_message` placeholders. 
- Updated package metadata and changelog: bumped `manifest.json` and `pyproject.toml` to version `1.9.5` and appended `CHANGELOG.md` entry for `1.9.5`. 
- Updated tests in `tests/test_config_flow.py` to stub and assert calls to `GooglePollenApiClient.async_fetch_pollen_data`, to introduce stubs for `homeassistant.exceptions.ConfigEntryAuthFailed` and `homeassistant.helpers.update_coordinator.UpdateFailed`, and to align assertions with the new error mappings and placeholder behavior.

### Testing
- Ran the updated unit tests with `pytest tests/test_config_flow.py`, which executed the config-flow validation tests and the modified assertions for error mapping and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1823ac330832496d550475b0b1a02)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Unified config-flow validation with runtime by reusing GooglePollenApiClient
  - Replaced manual HTTP request parsing with client.async_fetch_pollen_data()
  - Improved error mapping for auth, quota, timeout, and connection failures

- Enhanced exception handling with ConfigEntryAuthFailed and UpdateFailed
  - Maps HTTP 401/403 to invalid_auth, HTTP 429 to quota_exceeded
  - Preserves redacted error messages in placeholders

- Updated test suite to stub GooglePollenApiClient.async_fetch_pollen_data
  - Added stubs for homeassistant.exceptions and update_coordinator modules
  - Refactored test helpers to use exception-based mocking instead of HTTP responses

- Bumped version to 1.9.5 and updated changelog


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual HTTP<br/>Request Parsing"] -->|"Replace with"| B["GooglePollenApiClient<br/>async_fetch_pollen_data"]
  C["HTTP Status<br/>Code Mapping"] -->|"Refactor to"| D["Exception-based<br/>Error Handling"]
  E["ConfigEntryAuthFailed<br/>UpdateFailed"] -->|"Map to"| F["invalid_auth<br/>quota_exceeded<br/>cannot_connect"]
  B --> F
  D --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Reuse GooglePollenApiClient for config-flow validation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/config_flow.py

<ul><li>Removed manual HTTP request/response parsing and replaced with <br>GooglePollenApiClient.async_fetch_pollen_data() call<br> <li> Added imports for ConfigEntryAuthFailed and UpdateFailed exception <br>handling<br> <li> Refactored error handling to catch exceptions instead of checking HTTP <br>status codes<br> <li> Simplified validation logic by delegating HTTP communication to the <br>shared client<br> <li> Removed unused imports (json, POLLEN_API_TIMEOUT, <br>is_invalid_api_key_message, extract_error_message)</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/77/files#diff-2bf60984f3b03936f7c2154da3fc3848c4b334d79c13751db9d20ef3d453d646">+39/-80</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_config_flow.py</strong><dd><code>Update tests to mock GooglePollenApiClient and exception handling</code></dd></summary>
<hr>

tests/test_config_flow.py

<ul><li>Added stubs for homeassistant.exceptions.ConfigEntryAuthFailed and <br>homeassistant.helpers.update_coordinator.UpdateFailed<br> <li> Added stubs for homeassistant.util and homeassistant.util.dt modules <br>with parse_http_date and utcnow functions<br> <li> Replaced _patch_client_session() helper with _patch_client_fetch() <br>that mocks GooglePollenApiClient.async_fetch_pollen_data()<br> <li> Updated all test cases to use exception-based error injection instead <br>of HTTP status code responses<br> <li> Refactored test assertions to verify calls to the mocked <br>async_fetch_pollen_data method</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/77/files#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667">+153/-59</a></td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 1.9.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry for version 1.9.5 with release date 2026-02-27<br> <li> Documented GitHub Actions artifact upload bump to <br>actions/upload-artifact@v7<br> <li> Documented reuse of GooglePollenApiClient for config-flow validation <br>with consistent error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/77/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Bump manifest version to 1.9.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pollenlevels/manifest.json

- Bumped version from 1.9.4 to 1.9.5


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/77/files#diff-c669441e47d06d4aaed40b66e7e0b60fead7fc8092057d212dcf08b4bcf92d6a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump pyproject version to 1.9.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 1.9.4 to 1.9.5


</details>


  </td>
  <td><a href="https://github.com/eXPerience83/pollenlevels/pull/77/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

