### PR TITLE
Prepare 2.0.0 baseline with HA 2026.3 and Python 3.14

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: Build release ZIP (integration root at ZIP root)
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: Build release ZIP (integration root at ZIP root)
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +38,6 @@ jobs:
           fi
 
       - name: Install package
-        if: ${{ matrix.python-version >= '3.14' }}
         run: |
           python -m pip install .
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,6 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,8 +22,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          python-version: "3.14"
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Tooling
-- Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` must remain compatible with Home Assistant's current Python floor (Python 3.13 at the moment), so do not rely on 3.14-only syntax or standard library features outside tooling/CI.
+- Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
 - Format code with Black (line length 88, target-version `py314`) pinned at `black==25.*`.
 - Lint and sort imports with Ruff targeting `py314`, pinned at `ruff==0.14.*`, matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
@@ -26,7 +26,6 @@
 - Keep imports tidy—remove unused symbols and respect the Ruff isort grouping so the Home Assistant package stays first-party under `custom_components/pollenlevels`.
 - Translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep all other locale files in sync with it and do not add or rely on a `strings.json` file.
 
-Note: When Home Assistant raises its Python floor to 3.14, this guidance will be updated; until then, treat Python 3.13 as the compatibility target for integration code.
 
 ## Integration Architecture
 - This repository hosts the custom integration **Pollen Levels for Home Assistant**, distributed through **HACS**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@
 - Do NOT add any new boilerplate, intro text or `## [Unreleased]` section automatically. If such sections already exist, leave them and only edit their content when explicitly requested.
 - Version headings must use the pattern `## [version] - YYYY-MM-DD` (ASCII hyphen) and releases must stay in reverse chronological order. Use SemVer identifiers such as `1.8.2`, `1.8.2-rc1`, `1.8.1-alpha1`.
 - Inside each version, use only these headings: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`. Prefer `Changed` for documentation-only updates.
+- For breaking changes, keep one of the allowed section headings above and
+  prefix the bullet with `**Breaking change:**`; do not add a separate
+  `### Breaking Changes` heading.
 - Each change must be a `- ` bullet. Wrap long bullets around 80–100 characters with indented continuation lines; do NOT insert blank lines inside a bullet and avoid `<br>` or trailing double spaces.
 - Keep diffs minimal: never reflow or rewrap unrelated text, and never rename existing headings unless they clearly violate these rules.
 - If comparison links exist at the bottom of the changelog, keep the existing style and only extend it for new versions of this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [2.0.0] - 2026-05-07
-### Breaking Changes
-- Raised the minimum supported Home Assistant version to 2026.3.0.
-- Dropped Python 3.13 compatibility and aligned the project with Python 3.14+.
-
 ### Changed
+- **Breaking change:** Raised the minimum supported Home Assistant version to
+  2026.3.0.
+- **Breaking change:** Dropped Python 3.13 compatibility and aligned the project
+  with Python 3.14+.
 - Updated CI and project metadata to test and document the Python 3.14 baseline.
 
 ## [1.9.7] - 2026-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.0] - 2026-05-07
+### Breaking Changes
+- Raised the minimum supported Home Assistant version to 2026.3.0.
+- Dropped Python 3.13 compatibility and aligned the project with Python 3.14+.
+
+### Changed
+- Updated CI and project metadata to test and document the Python 3.14 baseline.
+
 ## [1.9.7] - 2026-04-08
 ### Changed
 - Aligned re-authentication/reconfiguration handling with Home Assistant's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
-- Follow Home Assistant's current Python floor for integration code (Python 3.13). Tooling is pinned to Python 3.14, but
-  integration logic must stay compatible with 3.13 syntax and standard library features.
+- The integration targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
+  Use Python 3.14 for local development and CI parity.
 - Format code with Black (line length 88, target-version `py314`) and sort/lint imports with Ruff (`ruff check --fix --select I` followed
   by `ruff check`).
 - The translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep every other locale file in

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 
 ---
 
+## Requirements
+
+- Requires Home Assistant 2026.3.0 or newer.
+- This release line targets Python 3.14+, matching the Home Assistant runtime baseline.
+
 ## 🌟 Features
 
 - **Multi-language support** — UI in 21 languages (**EN, ES, CA, DE, FR, IT, PL, RU, UK, NL, ZH-Hans, SV, CS, PT-BR, DA, NB, PT-PT, RO, FI, HU, ZH-Hant**) + API responses in any language.

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.7"
+    "version": "2.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Pollen Levels",
-  "homeassistant": "2025.3.0",
+  "homeassistant": "2026.3.0",
   "content_in_root": false,
   "render_readme": true,
   "hacs": "2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Tooling aligned to Home Assistant Python floor (>=3.14.0).
+# Tooling aligned to the Home Assistant Python floor (>=3.14.0).
 # NOTE: We purposely DO NOT set [tool.black].required-version; CI pins Black/Ruff
 # to the current minor series. If you ever need an exact lock, set both:
 #   - pyproject: required-version = "<desired black version>"
@@ -6,8 +6,8 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.7"
-# Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
+version = "2.0.0"
+# Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 
 [tool.black]


### PR DESCRIPTION
### Motivation
- Raise the integration baseline to follow Home Assistant 2026.3 which runs on Python 3.14, and stop claiming Python 3.13 compatibility. 
- Bump the integration/project version to a breaking `2.0.0` baseline to signal the runtime and CI change. 
- Keep the change narrow and focused on metadata, CI, and docs so runtime logic and existing entities remain untouched.

### Description
- Bumped manifest and package version to `2.0.0` and kept `requires-python = ">=3.14"` in `pyproject.toml` (files: `custom_components/pollenlevels/manifest.json`, `pyproject.toml`).
- Raised HACS/Home Assistant requirement to `2026.3.0` in `hacs.json` and added a short Requirements note to `README.md` stating `Requires Home Assistant 2026.3.0 or newer` and Python 3.14+ targeting (files: `hacs.json`, `README.md`).
- Updated CI to run only on Python 3.14 by removing `3.13` from the test matrix and adding explicit `setup-python` steps where needed for package and release workflows (files: `.github/workflows/tests.yml`, `.github/workflows/package-test.yml`, `.github/workflows/release.yml`).
- Updated contributor/agent guidance to target Python 3.14+ (files: `CONTRIBUTING.md`, `AGENTS.md`) and added a `2.0.0` changelog entry documenting the breaking changes (file: `CHANGELOG.md`).
- Note: PR #84 is intentionally not included in this baseline PR.

### Testing
- Ran `ruff check --fix --select I` and `ruff check .`, both completed successfully. 
- Ran `pytest -q` on Python 3.14 and all tests passed (`159 passed`).
- Ran the package ZIP structure validation (the package-test/release job snippet) and it succeeded. 
- `black --check .` reported files needing reformatting under the locally available Black (`26.x`) and the pinned `black==25.*` could not be installed in this environment due to package index access returning `403`, so the repo-format check was noted but not reproducibly pinned here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcad69ce688324a160b6869e5848a1)