### PR TITLE
Simplify reconfigure config-flow step, update translations, and bump version to 1.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@
   Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
-- Simplified the reconfigure flow to a single `reconfigure` step while keeping
-  the helper-based update/reload/abort path and API-key-only data refresh
-  behavior unchanged.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.9.7] - 2026-04-08
+### Changed
+- Aligned re-authentication/reconfiguration handling with Home Assistant's
+  helper-based entry APIs (`_get_*_entry` and update/reload/abort helper path).
+- Simplified reconfigure to a single real `reconfigure` config-flow step while
+  preserving the existing helper-based update path.
+- Moved reconfigure form translations from `config.step.reconfigure_confirm` to
+  `config.step.reconfigure` across bundled locales.
+
+### Fixed
+- Preserved API-key-only refresh behavior during re-authentication and
+  reconfiguration updates so option-owned fields are not reintroduced into
+  config-entry data.
+
 ## [1.9.6] - 2026-04-06
 ### Changed
 - Refactored config-flow API key confirmation handling to reuse a shared helper
@@ -9,6 +23,9 @@
   Assistant config-flow conventions while keeping the existing confirmation UX.
 - Localized reconfiguration step labels/descriptions and success/failure abort
   messages across bundled translations.
+- Simplified the reconfigure flow to a single `reconfigure` step while keeping
+  the helper-based update/reload/abort path and API-key-only data refresh
+  behavior unchanged.
 
 ### Fixed
 - Prevented both reconfigure and re-auth flows from writing option-owned fields

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -571,19 +571,13 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
-        """Handle a user-initiated reconfigure request."""
-        return await self.async_step_reconfigure_confirm()
-
-    async def async_step_reconfigure_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ):
         """Prompt for a refreshed API key from the reconfigure UI."""
         entry = self._get_reconfigure_entry()
         if entry is None:
             return self.async_abort(reason="reconfigure_failed")
         return await self._async_handle_api_key_confirm(
             entry=entry,
-            step_id="reconfigure_confirm",
+            step_id="reconfigure",
             success_reason="reconfigure_successful",
             user_input=user_input,
             persist_normalized_data=False,

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.6"
+    "version": "1.9.7"
 }

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -21,7 +21,7 @@
           "api_key": "Clau API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigura Nivells de Pol·len",
         "description": "Actualitza la clau API per a {latitude},{longitude}. En pots generar una a [la documentació de claus API de Google]({api_key_url}) i revisar [les restriccions de claus API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -21,7 +21,7 @@
           "api_key": "Klíč API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Překonfigurovat Pylové hladiny",
         "description": "Aktualizujte klíč API pro {latitude},{longitude}. Můžete ho vytvořit v [dokumentaci klíčů API Google]({api_key_url}) a projít [omezení klíčů API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -21,7 +21,7 @@
           "api_key": "API-nøgle"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Omkonfigurer Pollen Levels",
         "description": "Opdater API-nøglen for {latitude},{longitude}. Du kan oprette en i [Google API-nøgle-dokumentationen]({api_key_url}) og gennemgå [begrænsninger for API-nøgler]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -21,7 +21,7 @@
           "api_key": "API-Schlüssel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenwerte neu konfigurieren",
         "description": "Aktualisieren Sie den API-Schlüssel für {latitude},{longitude}. Sie können einen in der [Google-API-Schlüssel-Dokumentation]({api_key_url}) erstellen und [API-Schlüssel-Beschränkungen]({restricting_api_keys_url}) prüfen.",
         "data": {

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -21,7 +21,7 @@
           "api_key": "API Key"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigure Pollen Levels",
         "description": "Update the API key for {latitude},{longitude}. You can generate one at [Google API key docs]({api_key_url}) and review [API key restrictions]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -21,7 +21,7 @@
           "api_key": "Clave API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Niveles de Polen",
         "description": "Actualiza la clave API para {latitude},{longitude}. Puedes generar una en [la documentación de claves API de Google]({api_key_url}) y revisar [las restricciones de claves API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -21,7 +21,7 @@
           "api_key": "API-avain"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Määritä Pollenitasot uudelleen",
         "description": "Päivitä API-avain sijainnille {latitude},{longitude}. Voit luoda avaimen [Googlen API-avainohjeesta]({api_key_url}) ja tarkistaa [API-avaimen rajoitukset]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -21,7 +21,7 @@
           "api_key": "Clé API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurer Niveaux de pollen",
         "description": "Mettez à jour la clé API pour {latitude},{longitude}. Vous pouvez en générer une dans la [documentation des clés API Google]({api_key_url}) et consulter [les restrictions des clés API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -21,7 +21,7 @@
           "api_key": "API-kulcs"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenértékek újrakonfigurálása",
         "description": "Frissítse az API-kulcsot ehhez: {latitude},{longitude}. Új kulcsot a [Google API-kulcs dokumentációban]({api_key_url}) hozhat létre, és ellenőrizheti az [API-kulcs korlátozásokat]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -21,7 +21,7 @@
           "api_key": "Chiave API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Riconfigura Livelli Pollinici",
         "description": "Aggiorna la chiave API per {latitude},{longitude}. Puoi generarne una nella [documentazione delle chiavi API Google]({api_key_url}) e rivedere [le restrizioni delle chiavi API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -21,7 +21,7 @@
           "api_key": "API-nøkkel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurer Pollennivåer på nytt",
         "description": "Oppdater API-nøkkelen for {latitude},{longitude}. Du kan opprette en i [Google API-nøkkel-dokumentasjonen]({api_key_url}) og gjennomgå [API-nøkkelbegrensninger]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -21,7 +21,7 @@
           "api_key": "API-sleutel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Pollenwaarden opnieuw configureren",
         "description": "Werk de API-sleutel bij voor {latitude},{longitude}. Je kunt er een maken in de [Google API-sleutel-documentatie]({api_key_url}) en [API-sleutelbeperkingen]({restricting_api_keys_url}) bekijken.",
         "data": {

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -21,7 +21,7 @@
           "api_key": "Klucz API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Skonfiguruj ponownie Poziomy pyłków",
         "description": "Zaktualizuj klucz API dla {latitude},{longitude}. Możesz utworzyć go w [dokumentacji kluczy API Google]({api_key_url}) i sprawdzić [ograniczenia kluczy API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -21,7 +21,7 @@
           "api_key": "Chave da API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Níveis de Pólen",
         "description": "Atualize a chave de API para {latitude},{longitude}. Você pode gerar uma na [documentação de chaves de API do Google]({api_key_url}) e revisar [as restrições de chave de API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -21,7 +21,7 @@
           "api_key": "Chave da API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurar Níveis de Pólen",
         "description": "Atualize a chave de API para {latitude},{longitude}. Pode gerar uma na [documentação de chaves de API da Google]({api_key_url}) e rever [as restrições de chave de API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -21,7 +21,7 @@
           "api_key": "Cheie API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Reconfigurează Niveluri de polen",
         "description": "Actualizați cheia API pentru {latitude},{longitude}. Puteți genera una în [documentația cheilor API Google]({api_key_url}) și revizui [restricțiile cheilor API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -21,7 +21,7 @@
           "api_key": "Ключ API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Перенастроить Уровни пыльцы",
         "description": "Обновите API-ключ для {latitude},{longitude}. Вы можете создать его в [документации по API-ключам Google]({api_key_url}) и проверить [ограничения API-ключей]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -21,7 +21,7 @@
           "api_key": "API-nyckel"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Konfigurera om Pollennivåer",
         "description": "Uppdatera API-nyckeln för {latitude},{longitude}. Du kan skapa en i [Google API-nyckeldokumentation]({api_key_url}) och granska [API-nyckelbegränsningar]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -21,7 +21,7 @@
           "api_key": "Ключ API"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "Переналаштувати Рівні пилку",
         "description": "Оновіть API-ключ для {latitude},{longitude}. Ви можете створити його в [документації ключів API Google]({api_key_url}) та переглянути [обмеження ключів API]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -21,7 +21,7 @@
           "api_key": "API 密钥"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "重新配置花粉水平",
         "description": "更新 {latitude},{longitude} 的 API 密钥。您可以在 [Google API 密钥文档]({api_key_url}) 生成，并查看 [API 密钥限制]({restricting_api_keys_url}).",
         "data": {

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -21,7 +21,7 @@
           "api_key": "API 金鑰"
         }
       },
-      "reconfigure_confirm": {
+      "reconfigure": {
         "title": "重新設定花粉水平",
         "description": "更新 {latitude},{longitude} 的 API 金鑰。您可以在 [Google API 金鑰文件]({api_key_url}) 產生，並檢視 [API 金鑰限制]({restricting_api_keys_url}).",
         "data": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.6"
+version = "1.9.7"
 # Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -820,7 +820,7 @@ def test_reauth_confirm_schema_masks_api_key_and_uses_blank_default(
     assert api_selector.config.type == cf.TextSelectorType.PASSWORD
 
 
-def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
+def test_reconfigure_schema_masks_api_key_and_uses_blank_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reconfigure form should mask API key input and avoid prefilling secrets."""
@@ -858,9 +858,9 @@ def test_reconfigure_confirm_schema_masks_api_key_and_uses_blank_default(
 
     flow.async_show_form = _capture_show_form  # type: ignore[method-assign]
 
-    result = asyncio.run(flow.async_step_reconfigure_confirm())
+    result = asyncio.run(flow.async_step_reconfigure())
 
-    assert result == {"step_id": "reconfigure_confirm"}
+    assert result == {"step_id": "reconfigure"}
     assert captured_default["api_key"] == ""
     schema = captured["schema"]
     assert hasattr(schema, "schema")
@@ -1723,7 +1723,7 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
 
 
-def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
+def test_reconfigure_updates_existing_entry_and_reloads() -> None:
     """Reconfigure confirmation should update existing entry credentials and reload."""
 
     entry = cf.config_entries.ConfigEntry(
@@ -1774,8 +1774,8 @@ def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
 
     async def run_flow():
         first = await flow.async_step_reconfigure()
-        assert first == {"step_id": "reconfigure_confirm"}
-        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+        assert first == {"step_id": "reconfigure"}
+        return await flow.async_step_reconfigure({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 
@@ -1791,7 +1791,7 @@ def test_reconfigure_confirm_updates_existing_entry_and_reloads() -> None:
     assert created["called"] is False
 
 
-def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> None:
+def test_reconfigure_does_not_reintroduce_option_fields_in_data() -> None:
     """Reconfigure should only update API key in data, preserving option boundaries."""
 
     entry = cf.config_entries.ConfigEntry(
@@ -1849,8 +1849,8 @@ def test_reconfigure_confirm_does_not_reintroduce_option_fields_in_data() -> Non
 
     async def run_flow():
         first = await flow.async_step_reconfigure()
-        assert first == {"step_id": "reconfigure_confirm"}
-        return await flow.async_step_reconfigure_confirm({CONF_API_KEY: "new-key"})
+        assert first == {"step_id": "reconfigure"}
+        return await flow.async_step_reconfigure({CONF_API_KEY: "new-key"})
 
     result = asyncio.run(run_flow())
 


### PR DESCRIPTION
### Motivation
- Align re-authentication/reconfiguration handling with Home Assistant helper-based entry APIs and simplify the reconfigure UX to a single step.
- Ensure API-key-only refresh behavior is preserved during re-auth and reconfigure so option-owned fields are not reintroduced into config-entry data.
- Update bundled translations and package metadata to reflect the new reconfigure step and release version.

### Description
- Consolidated the reconfigure flow into a single `async_step_reconfigure` step and removed the separate `async_step_reconfigure_confirm`, using `step_id="reconfigure"` for the form display and handling.
- Kept `persist_normalized_data=False` in the API key confirm handler to preserve API-key-only update semantics and maintain helper-based update/reload/abort paths.
- Renamed translation keys from `reconfigure_confirm` to `reconfigure` across all bundled locale files to match the new step name.
- Bumped the integration version in `manifest.json` and `pyproject.toml` to `1.9.7` and added a `CHANGELOG.md` entry describing the changes.
- Updated `tests/test_config_flow.py` to call the new `async_step_reconfigure` step and to expect the updated `step_id` and behavior.

### Testing
- Ran the updated config flow unit tests with `pytest tests/test_config_flow.py` and the modified tests completed successfully.
- The updated tests assert masked API key defaults, preserved option boundaries during reconfigure/reauth flows, and correct update/reload behavior, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f89d202c83249ced5ced7a3cb134)