### PR TITLE
Add reconfigure flow and translations; add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.9.6] - 2026-04-06
+### Changed
+- Refactored config-flow API key confirmation handling to reuse a shared helper
+  across re-authentication and reconfiguration steps, reducing duplication
+  while preserving existing behavior.
+- Localized reconfiguration step labels/descriptions and success/failure abort
+  messages across bundled translations.
+
 ## [1.9.5] - 2026-03-02
 ### Changed
 - Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
 
+### Fixed
+- Prevented the reconfigure flow from writing option-owned fields back into
+  config-entry data when saving a refreshed API key.
+
 ## [1.9.5] - 2026-03-02
 ### Changed
 - Bumped GitHub Actions artifact upload to `actions/upload-artifact@v7`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 - Refactored config-flow API key confirmation handling to reuse a shared helper
   across re-authentication and reconfiguration steps, reducing duplication
   while preserving existing behavior.
+- Aligned re-authentication/reconfiguration flow handling with Home Assistant's
+  helper-based entry APIs (`_get_*_entry` and update/reload/abort helper path).
+- Normalized the reconfigure step signature/shape to match current Home
+  Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields
   back into config-entry data when saving a refreshed API key.
+- Preserved the API-key-only data refresh behavior while migrating reauth and
+  reconfigure confirmations to the helper-based update path.
 
 ## [1.9.5] - 2026-03-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   messages across bundled translations.
 
 ### Fixed
-- Prevented the reconfigure flow from writing option-owned fields back into
-  config-entry data when saving a refreshed API key.
+- Prevented both reconfigure and re-auth flows from writing option-owned fields
+  back into config-entry data when saving a refreshed API key.
 
 ## [1.9.5] - 2026-03-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@
   Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
-- Simplified the reconfigure flow to a single `reconfigure` step while keeping
-  the helper-based update/reload/abort path and API-key-only data refresh
-  behavior unchanged.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.9.7] - 2026-04-08
+### Changed
+- Aligned re-authentication/reconfiguration handling with Home Assistant's
+  helper-based entry APIs (`_get_*_entry` and update/reload/abort helper path).
+- Simplified reconfigure to a single real `reconfigure` config-flow step while
+  preserving the existing helper-based update path.
+- Moved reconfigure form translations from `config.step.reconfigure_confirm` to
+  `config.step.reconfigure` across bundled locales.
+
+### Fixed
+- Preserved API-key-only refresh behavior during re-authentication and
+  reconfiguration updates so option-owned fields are not reintroduced into
+  config-entry data.
+
 ## [1.9.6] - 2026-04-06
 ### Changed
 - Refactored config-flow API key confirmation handling to reuse a shared helper
@@ -9,6 +23,9 @@
   Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
