### PR TITLE
Migrate reauth/reconfigure flows to helper-based update path and normalize signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 - Refactored config-flow API key confirmation handling to reuse a shared helper
   across re-authentication and reconfiguration steps, reducing duplication
   while preserving existing behavior.
+- Aligned re-authentication/reconfiguration flow handling with Home Assistant's
+  helper-based entry APIs (`_get_*_entry` and update/reload/abort helper path).
+- Normalized the reconfigure step signature/shape to match current Home
+  Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields
   back into config-entry data when saving a refreshed API key.
+- Preserved the API-key-only data refresh behavior while migrating reauth and
+  reconfigure confirmations to the helper-based update path.
 
 ## [1.9.5] - 2026-03-02
 ### Changed

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -281,11 +281,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 3
 
-    def __init__(self) -> None:
-        """Initialize the config flow state."""
-        self._reauth_entry: config_entries.ConfigEntry | None = None
-        self._reconfigure_entry: config_entries.ConfigEntry | None = None
-
     @staticmethod
     def async_get_options_flow(entry: config_entries.ConfigEntry):
         """Return the options flow handler."""
@@ -506,11 +501,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: dict[str, Any]):
         """Handle re-authentication when credentials become invalid."""
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-        if entry is None:
-            return self.async_abort(reason="reauth_failed")
-
-        self._reauth_entry = entry
         return await self.async_step_reauth_confirm()
 
     async def _async_handle_api_key_confirm(
@@ -540,15 +530,16 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             if not errors and normalized is not None:
                 if persist_normalized_data:
-                    new_data = normalized
+                    data_updates = normalized
                 else:
-                    new_data = {
-                        **entry.data,
+                    data_updates = {
                         CONF_API_KEY: str(normalized.get(CONF_API_KEY, "")).strip(),
                     }
-                self.hass.config_entries.async_update_entry(entry, data=new_data)
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason=success_reason)
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=data_updates,
+                    reason=success_reason,
+                )
 
         schema = vol.Schema(
             {
@@ -568,31 +559,30 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
         """Prompt for a refreshed API key and validate it."""
-        assert self._reauth_entry is not None
+        entry = self._get_reauth_entry()
+        if entry is None:
+            return self.async_abort(reason="reauth_failed")
         return await self._async_handle_api_key_confirm(
-            entry=self._reauth_entry,
+            entry=entry,
             step_id="reauth_confirm",
             success_reason="reauth_successful",
             user_input=user_input,
             persist_normalized_data=False,
         )
 
-    async def async_step_reconfigure(self, entry_data: dict[str, Any]):
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
         """Handle a user-initiated reconfigure request."""
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-        if entry is None:
-            return self.async_abort(reason="reconfigure_failed")
-
-        self._reconfigure_entry = entry
         return await self.async_step_reconfigure_confirm()
 
     async def async_step_reconfigure_confirm(
         self, user_input: dict[str, Any] | None = None
     ):
         """Prompt for a refreshed API key from the reconfigure UI."""
-        assert self._reconfigure_entry is not None
+        entry = self._get_reconfigure_entry()
+        if entry is None:
+            return self.async_abort(reason="reconfigure_failed")
         return await self._async_handle_api_key_confirm(
-            entry=self._reconfigure_entry,
+            entry=entry,
             step_id="reconfigure_confirm",
             success_reason="reconfigure_successful",
             user_input=user_input,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -71,6 +71,24 @@ class _StubConfigFlow:
     def add_suggested_values_to_schema(self, schema, suggested_values):
         return schema
 
+    def _get_reauth_entry(self):
+        entry_id = self.context.get("entry_id")
+        return self.hass.config_entries.async_get_entry(entry_id)
+
+    def _get_reconfigure_entry(self):
+        entry_id = self.context.get("entry_id")
+        return self.hass.config_entries.async_get_entry(entry_id)
+
+    def async_update_reload_and_abort(
+        self, entry, *, data_updates=None, reason=None, **kwargs
+    ):
+        new_data = dict(entry.data)
+        if data_updates:
+            new_data.update(data_updates)
+        self.hass.config_entries.async_update_entry(entry, data=new_data)
+        self.hass.config_entries.async_reload(entry.entry_id)
+        return self.async_abort(reason=reason)
+
 
 class _StubOptionsFlow:
     pass
@@ -780,7 +798,7 @@ def test_reauth_confirm_schema_masks_api_key_and_uses_blank_default(
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=SimpleNamespace())
     flow.context = {"entry_id": "entry-id"}
-    flow._reauth_entry = entry
+    flow._get_reauth_entry = lambda: entry  # type: ignore[method-assign]
 
     captured: dict[str, object] = {}
 
@@ -829,7 +847,7 @@ def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=SimpleNamespace())
     flow.context = {"entry_id": "entry-id"}
-    flow._reconfigure_entry = entry
+    flow._get_reconfigure_entry = lambda: entry  # type: ignore[method-assign]
 
     captured: dict[str, object] = {}
 
@@ -1581,8 +1599,8 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
     assert flow.unique_ids[0] == flow.unique_ids[1] == "1.0000_2.0000"
 
 
-def test_reauth_confirm_updates_and_reloads_entry() -> None:
-    """Re-auth confirmation should update stored credentials and reload the entry."""
+def test_reauth_confirm_updates_existing_entry_and_reloads() -> None:
+    """Re-auth confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
         data={
@@ -1605,7 +1623,7 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             self.reloaded = entry_id
 
     recorder = _Recorder()
@@ -1614,12 +1632,7 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
 
-    normalized = {
-        CONF_API_KEY: "new-key",
-        CONF_LATITUDE: 1.0,
-        CONF_LONGITUDE: 2.0,
-        CONF_LANGUAGE_CODE: "en",
-    }
+    normalized = {**entry.data, CONF_API_KEY: "new-key", CONF_FORECAST_DAYS: 3}
 
     async def fake_validate(
         user_input, *, check_unique_id, description_placeholders=None
@@ -1635,7 +1648,13 @@ def test_reauth_confirm_updates_and_reloads_entry() -> None:
     result = asyncio.run(run_flow())
 
     assert result == {"type": "abort", "reason": "reauth_successful"}
-    assert recorder.updated == (entry, normalized)
+    assert recorder.updated == (
+        entry,
+        {
+            **entry.data,
+            CONF_API_KEY: "new-key",
+        },
+    )
     assert recorder.reloaded == "entry-id"
 
 
@@ -1665,7 +1684,7 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             return None
 
     recorder = _Recorder()
@@ -1704,8 +1723,8 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
 
 
-def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
-    """Reconfigure confirmation should update stored credentials and reload entry."""
+def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
+    """Reconfigure confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
         data={
@@ -1728,7 +1747,7 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             self.reloaded = entry_id
 
     recorder = _Recorder()
@@ -1736,13 +1755,15 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
+    created: dict[str, bool] = {"called": False}
 
-    normalized = {
-        CONF_API_KEY: "new-key",
-        CONF_LATITUDE: 1.0,
-        CONF_LONGITUDE: 2.0,
-        CONF_LANGUAGE_CODE: "en",
-    }
+    def _capture_create_entry(*args, **kwargs):
+        created["called"] = True
+        return {"type": "create_entry"}
+
+    flow.async_create_entry = _capture_create_entry  # type: ignore[method-assign]
+
+    normalized = {**entry.data, CONF_API_KEY: "new-key", CONF_UPDATE_INTERVAL: 12}
 
     async def fake_validate(
         user_input, *, check_unique_id, description_placeholders=None
@@ -1752,14 +1773,22 @@ def test_reconfigure_confirm_updates_and_reloads_entry() -> None:
     flow._async_validate_input = fake_validate  # type: ignore[assignment]
 
     async def run_flow():
-        await flow.async_step_reconfigure(entry.data)
+        first = await flow.async_step_reconfigure()
+        assert first == {"step_id": "reconfigure_confirm"}
         return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 
     assert result == {"type": "abort", "reason": "reconfigure_successful"}
-    assert recorder.updated == (entry, normalized)
+    assert recorder.updated == (
+        entry,
+        {
+            **entry.data,
+            CONF_API_KEY: "new-key",
+        },
+    )
     assert recorder.reloaded == "entry-id"
+    assert created["called"] is False
 
 
 def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> None:
@@ -1788,7 +1817,7 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
         def async_update_entry(self, entry_to_update, *, data):
             self.updated = (entry_to_update, data)
 
-        async def async_reload(self, entry_id: str):
+        def async_reload(self, entry_id: str):
             return None
 
     recorder = _Recorder()
@@ -1796,6 +1825,13 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     flow = PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(config_entries=recorder)
     flow.context = {"entry_id": "entry-id"}
+    created: dict[str, bool] = {"called": False}
+
+    def _capture_create_entry(*args, **kwargs):
+        created["called"] = True
+        return {"type": "create_entry"}
+
+    flow.async_create_entry = _capture_create_entry  # type: ignore[method-assign]
 
     # Validation may normalize and include option-backed fields.
     normalized = {
@@ -1812,7 +1848,8 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     flow._async_validate_input = fake_validate  # type: ignore[assignment]
 
     async def run_flow():
-        await flow.async_step_reconfigure(entry.data)
+        first = await flow.async_step_reconfigure()
+        assert first == {"step_id": "reconfigure_confirm"}
         return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
@@ -1823,6 +1860,7 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
     assert updated_entry is entry
     assert updated_data[CONF_API_KEY] == "new-key"
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
+    assert created["called"] is False
 
 
 def test_async_step_user_uses_custom_entry_name() -> None:


### PR DESCRIPTION
### Motivation
- Reduce duplication and align the integration's re-authentication and reconfiguration flows with Home Assistant's helper-style config-entry APIs while preserving existing user-facing behavior.
- Ensure API-key-only refreshes do not accidentally write option-owned fields back into the config entry when confirming credentials.

### Description
- Reworked `PollenLevelsConfigFlow` to stop storing `_reauth_entry`/_reconfigure_entry` and instead use `_get_reauth_entry`/`_get_reconfigure_entry` helper semantics and a single `_async_handle_api_key_confirm` to centralize confirmation logic.
- Replaced direct calls to `async_update_entry`/`async_reload`/`async_abort` with a helper-style `async_update_reload_and_abort` path that only writes intended `data_updates` when persisting a refreshed API key.
- Normalized `async_step_reconfigure` signature to accept optional `user_input` and return the confirm step, and adjusted `async_step_reauth` to use the new helper lookups and flows.
- Updated `CHANGELOG.md` with notes about the helper-based migration and localized/reconfiguration messaging improvements.

### Testing
- Ran the unit tests in `tests/test_config_flow.py` that exercise reauth/reconfigure forms and confirm behavior, including `test_reauth_confirm_schema_masks_api_key_and_uses_blank_default` and `test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default`, and they succeeded.
- Ran modified update/reload/abort behavior tests including `test_reauth_confirm_updates_existing_entry_and_reloads`, `test_reauth_confirm_does_not_reintroduce_option_fields_in_data`, `test_reconfigure_confirm_updates_existing_entry_and_reloads`, and `test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data`, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b1f8eeb48324a7e407becdf40159)