+- Simplified the reconfigure flow to a single `reconfigure` step while keeping
+  the helper-based update/reload/abort path and API-key-only data refresh
+  behavior unchanged.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -284,6 +284,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow state."""
         self._reauth_entry: config_entries.ConfigEntry | None = None
+        self._reconfigure_entry: config_entries.ConfigEntry | None = None
 
     @staticmethod
     def async_get_options_flow(entry: config_entries.ConfigEntry):
@@ -549,6 +550,61 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders=placeholders,
+        )
+
+    async def async_step_reconfigure(self, entry_data: dict[str, Any]):
+        """Handle a user-initiated reconfigure request."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return self.async_abort(reason="reconfigure_failed")
+
+        self._reconfigure_entry = entry
+        return await self.async_step_reconfigure_confirm()
+
+    async def async_step_reconfigure_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ):
+        """Prompt for a refreshed API key from the reconfigure UI."""
+        assert self._reconfigure_entry is not None
+
+        errors: dict[str, str] = {}
+        placeholders = {
+            "latitude": f"{self._reconfigure_entry.data.get(CONF_LATITUDE)}",
+            "longitude": f"{self._reconfigure_entry.data.get(CONF_LONGITUDE)}",
+            "api_key_url": POLLEN_API_KEY_URL,
+            "restricting_api_keys_url": RESTRICTING_API_KEYS_URL,
+        }
+
+        if user_input:
+            combined: dict[str, Any] = {**self._reconfigure_entry.data, **user_input}
+            errors, normalized = await self._async_validate_input(
+                combined,
+                check_unique_id=False,
+                description_placeholders=placeholders,
+            )
+            if not errors and normalized is not None:
+                self.hass.config_entries.async_update_entry(
+                    self._reconfigure_entry, data=normalized
+                )
+                await self.hass.config_entries.async_reload(
+                    self._reconfigure_entry.entry_id
+                )
+                return self.async_abort(reason="reconfigure_successful")
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_API_KEY,
+                    default="",
+                ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure_confirm",
             data_schema=schema,
             errors=errors,
             description_placeholders=placeholders,

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -571,19 +571,13 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
-        """Handle a user-initiated reconfigure request."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ):
         """Prompt for a refreshed API key from the reconfigure UI."""
         entry = self._get_reconfigure_entry()
         if entry is None:
             return self.async_abort(reason="reconfigure_failed")
         return await self._async_handle_api_key_confirm(
             entry=entry,
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             success_reason="reconfigure_successful",
             user_input=user_input,
             persist_normalized_data=False,

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -520,6 +520,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         step_id: str,
         success_reason: str,
         user_input: dict[str, Any] | None,
+        persist_normalized_data: bool = True,
     ):
         """Render/process an API-key confirmation step for an existing entry."""
         errors: dict[str, str] = {}
@@ -538,7 +539,14 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders=placeholders,
             )
             if not errors and normalized is not None:
-                self.hass.config_entries.async_update_entry(entry, data=normalized)
+                if persist_normalized_data:
+                    new_data = normalized
+                else:
+                    new_data = {
+                        **entry.data,
+                        CONF_API_KEY: str(normalized.get(CONF_API_KEY, "")).strip(),
+                    }
+                self.hass.config_entries.async_update_entry(entry, data=new_data)
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_abort(reason=success_reason)
 
@@ -587,6 +595,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_confirm",
             success_reason="reconfigure_successful",
             user_input=user_input,
+            persist_normalized_data=False,
         )
 
 

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -513,31 +513,34 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._reauth_entry = entry
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
-        """Prompt for a refreshed API key and validate it."""
-        assert self._reauth_entry is not None
-
+    async def _async_handle_api_key_confirm(
+        self,
+        *,
+        entry: config_entries.ConfigEntry,
+        step_id: str,
+        success_reason: str,
+        user_input: dict[str, Any] | None,
+    ):
+        """Render/process an API-key confirmation step for an existing entry."""
         errors: dict[str, str] = {}
         placeholders = {
-            "latitude": f"{self._reauth_entry.data.get(CONF_LATITUDE)}",
-            "longitude": f"{self._reauth_entry.data.get(CONF_LONGITUDE)}",
+            "latitude": f"{entry.data.get(CONF_LATITUDE)}",
+            "longitude": f"{entry.data.get(CONF_LONGITUDE)}",
             "api_key_url": POLLEN_API_KEY_URL,
             "restricting_api_keys_url": RESTRICTING_API_KEYS_URL,
         }
 
         if user_input:
-            combined: dict[str, Any] = {**self._reauth_entry.data, **user_input}
+            combined: dict[str, Any] = {**entry.data, **user_input}
             errors, normalized = await self._async_validate_input(
                 combined,
                 check_unique_id=False,
                 description_placeholders=placeholders,
             )
             if not errors and normalized is not None:
-                self.hass.config_entries.async_update_entry(
-                    self._reauth_entry, data=normalized
-                )
-                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
+                self.hass.config_entries.async_update_entry(entry, data=normalized)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason=success_reason)
 
         schema = vol.Schema(
             {
@@ -549,10 +552,20 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(
-            step_id="reauth_confirm",
+            step_id=step_id,
             data_schema=schema,
             errors=errors,
             description_placeholders=placeholders,
+        )
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+        """Prompt for a refreshed API key and validate it."""
+        assert self._reauth_entry is not None
+        return await self._async_handle_api_key_confirm(
+            entry=self._reauth_entry,
+            step_id="reauth_confirm",
+            success_reason="reauth_successful",
+            user_input=user_input,
         )
 
     async def async_step_reconfigure(self, entry_data: dict[str, Any]):
@@ -569,45 +582,11 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ):
         """Prompt for a refreshed API key from the reconfigure UI."""
         assert self._reconfigure_entry is not None
-
-        errors: dict[str, str] = {}
-        placeholders = {
-            "latitude": f"{self._reconfigure_entry.data.get(CONF_LATITUDE)}",
-            "longitude": f"{self._reconfigure_entry.data.get(CONF_LONGITUDE)}",
-            "api_key_url": POLLEN_API_KEY_URL,
-            "restricting_api_keys_url": RESTRICTING_API_KEYS_URL,
-        }
-
-        if user_input:
-            combined: dict[str, Any] = {**self._reconfigure_entry.data, **user_input}
-            errors, normalized = await self._async_validate_input(
-                combined,
-                check_unique_id=False,
-                description_placeholders=placeholders,
-            )
-            if not errors and normalized is not None:
-                self.hass.config_entries.async_update_entry(
-                    self._reconfigure_entry, data=normalized
-                )
-                await self.hass.config_entries.async_reload(
-                    self._reconfigure_entry.entry_id
-                )
-                return self.async_abort(reason="reconfigure_successful")
-
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_API_KEY,
-                    default="",
-                ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
-            }
-        )
-
-        return self.async_show_form(
+        return await self._async_handle_api_key_confirm(
+            entry=self._reconfigure_entry,
             step_id="reconfigure_confirm",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders=placeholders,
+            success_reason="reconfigure_successful",
+            user_input=user_input,
         )
 
 

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -574,6 +574,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             success_reason="reauth_successful",
             user_input=user_input,
+            persist_normalized_data=False,
         )
 
     async def async_step_reconfigure(self, entry_data: dict[str, Any]):

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -281,11 +281,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 3
 
-    def __init__(self) -> None:
-        """Initialize the config flow state."""
-        self._reauth_entry: config_entries.ConfigEntry | None = None
-        self._reconfigure_entry: config_entries.ConfigEntry | None = None
-
     @staticmethod
     def async_get_options_flow(entry: config_entries.ConfigEntry):
         """Return the options flow handler."""
@@ -506,11 +501,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: dict[str, Any]):
         """Handle re-authentication when credentials become invalid."""
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-        if entry is None:
-            return self.async_abort(reason="reauth_failed")
-
-        self._reauth_entry = entry
         return await self.async_step_reauth_confirm()
 
     async def _async_handle_api_key_confirm(
@@ -540,15 +530,16 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             if not errors and normalized is not None:
                 if persist_normalized_data:
-                    new_data = normalized
+                    data_updates = normalized
                 else:
-                    new_data = {
-                        **entry.data,
+                    data_updates = {
                         CONF_API_KEY: str(normalized.get(CONF_API_KEY, "")).strip(),
                     }
-                self.hass.config_entries.async_update_entry(entry, data=new_data)
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason=success_reason)
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=data_updates,
+                    reason=success_reason,
+                )
 
         schema = vol.Schema(
             {
@@ -568,31 +559,30 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
         """Prompt for a refreshed API key and validate it."""
-        assert self._reauth_entry is not None
+        entry = self._get_reauth_entry()
+        if entry is None:
+            return self.async_abort(reason="reauth_failed")
         return await self._async_handle_api_key_confirm(
-            entry=self._reauth_entry,
+            entry=entry,
             step_id="reauth_confirm",
             success_reason="reauth_successful",
             user_input=user_input,
             persist_normalized_data=False,
         )
 
-    async def async_step_reconfigure(self, entry_data: dict[str, Any]):
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
         """Handle a user-initiated reconfigure request."""
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-        if entry is None:
-            return self.async_abort(reason="reconfigure_failed")
-
-        self._reconfigure_entry = entry
         return await self.async_step_reconfigure_confirm()
 
     async def async_step_reconfigure_confirm(
         self, user_input: dict[str, Any] | None = None
     ):
         """Prompt for a refreshed API key from the reconfigure UI."""
-        assert self._reconfigure_entry is not None
+        entry = self._get_reconfigure_entry()
+        if entry is None:
+            return self.async_abort(reason="reconfigure_failed")
         return await self._async_handle_api_key_confirm(
-            entry=self._reconfigure_entry,
+            entry=entry,
             step_id="reconfigure_confirm",
             success_reason="reconfigure_successful",
             user_input=user_input,

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.5"
+    "version": "1.9.6"
 }

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.6"
+    "version": "1.9.7"
 }

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -21,7 +21,7 @@
           "api_key": "Clau API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigura Nivells de Pol·len",
         "description": "Actualitza la clau API per a {latitude},{longitude}. En pots generar una a [la documentació de claus API de Google]({api_key_url}) i revisar [les restriccions de claus API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Clau API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigura Nivells de Pol·len",
+        "description": "Actualitza la clau API per a {latitude},{longitude}. En pots generar una a [la documentació de claus API de Google]({api_key_url}) i revisar [les restriccions de claus API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Clau API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Aquesta ubicació ja està configurada.",
       "reauth_successful": "La reautenticació s'ha completat correctament.",
-      "reauth_failed": "La reautenticació ha fallat. Torna-ho a provar."
+      "reauth_failed": "La reautenticació ha fallat. Torna-ho a provar.",
+      "reconfigure_successful": "La reconfiguració s'ha completat correctament.",
+      "reconfigure_failed": "La reconfiguració ha fallat. Torna-ho a provar."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Klíč API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Překonfigurovat Pylové hladiny",
+        "description": "Aktualizujte klíč API pro {latitude},{longitude}. Můžete ho vytvořit v [dokumentaci klíčů API Google]({api_key_url}) a projít [omezení klíčů API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API klíč"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Toto umístění je již nakonfigurováno.",
       "reauth_successful": "Opětovné ověření proběhlo úspěšně.",
-      "reauth_failed": "Opětovné ověření se nezdařilo. Zkuste to znovu."
+      "reauth_failed": "Opětovné ověření se nezdařilo. Zkuste to znovu.",
+      "reconfigure_successful": "Překonfigurování bylo úspěšně dokončeno.",
+      "reconfigure_failed": "Překonfigurování selhalo. Zkuste to prosím znovu."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -21,7 +21,7 @@
           "api_key": "Klíč API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Překonfigurovat Pylové hladiny",
         "description": "Aktualizujte klíč API pro {latitude},{longitude}. Můžete ho vytvořit v [dokumentaci klíčů API Google]({api_key_url}) a projít [omezení klíčů API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -21,7 +21,7 @@
           "api_key": "API-nøgle"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Omkonfigurer Pollen Levels",
         "description": "Opdater API-nøglen for {latitude},{longitude}. Du kan oprette en i [Google API-nøgle-dokumentationen]({api_key_url}) og gennemgå [begrænsninger for API-nøgler]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-nøgle"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Omkonfigurer Pollen Levels",
+        "description": "Opdater API-nøglen for {latitude},{longitude}. Du kan oprette en i [Google API-nøgle-dokumentationen]({api_key_url}) og gennemgå [begrænsninger for API-nøgler]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-nøgle"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Denne placering er allerede konfigureret.",
       "reauth_successful": "Genautentificering fuldført.",
-      "reauth_failed": "Genautentificering mislykkedes. Prøv igen."
+      "reauth_failed": "Genautentificering mislykkedes. Prøv igen.",
+      "reconfigure_successful": "Omkonfiguration blev fuldført.",
+      "reconfigure_failed": "Omkonfiguration mislykkedes. Prøv igen."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -21,7 +21,7 @@
           "api_key": "API-Schlüssel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenwerte neu konfigurieren",
         "description": "Aktualisieren Sie den API-Schlüssel für {latitude},{longitude}. Sie können einen in der [Google-API-Schlüssel-Dokumentation]({api_key_url}) erstellen und [API-Schlüssel-Beschränkungen]({restricting_api_keys_url}) prüfen.",
         "data": {

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-Schlüssel"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Pollenwerte neu konfigurieren",
+        "description": "Aktualisieren Sie den API-Schlüssel für {latitude},{longitude}. Sie können einen in der [Google-API-Schlüssel-Dokumentation]({api_key_url}) erstellen und [API-Schlüssel-Beschränkungen]({restricting_api_keys_url}) prüfen.",
+        "data": {
+          "api_key": "API-Schlüssel"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Dieser Standort ist bereits konfiguriert.",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich.",
-      "reauth_failed": "Die erneute Authentifizierung ist fehlgeschlagen. Bitte versuche es erneut."
+      "reauth_failed": "Die erneute Authentifizierung ist fehlgeschlagen. Bitte versuche es erneut.",
+      "reconfigure_successful": "Die Neukonfiguration wurde erfolgreich abgeschlossen.",
+      "reconfigure_failed": "Die Neukonfiguration ist fehlgeschlagen. Bitte versuchen Sie es erneut."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API Key"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigure Pollen Levels",
+        "description": "Update the API key for {latitude},{longitude}. You can generate one at [Google API key docs]({api_key_url}) and review [API key restrictions]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API Key"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "This location is already configured.",
       "reauth_successful": "Re-authentication completed successfully.",
-      "reauth_failed": "Re-authentication failed. Please try again."
+      "reauth_failed": "Re-authentication failed. Please try again.",
+      "reconfigure_successful": "Reconfiguration completed successfully.",
+      "reconfigure_failed": "Reconfiguration failed. Please try again."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -21,7 +21,7 @@
           "api_key": "API Key"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure Pollen Levels",
         "description": "Update the API key for {latitude},{longitude}. You can generate one at [Google API key docs]({api_key_url}) and review [API key restrictions]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -21,7 +21,7 @@
           "api_key": "Clave API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Niveles de Polen",
         "description": "Actualiza la clave API para {latitude},{longitude}. Puedes generar una en [la documentación de claves API de Google]({api_key_url}) y revisar [las restricciones de claves API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Clave API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigurar Niveles de Polen",
+        "description": "Actualiza la clave API para {latitude},{longitude}. Puedes generar una en [la documentación de claves API de Google]({api_key_url}) y revisar [las restricciones de claves API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Clave API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Esta ubicación ya está configurada.",
       "reauth_successful": "La reautenticación se completó correctamente.",
-      "reauth_failed": "La reautenticación falló. Inténtalo de nuevo."
+      "reauth_failed": "La reautenticación falló. Inténtalo de nuevo.",
+      "reconfigure_successful": "La reconfiguración se completó correctamente.",
+      "reconfigure_failed": "La reconfiguración falló. Inténtalo de nuevo."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-avain"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Määritä Pollenitasot uudelleen",
+        "description": "Päivitä API-avain sijainnille {latitude},{longitude}. Voit luoda avaimen [Googlen API-avainohjeesta]({api_key_url}) ja tarkistaa [API-avaimen rajoitukset]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-avain"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Tämä sijainti on jo määritetty.",
       "reauth_successful": "Uudelleentodennus onnistui.",
-      "reauth_failed": "Uudelleentodennus epäonnistui. Yritä uudelleen."
+      "reauth_failed": "Uudelleentodennus epäonnistui. Yritä uudelleen.",
+      "reconfigure_successful": "Uudelleenmääritys onnistui.",
+      "reconfigure_failed": "Uudelleenmääritys epäonnistui. Yritä uudelleen."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -21,7 +21,7 @@
           "api_key": "API-avain"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Määritä Pollenitasot uudelleen",
         "description": "Päivitä API-avain sijainnille {latitude},{longitude}. Voit luoda avaimen [Googlen API-avainohjeesta]({api_key_url}) ja tarkistaa [API-avaimen rajoitukset]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Clé API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigurer Niveaux de pollen",
+        "description": "Mettez à jour la clé API pour {latitude},{longitude}. Vous pouvez en générer une dans la [documentation des clés API Google]({api_key_url}) et consulter [les restrictions des clés API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Clé API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Cet emplacement est déjà configuré.",
       "reauth_successful": "La réauthentification a réussi.",
-      "reauth_failed": "La réauthentification a échoué. Veuillez réessayer."
+      "reauth_failed": "La réauthentification a échoué. Veuillez réessayer.",
+      "reconfigure_successful": "La reconfiguration est terminée avec succès.",
+      "reconfigure_failed": "Échec de la reconfiguration. Veuillez réessayer."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -21,7 +21,7 @@
           "api_key": "Clé API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurer Niveaux de pollen",
         "description": "Mettez à jour la clé API pour {latitude},{longitude}. Vous pouvez en générer une dans la [documentation des clés API Google]({api_key_url}) et consulter [les restrictions des clés API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -21,7 +21,7 @@
           "api_key": "API-kulcs"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenértékek újrakonfigurálása",
         "description": "Frissítse az API-kulcsot ehhez: {latitude},{longitude}. Új kulcsot a [Google API-kulcs dokumentációban]({api_key_url}) hozhat létre, és ellenőrizheti az [API-kulcs korlátozásokat]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-kulcs"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Pollenértékek újrakonfigurálása",
+        "description": "Frissítse az API-kulcsot ehhez: {latitude},{longitude}. Új kulcsot a [Google API-kulcs dokumentációban]({api_key_url}) hozhat létre, és ellenőrizheti az [API-kulcs korlátozásokat]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-kulcs"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Ez a hely már konfigurálva van.",
       "reauth_successful": "Az újrahitelesítés sikerült.",
-      "reauth_failed": "Az újrahitelesítés nem sikerült. Próbáld meg újra."
+      "reauth_failed": "Az újrahitelesítés nem sikerült. Próbáld meg újra.",
+      "reconfigure_successful": "Az újrakonfigurálás sikeresen befejeződött.",
+      "reconfigure_failed": "Az újrakonfigurálás sikertelen. Kérjük, próbálja újra."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -21,7 +21,7 @@
           "api_key": "Chiave API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Riconfigura Livelli Pollinici",
         "description": "Aggiorna la chiave API per {latitude},{longitude}. Puoi generarne una nella [documentazione delle chiavi API Google]({api_key_url}) e rivedere [le restrizioni delle chiavi API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Chiave API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Riconfigura Livelli Pollinici",
+        "description": "Aggiorna la chiave API per {latitude},{longitude}. Puoi generarne una nella [documentazione delle chiavi API Google]({api_key_url}) e rivedere [le restrizioni delle chiavi API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Chiave API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Questa posizione è già configurata.",
       "reauth_successful": "La ri-autenticazione è stata completata con successo.",
-      "reauth_failed": "La ri-autenticazione non è riuscita. Riprova."
+      "reauth_failed": "La ri-autenticazione non è riuscita. Riprova.",
+      "reconfigure_successful": "Riconfigurazione completata con successo.",
+      "reconfigure_failed": "Riconfigurazione non riuscita. Riprova."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -21,7 +21,7 @@
           "api_key": "API-nøkkel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurer Pollennivåer på nytt",
         "description": "Oppdater API-nøkkelen for {latitude},{longitude}. Du kan opprette en i [Google API-nøkkel-dokumentasjonen]({api_key_url}) og gjennomgå [API-nøkkelbegrensninger]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-nøkkel"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Konfigurer Pollennivåer på nytt",
+        "description": "Oppdater API-nøkkelen for {latitude},{longitude}. Du kan opprette en i [Google API-nøkkel-dokumentasjonen]({api_key_url}) og gjennomgå [API-nøkkelbegrensninger]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-nøkkel"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Dette stedet er allerede konfigurert.",
       "reauth_successful": "Ny autentisering fullført.",
-      "reauth_failed": "Ny autentisering mislyktes. Prøv igjen."
+      "reauth_failed": "Ny autentisering mislyktes. Prøv igjen.",
+      "reconfigure_successful": "Omkonfigurering fullført.",
+      "reconfigure_failed": "Omkonfigurering mislyktes. Prøv igjen."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -21,7 +21,7 @@
           "api_key": "API-sleutel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenwaarden opnieuw configureren",
         "description": "Werk de API-sleutel bij voor {latitude},{longitude}. Je kunt er een maken in de [Google API-sleutel-documentatie]({api_key_url}) en [API-sleutelbeperkingen]({restricting_api_keys_url}) bekijken.",
         "data": {

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-sleutel"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Pollenwaarden opnieuw configureren",
+        "description": "Werk de API-sleutel bij voor {latitude},{longitude}. Je kunt er een maken in de [Google API-sleutel-documentatie]({api_key_url}) en [API-sleutelbeperkingen]({restricting_api_keys_url}) bekijken.",
+        "data": {
+          "api_key": "API-sleutel"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Deze locatie is al geconfigureerd.",
       "reauth_successful": "Opnieuw autoriseren voltooid.",
-      "reauth_failed": "Opnieuw autoriseren is mislukt. Probeer het opnieuw."
+      "reauth_failed": "Opnieuw autoriseren is mislukt. Probeer het opnieuw.",
+      "reconfigure_successful": "Herconfiguratie is succesvol voltooid.",
+      "reconfigure_failed": "Herconfiguratie is mislukt. Probeer het opnieuw."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Klucz API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Skonfiguruj ponownie Poziomy pyłków",
+        "description": "Zaktualizuj klucz API dla {latitude},{longitude}. Możesz utworzyć go w [dokumentacji kluczy API Google]({api_key_url}) i sprawdzić [ograniczenia kluczy API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Klucz API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Ta lokalizacja jest już skonfigurowana.",
       "reauth_successful": "Ponowne uwierzytelnienie zakończone pomyślnie.",
-      "reauth_failed": "Ponowne uwierzytelnienie nie powiodło się. Spróbuj ponownie."
+      "reauth_failed": "Ponowne uwierzytelnienie nie powiodło się. Spróbuj ponownie.",
+      "reconfigure_successful": "Ponowna konfiguracja została zakończona pomyślnie.",
+      "reconfigure_failed": "Ponowna konfiguracja nie powiodła się. Spróbuj ponownie."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -21,7 +21,7 @@
           "api_key": "Klucz API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Skonfiguruj ponownie Poziomy pyłków",
         "description": "Zaktualizuj klucz API dla {latitude},{longitude}. Możesz utworzyć go w [dokumentacji kluczy API Google]({api_key_url}) i sprawdzić [ograniczenia kluczy API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Chave da API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigurar Níveis de Pólen",
+        "description": "Atualize a chave de API para {latitude},{longitude}. Você pode gerar uma na [documentação de chaves de API do Google]({api_key_url}) e revisar [as restrições de chave de API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Chave de API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Este local já está configurado.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
-      "reauth_failed": "A reautenticação falhou. Tente novamente."
+      "reauth_failed": "A reautenticação falhou. Tente novamente.",
+      "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",
+      "reconfigure_failed": "A reconfiguração falhou. Tente novamente."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -21,7 +21,7 @@
           "api_key": "Chave da API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Níveis de Pólen",
         "description": "Atualize a chave de API para {latitude},{longitude}. Você pode gerar uma na [documentação de chaves de API do Google]({api_key_url}) e revisar [as restrições de chave de API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Chave da API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigurar Níveis de Pólen",
+        "description": "Atualize a chave de API para {latitude},{longitude}. Pode gerar uma na [documentação de chaves de API da Google]({api_key_url}) e rever [as restrições de chave de API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Chave de API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Esta localização já está configurada.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
-      "reauth_failed": "A reautenticação falhou. Tente novamente."
+      "reauth_failed": "A reautenticação falhou. Tente novamente.",
+      "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",
+      "reconfigure_failed": "A reconfiguração falhou. Tente novamente."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -21,7 +21,7 @@
           "api_key": "Chave da API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Níveis de Pólen",
         "description": "Atualize a chave de API para {latitude},{longitude}. Pode gerar uma na [documentação de chaves de API da Google]({api_key_url}) e rever [as restrições de chave de API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -21,7 +21,7 @@
           "api_key": "Cheie API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurează Niveluri de polen",
         "description": "Actualizați cheia API pentru {latitude},{longitude}. Puteți genera una în [documentația cheilor API Google]({api_key_url}) și revizui [restricțiile cheilor API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Cheie API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Reconfigurează Niveluri de polen",
+        "description": "Actualizați cheia API pentru {latitude},{longitude}. Puteți genera una în [documentația cheilor API Google]({api_key_url}) și revizui [restricțiile cheilor API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "Cheie API"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Această locație este deja configurată.",
       "reauth_successful": "Reautentificarea s-a încheiat cu succes.",
-      "reauth_failed": "Reautentificarea a eșuat. Încercați din nou."
+      "reauth_failed": "Reautentificarea a eșuat. Încercați din nou.",
+      "reconfigure_successful": "Reconfigurarea s-a finalizat cu succes.",
+      "reconfigure_failed": "Reconfigurarea a eșuat. Încercați din nou."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -21,7 +21,7 @@
           "api_key": "Ключ API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Перенастроить Уровни пыльцы",
         "description": "Обновите API-ключ для {latitude},{longitude}. Вы можете создать его в [документации по API-ключам Google]({api_key_url}) и проверить [ограничения API-ключей]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Ключ API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Перенастроить Уровни пыльцы",
+        "description": "Обновите API-ключ для {latitude},{longitude}. Вы можете создать его в [документации по API-ключам Google]({api_key_url}) и проверить [ограничения API-ключей]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-ключ"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Это местоположение уже настроено.",
       "reauth_successful": "Повторная аутентификация выполнена успешно.",
-      "reauth_failed": "Повторная аутентификация не удалась. Повторите попытку."
+      "reauth_failed": "Повторная аутентификация не удалась. Повторите попытку.",
+      "reconfigure_successful": "Перенастройка успешно завершена.",
+      "reconfigure_failed": "Не удалось выполнить перенастройку. Повторите попытку."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -21,7 +21,7 @@
           "api_key": "API-nyckel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurera om Pollennivåer",
         "description": "Uppdatera API-nyckeln för {latitude},{longitude}. Du kan skapa en i [Google API-nyckeldokumentation]({api_key_url}) och granska [API-nyckelbegränsningar]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API-nyckel"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Konfigurera om Pollennivåer",
+        "description": "Uppdatera API-nyckeln för {latitude},{longitude}. Du kan skapa en i [Google API-nyckeldokumentation]({api_key_url}) och granska [API-nyckelbegränsningar]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-nyckel"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Den här platsen är redan konfigurerad.",
       "reauth_successful": "Återautentiseringen lyckades.",
-      "reauth_failed": "Återautentiseringen misslyckades. Försök igen."
+      "reauth_failed": "Återautentiseringen misslyckades. Försök igen.",
+      "reconfigure_successful": "Omkonfigureringen slutfördes.",
+      "reconfigure_failed": "Omkonfigureringen misslyckades. Försök igen."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -21,7 +21,7 @@
           "api_key": "Ключ API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Переналаштувати Рівні пилку",
         "description": "Оновіть API-ключ для {latitude},{longitude}. Ви можете створити його в [документації ключів API Google]({api_key_url}) та переглянути [обмеження ключів API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "Ключ API"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "Переналаштувати Рівні пилку",
+        "description": "Оновіть API-ключ для {latitude},{longitude}. Ви можете створити його в [документації ключів API Google]({api_key_url}) та переглянути [обмеження ключів API]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API-ключ"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "Це розташування вже налаштовано.",
       "reauth_successful": "Повторна автентифікація виконана успішно.",
-      "reauth_failed": "Повторна автентифікація не вдалася. Спробуйте ще раз."
+      "reauth_failed": "Повторна автентифікація не вдалася. Спробуйте ще раз.",
+      "reconfigure_successful": "Переналаштування успішно завершено.",
+      "reconfigure_failed": "Не вдалося виконати переналаштування. Спробуйте ще раз."
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API 密钥"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "重新配置花粉水平",
+        "description": "更新 {latitude},{longitude} 的 API 密钥。您可以在 [Google API 密钥文档]({api_key_url}) 生成，并查看 [API 密钥限制]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API 密钥"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "该位置已配置。",
       "reauth_successful": "重新验证已成功完成。",
-      "reauth_failed": "重新验证失败。请重试。"
+      "reauth_failed": "重新验证失败。请重试。",
+      "reconfigure_successful": "重新配置已成功完成。",
+      "reconfigure_failed": "重新配置失败。请重试。"
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -21,7 +21,7 @@
           "api_key": "API 密钥"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "重新配置花粉水平",
         "description": "更新 {latitude},{longitude} 的 API 密钥。您可以在 [Google API 密钥文档]({api_key_url}) 生成，并查看 [API 密钥限制]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -20,6 +20,13 @@
         "data": {
           "api_key": "API 金鑰"
         }
+      },
+      "reconfigure_confirm": {
+        "title": "重新設定花粉水平",
+        "description": "更新 {latitude},{longitude} 的 API 金鑰。您可以在 [Google API 金鑰文件]({api_key_url}) 產生，並檢視 [API 金鑰限制]({restricting_api_keys_url}).",
+        "data": {
+          "api_key": "API 金鑰"
+        }
       }
     },
     "error": {
@@ -37,7 +44,9 @@
     "abort": {
       "already_configured": "此位置已設定。",
       "reauth_successful": "重新驗證已成功完成。",
-      "reauth_failed": "重新驗證失敗。請再試一次。"
+      "reauth_failed": "重新驗證失敗。請再試一次。",
+      "reconfigure_successful": "重新設定已成功完成。",
+      "reconfigure_failed": "重新設定失敗。請再試一次。"
     }
   },
   "options": {

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -21,7 +21,7 @@
           "api_key": "API 金鑰"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "重新設定花粉水平",
         "description": "更新 {latitude},{longitude} 的 API 金鑰。您可以在 [Google API 金鑰文件]({api_key_url}) 產生，並檢視 [API 金鑰限制]({restricting_api_keys_url}).",
         "data": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.5"
+version = "1.9.6"
 # Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.6"
+version = "1.9.7"
 # Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -802,6 +802,55 @@ def test_reauth_confirm_schema_masks_api_key_and_uses_blank_default(
     assert api_selector.config.type == cf.TextSelectorType.PASSWORD
 
 
+def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reconfigure form should mask API key input and avoid prefilling secrets."""
+
+    captured_default: dict[str, object] = {}
+    orig_required = cf.vol.Required
+
+    def _capture_required(key, **kwargs):
+        if key == CONF_API_KEY:
+            captured_default["api_key"] = kwargs.get("default")
+        return orig_required(key, **kwargs)
+
+    monkeypatch.setattr(cf.vol, "Required", _capture_required)
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 1.0,
+            CONF_LONGITUDE: 2.0,
+        },
+        entry_id="entry-id",
+    )
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=SimpleNamespace())
+    flow.context = {"entry_id": "entry-id"}
+    flow._reconfigure_entry = entry
+
+    captured: dict[str, object] = {}
+
+    def _capture_show_form(*, step_id=None, data_schema=None, **kwargs):
+        captured["step_id"] = step_id
+        captured["schema"] = data_schema
+        return {"step_id": step_id}
+
+    flow.async_show_form = _capture_show_form  # type: ignore[method-assign]
+
+    result = asyncio.run(flow.async_step_reconfigure_confirm())
+
+    assert result == {"step_id": "reconfigure_confirm"}
+    assert captured_default["api_key"] == ""
+    schema = captured["schema"]
+    assert hasattr(schema, "schema")
+    api_selector = schema.schema[CONF_API_KEY]
+    assert isinstance(api_selector, cf.TextSelector)
+    assert api_selector.config.type == cf.TextSelectorType.PASSWORD
+
+
 def test_validate_input_update_interval_below_min_sets_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1586,6 +1635,64 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     result = asyncio.run(run_flow())
 
     assert result == {"type": "abort", "reason": "reauth_successful"}
+    assert recorder.updated == (entry, normalized)
+    assert recorder.reloaded == "entry-id"
+
+
+def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
+    """Reconfigure confirmation should update stored credentials and reload entry."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 1.0,
+            CONF_LONGITUDE: 2.0,
+            CONF_LANGUAGE_CODE: "en",
+        },
+        entry_id="entry-id",
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.updated = None
+            self.reloaded = None
+
+        def async_get_entry(self, entry_id: str):
+            return entry if entry_id == entry.entry_id else None
+
+        def async_update_entry(self, entry_to_update, *, data):
+            self.updated = (entry_to_update, data)
+
+        async def async_reload(self, entry_id: str):
+            self.reloaded = entry_id
+
+    recorder = _Recorder()
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=recorder)
+    flow.context = {"entry_id": "entry-id"}
+
+    normalized = {
+        CONF_API_KEY: "new-key",
+        CONF_LATITUDE: 1.0,
+        CONF_LONGITUDE: 2.0,
+        CONF_LANGUAGE_CODE: "en",
+    }
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    async def run_flow():
+        await flow.async_step_reconfigure(entry.data)
+        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+
+    result = asyncio.run(run_flow())
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
     assert recorder.updated == (entry, normalized)
     assert recorder.reloaded == "entry-id"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -820,7 +820,7 @@ def test_reauth_confirm_schema_masks_api_key_and_uses_blank_default(
     assert api_selector.config.type == cf.TextSelectorType.PASSWORD
 
 
-def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
+def test_reconfigure_schema_masks_api_key_and_uses_blank_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reconfigure form should mask API key input and avoid prefilling secrets."""
@@ -858,9 +858,9 @@ def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
 
     flow.async_show_form = _capture_show_form  # type: ignore[method-assign]
 
-    result = asyncio.run(flow.async_step_reconfigure_confirm())
+    result = asyncio.run(flow.async_step_reconfigure())
 
-    assert result == {"step_id": "reconfigure_confirm"}
+    assert result == {"step_id": "reconfigure"}
     assert captured_default["api_key"] == ""
     schema = captured["schema"]
     assert hasattr(schema, "schema")
@@ -1723,7 +1723,7 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
 
 
-def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
+def test_reconfigure_updates_existing_entry_and_reloads() -> None:
     """Reconfigure confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
@@ -1774,8 +1774,8 @@ def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
 
     async def run_flow():
         first = await flow.async_step_reconfigure()
-        assert first == {"step_id": "reconfigure_confirm"}
-        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+        assert first == {"step_id": "reconfigure"}
+        return await flow.async_step_reconfigure({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 
@@ -1791,7 +1791,7 @@ def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
     assert created["called"] is False
 
 
-def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> None:
+def test_reconfigure_does_not_reintroduce_option_fields_in_data() -> None:
     """Reconfigure should only update API key in data, preserving option boundaries."""
 
     entry = cf.config_entries.ConfigEntry(
@@ -1849,8 +1849,8 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
 
     async def run_flow():
         first = await flow.async_step_reconfigure()
-        assert first == {"step_id": "reconfigure_confirm"}
-        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+        assert first == {"step_id": "reconfigure"}
+        return await flow.async_step_reconfigure({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -71,6 +71,24 @@ class _StubConfigFlow:
     def add_suggested_values_to_schema(self, schema, suggested_values):
         return schema
 
+    def _get_reauth_entry(self):
+        entry_id = self.context.get("entry_id")
+        return self.hass.config_entries.async_get_entry(entry_id)
+
+    def _get_reconfigure_entry(self):
+        entry_id = self.context.get("entry_id")
+        return self.hass.config_entries.async_get_entry(entry_id)
+
+    def async_update_reload_and_abort(
+        self, entry, *, data_updates=None, reason=None, **kwargs
+    ):
+        new_data = dict(entry.data)
+        if data_updates:
+            new_data.update(data_updates)
+        self.hass.config_entries.async_update_entry(entry, data=new_data)
+        self.hass.config_entries.async_reload(entry.entry_id)
+        return self.async_abort(reason=reason)
+
 
 class _StubOptionsFlow:
     pass
@@ -780,7 +798,7 @@ def test_reauth_confirm_schema_masks_api_key_and_uses_blank_default(
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=SimpleNamespace())
     flow.context = {"entry_id": "entry-id"}
-    flow._reauth_entry = entry
+    flow._get_reauth_entry = lambda: entry  # type: ignore[method-assign]
 
     captured: dict[str, object] = {}
 
@@ -829,7 +847,7 @@ def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=SimpleNamespace())
     flow.context = {"entry_id": "entry-id"}
-    flow._reconfigure_entry = entry
+    flow._get_reconfigure_entry = lambda: entry  # type: ignore[method-assign]
 
     captured: dict[str, object] = {}
 
@@ -1581,8 +1599,8 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
     assert flow.unique_ids[0] == flow.unique_ids[1] == "1.0000_2.0000"
 
 
-def test_reauth_confirm_updates_and_reloads_entry() -> None:
-    """Re-auth confirmation should update stored credentials and reload the entry."""
+def test_reauth_confirm_updates_existing_entry_and_reloads() -> None:
+    """Re-auth confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
         data={
@@ -1605,7 +1623,7 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             self.reloaded = entry_id
 
     recorder = _Recorder()
@@ -1614,12 +1632,7 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
 
-    normalized = {
-        CONF_API_KEY: "new-key",
-        CONF_LATITUDE: 1.0,
-        CONF_LONGITUDE: 2.0,
-        CONF_LANGUAGE_CODE: "en",
-    }
+    normalized = {**entry.data, CONF_API_KEY: "new-key", CONF_FORECAST_DAYS: 3}
 
     async def fake_validate(
         user_input, *, check_unique_id, description_placeholders=None
@@ -1635,7 +1648,13 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     result = asyncio.run(run_flow())
 
     assert result == {"type": "abort", "reason": "reauth_successful"}
-    assert recorder.updated == (entry, normalized)
+    assert recorder.updated == (
+        entry,
+        {
+            **entry.data,
+            CONF_API_KEY: "new-key",
+        },
+    )
     assert recorder.reloaded == "entry-id"
 
 
@@ -1665,7 +1684,7 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             return None
 
     recorder = _Recorder()
@@ -1704,8 +1723,8 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
 
 
-def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
-    """Reconfigure confirmation should update stored credentials and reload entry."""
+def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
+    """Reconfigure confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
         data={
@@ -1728,7 +1747,7 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             self.reloaded = entry_id
 
     recorder = _Recorder()
@@ -1736,13 +1755,15 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
+    created: dict[str, bool] = {"called": False}
 
-    normalized = {
-        CONF_API_KEY: "new-key",
-        CONF_LATITUDE: 1.0,
-        CONF_LONGITUDE: 2.0,
-        CONF_LANGUAGE_CODE: "en",
-    }
+    def _capture_create_entry(*args, **kwargs):
+        created["called"] = True
+        return {"type": "create_entry"}
+
+    flow.async_create_entry = _capture_create_entry  # type: ignore[method-assign]
+
+    normalized = {**entry.data, CONF_API_KEY: "new-key", CONF_UPDATE_INTERVAL: 12}
 
     async def fake_validate(
         user_input, *, check_unique_id, description_placeholders=None
@@ -1752,14 +1773,22 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     flow._async_validate_input = fake_validate  # type: ignore[assignment]
 
     async def run_flow():
-        await flow.async_step_reconfigure(entry.data)
+        first = await flow.async_step_reconfigure()
+        assert first == {"step_id": "reconfigure_confirm"}
         return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 
     assert result == {"type": "abort", "reason": "reconfigure_successful"}
-    assert recorder.updated == (entry, normalized)
+    assert recorder.updated == (
+        entry,
+        {
+            **entry.data,
+            CONF_API_KEY: "new-key",
+        },
+    )
     assert recorder.reloaded == "entry-id"
+    assert created["called"] is False
 
 
 def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> None:
@@ -1788,7 +1817,7 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             return None
 
     recorder = _Recorder()
@@ -1796,6 +1825,13 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
+    created: dict[str, bool] = {"called": False}
+
+    def _capture_create_entry(*args, **kwargs):
+        created["called"] = True
+        return {"type": "create_entry"}
+
+    flow.async_create_entry = _capture_create_entry  # type: ignore[method-assign]
 
     # Validation may normalize and include option-backed fields.
     normalized = {
@@ -1812,7 +1848,8 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     flow._async_validate_input = fake_validate  # type: ignore[assignment]
 
     async def run_flow():
-        await flow.async_step_reconfigure(entry.data)
+        first = await flow.async_step_reconfigure()
+        assert first == {"step_id": "reconfigure_confirm"}
         return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
@@ -1823,6 +1860,7 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     assert updated_entry is entry
     assert updated_data[CONF_API_KEY] == "new-key"
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
+    assert created["called"] is False
 
 
 def test_async_step_user_uses_custom_entry_name() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1639,6 +1639,71 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     assert recorder.reloaded == "entry-id"
 
 
+def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
+    """Reauth should only update API key in data, preserving option boundaries."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 1.0,
+            CONF_LONGITUDE: 2.0,
+            CONF_LANGUAGE_CODE: "en",
+            CONF_UPDATE_INTERVAL: 6,
+            # Intentionally no CONF_FORECAST_DAYS in data.
+        },
+        options={CONF_FORECAST_DAYS: 5, CONF_CREATE_FORECAST_SENSORS: "D+1"},
+        entry_id="entry-id",
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.updated = None
+
+        def async_get_entry(self, entry_id: str):
+            return entry if entry_id == entry.entry_id else None
+
+        def async_update_entry(self, entry_to_update, *, data):
+            self.updated = (entry_to_update, data)
+
+        async def async_reload(self, entry_id: str):
+            return None
+
+    recorder = _Recorder()
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=recorder)
+    flow.context = {"entry_id": "entry-id"}
+
+    # Validation may normalize and include option-backed fields.
+    normalized = {
+        **entry.data,
+        CONF_API_KEY: "new-key",
+        CONF_FORECAST_DAYS: 2,
+        CONF_CREATE_FORECAST_SENSORS: "none",
+    }
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    async def run_flow():
+        await flow.async_step_reauth(entry.data)
+        return await flow.async_step_reauth_confirm({CONF_API_KEY: "new-key"})
+
+    result = asyncio.run(run_flow())
+
+    assert result == {"type": "abort", "reason": "reauth_successful"}
+    assert recorder.updated is not None
+    updated_entry, updated_data = recorder.updated
+    assert updated_entry is entry
+    assert updated_data[CONF_API_KEY] == "new-key"
+    assert CONF_FORECAST_DAYS not in updated_data
+    assert CONF_CREATE_FORECAST_SENSORS not in updated_data
+
+
 def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     """Reconfigure confirmation should update stored credentials and reload entry."""
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1697,6 +1697,69 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     assert recorder.reloaded == "entry-id"
 
 
+def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> None:
+    """Reconfigure should only update API key in data, preserving option boundaries."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 1.0,
+            CONF_LONGITUDE: 2.0,
+            CONF_LANGUAGE_CODE: "en",
+            CONF_UPDATE_INTERVAL: 6,
+            # Intentionally no CONF_CREATE_FORECAST_SENSORS in data.
+        },
+        options={CONF_CREATE_FORECAST_SENSORS: "D+1"},
+        entry_id="entry-id",
+    )
+
+    class _Recorder:
+        def __init__(self) -> None:
+            self.updated = None
+
+        def async_get_entry(self, entry_id: str):
+            return entry if entry_id == entry.entry_id else None
+
+        def async_update_entry(self, entry_to_update, *, data):
+            self.updated = (entry_to_update, data)
+
+        async def async_reload(self, entry_id: str):
+            return None
+
+    recorder = _Recorder()
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=recorder)
+    flow.context = {"entry_id": "entry-id"}
+
+    # Validation may normalize and include option-backed fields.
+    normalized = {
+        **entry.data,
+        CONF_API_KEY: "new-key",
+        CONF_CREATE_FORECAST_SENSORS: "none",
+    }
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    async def run_flow():
+        await flow.async_step_reconfigure(entry.data)
+        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+
+    result = asyncio.run(run_flow())
+
+    assert result == {"type": "abort", "reason": "reconfigure_successful"}
+    assert recorder.updated is not None
+    updated_entry, updated_data = recorder.updated
+    assert updated_entry is entry
+    assert updated_data[CONF_API_KEY] == "new-key"
+    assert CONF_CREATE_FORECAST_SENSORS not in updated_data
+
+
 def test_async_step_user_uses_custom_entry_name() -> None:
     """Config flow should honor a custom entry title provided by the user."""
 


### PR DESCRIPTION
### Motivation

- Provide a user-initiated reconfigure path to allow updating an API key without full reauth or recreating the config entry.
- Surface localized UI strings for the new reconfigure step and abort reasons across supported languages.

### Description

- Add a `_reconfigure_entry` attribute and implement `async_step_reconfigure` and `async_step_reconfigure_confirm` in `PollenLevelsConfigFlow` to prompt for and validate a refreshed API key and reload the entry via `async_reload` on success.
- Reuse existing validation via `_async_validate_input` with `check_unique_id=False` and show a masked `TextSelector` password field for API key input in the `reconfigure_confirm` form.
- Update translation files to add `reconfigure_confirm` UI strings and new abort reasons `reconfigure_successful` and `reconfigure_failed` for all bundled locales.
- Add unit tests in `tests/test_config_flow.py` covering the `reconfigure_confirm` schema masking/default behavior and the update+reload behavior of the reconfigure flow.

### Testing

- Ran unit tests in `tests/test_config_flow.py`, including `test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default` and `test_reconfigure_confirm_updates_and_reloads_entry`, and they passed.
- Existing config flow validation tests were also executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d383d07e608324b30f42fa84bb828f)