### PR TITLE
Add daily summary sensors; bump Home Assistant/Python baseline to 2026.3 / 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,6 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.13", "3.14"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,8 +22,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          python-version: "3.14"
+          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -38,7 +34,6 @@ jobs:
           fi
 
       - name: Install package
-        if: ${{ matrix.python-version >= '3.14' }}
         run: |
           python -m pip install .
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Tooling
-- Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` must remain compatible with Home Assistant's current Python floor (Python 3.13 at the moment), so do not rely on 3.14-only syntax or standard library features outside tooling/CI.
+- Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
 - Format code with Black (line length 88, target-version `py314`) pinned at `black==25.*`.
 - Lint and sort imports with Ruff targeting `py314`, pinned at `ruff==0.14.*`, matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
@@ -17,6 +17,7 @@
 - Do NOT add any new boilerplate, intro text or `## [Unreleased]` section automatically. If such sections already exist, leave them and only edit their content when explicitly requested.
 - Version headings must use the pattern `## [version] - YYYY-MM-DD` (ASCII hyphen) and releases must stay in reverse chronological order. Use SemVer identifiers such as `1.8.2`, `1.8.2-rc1`, `1.8.1-alpha1`.
 - Inside each version, use only these headings: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`. Prefer `Changed` for documentation-only updates.
+- For breaking changes, keep one of the allowed section headings above and prefix the bullet with `**Breaking change:**`; do not add a separate `### Breaking Changes` heading.
 - Each change must be a `- ` bullet. Wrap long bullets around 80–100 characters with indented continuation lines; do NOT insert blank lines inside a bullet and avoid `<br>` or trailing double spaces.
 - Keep diffs minimal: never reflow or rewrap unrelated text, and never rename existing headings unless they clearly violate these rules.
 - If comparison links exist at the bottom of the changelog, keep the existing style and only extend it for new versions of this repository.
@@ -26,7 +27,6 @@
 - Keep imports tidy—remove unused symbols and respect the Ruff isort grouping so the Home Assistant package stays first-party under `custom_components/pollenlevels`.
 - Translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep all other locale files in sync with it and do not add or rely on a `strings.json` file.
 
-Note: When Home Assistant raises its Python floor to 3.14, this guidance will be updated; until then, treat Python 3.13 as the compatibility target for integration code.
 
 ## Integration Architecture
 - This repository hosts the custom integration **Pollen Levels for Home Assistant**, distributed through **HACS**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.1.0] - 2026-05-07
+### Added
+- Added daily summary sensors for plants in season, overall pollen risk, and top
+  pollen types.
+
+## [2.0.0] - 2026-05-07
+### Changed
+- **Breaking change:** Raised the minimum supported Home Assistant version to
+  2026.3.0.
+- **Breaking change:** Dropped Python 3.13 compatibility and aligned the project
+  with Python 3.14+.
+- Updated CI and project metadata to test and document the Python 3.14 baseline.
+
 ## [1.9.7] - 2026-04-08
 ### Changed
 - Aligned re-authentication/reconfiguration handling with Home Assistant's

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - **Configurable updates** — Change update interval, language, forecast days, and per-day sensors without reinstalling.  
 - **Manual refresh** — Call `pollenlevels.force_update` to trigger an immediate update and reset the timer.
 - **Last Updated sensor** — Shows timestamp of last successful update.
+- **Daily summary sensors** — Shows plants in season today, overall pollen risk today,
+  and top pollen types today.
 - **Rich attributes** — Includes `inSeason`, index `description`, health `advice`,
   `color_hex`, `color_rgb`, and plant details.
 - **Resilient startup** — Retries setup automatically when the first API response lacks daily pollen info (`dailyInfo` types/plants), ensuring entities appear once data is ready.

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -210,7 +210,7 @@ async def async_setup_entry(
     normalized_mode = normalize_sensor_mode(raw_mode, _LOGGER)
     try:
         mode = ForecastSensorMode(normalized_mode)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as _err:
         mode = ForecastSensorMode.NONE
     create_d1 = (
         mode in (ForecastSensorMode.D1, ForecastSensorMode.D1_D2) and forecast_days >= 2
@@ -281,7 +281,7 @@ async def async_setup_entry(
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
-    except (ConfigEntryAuthFailed, ConfigEntryNotReady):
+    except (ConfigEntryAuthFailed, ConfigEntryNotReady) as _err:
         entry.runtime_data = None
         raise
     except Exception as err:

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -54,7 +54,7 @@ class GooglePollenApiClient:
             if math.isfinite(parsed) and parsed > 0:
                 return parsed
             return 2.0
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as _err:
             retry_at = dt_util.parse_http_date(retry_after_raw)
             if retry_at is not None:
                 delay = (retry_at - dt_util.utcnow()).total_seconds()

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -109,7 +109,7 @@ def _safe_coord(value: float | None, *, lat: bool) -> float | None:
         if lat:
             return cv.latitude(value)
         return cv.longitude(value)
-    except (vol.Invalid, TypeError, ValueError):
+    except vol.Invalid, TypeError, ValueError:
         return None
 
 
@@ -210,7 +210,7 @@ def _validate_location_dict(
     try:
         lat = cv.latitude(lat_val)
         lon = cv.longitude(lon_val)
-    except (vol.Invalid, TypeError, ValueError):
+    except vol.Invalid, TypeError, ValueError:
         return None
 
     return lat, lon
@@ -358,7 +358,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lat = cv.latitude(user_input.get(CONF_LATITUDE))
                 lon = cv.longitude(user_input.get(CONF_LONGITUDE))
                 latlon = (lat, lon)
-            except (vol.Invalid, TypeError):
+            except vol.Invalid, TypeError:
                 _LOGGER.debug(
                     "Invalid coordinates provided (values redacted): parsing failed"
                 )

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -35,7 +35,7 @@ def _normalize_channel(v: Any) -> int | None:
     """
     try:
         f = float(v)
-    except (TypeError, ValueError, OverflowError):
+    except (TypeError, ValueError, OverflowError) as _err:
         return None
     if not math.isfinite(f):
         return None
@@ -422,7 +422,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                 # Use day-specific 'inSeason' and 'advice' from the forecast day.
                 try:
                     day_obj = daily[off]
-                except (IndexError, TypeError):
+                except (IndexError, TypeError) as _err:
                     day_obj = None
                 day_item = type_by_day_code[off].get(_tcode) if day_obj else None
                 day_in_season = (

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -66,7 +66,7 @@ async def async_get_config_entry_diagnostics(
     def _rounded(value: Any) -> float | None:
         try:
             f = float(value)
-        except (TypeError, ValueError, OverflowError):
+        except (TypeError, ValueError, OverflowError) as _err:
             return None
         if not math.isfinite(f):
             return None

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -1,11 +1,13 @@
 {
     "domain": "pollenlevels",
     "name": "Pollen Levels",
-    "codeowners": ["@eXPerience83"],
+    "codeowners": [
+        "@eXPerience83"
+    ],
     "config_flow": true,
     "documentation": "https://github.com/eXPerience83/pollenlevels",
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "1.9.7"
+    "version": "2.1.0"
 }

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from collections.abc import Awaitable
 from datetime import date  # Added `date` for DATE device class native_value
 from enum import StrEnum
+from numbers import Real
 from typing import TYPE_CHECKING, Any, cast
 
 # Modern sensor base + enums
@@ -75,6 +77,82 @@ TYPE_ICONS = {
 # Plants reuse the same icon mapping by type.
 PLANT_TYPE_ICONS = TYPE_ICONS
 DEFAULT_ICON = "mdi:flower-pollen"
+
+
+def _normalize_code(code: Any) -> str:
+    """Return a stable normalized code for deterministic ordering."""
+    return str(code or "").casefold()
+
+
+def _is_finite_number(value: Any) -> bool:
+    """Return whether a value is a finite non-boolean number."""
+    return (
+        isinstance(value, Real) and not isinstance(value, bool) and math.isfinite(value)
+    )
+
+
+def _entry_code(key: str, info: dict[str, Any]) -> str:
+    """Return the API code for a coordinator data entry."""
+    if info.get("code") is not None:
+        return str(info["code"])
+    if key.startswith("type_"):
+        return key.removeprefix("type_").upper()
+    if key.startswith("plants_"):
+        return key.removeprefix("plants_").upper()
+    return key
+
+
+def _display_name(code: str, info: dict[str, Any]) -> str:
+    """Return a user-facing display name for a coordinator data entry."""
+    return str(info.get("displayName") or info.get("name") or code)
+
+
+def _current_type_entries(
+    data: dict[str, Any],
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Return current-day pollen type entries sorted by normalized type code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, raw_info in data.items():
+        if key.endswith(("_d1", "_d2")) or not isinstance(raw_info, dict):
+            continue
+        info = raw_info
+        if info.get("source") != "type":
+            continue
+        code = _entry_code(key, info)
+        entries.append((key, code, _display_name(code, info), info))
+    entries.sort(key=lambda item: _normalize_code(item[1]))
+    return entries
+
+
+def _current_plant_entries(
+    data: dict[str, Any],
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Return current-day plant entries sorted by normalized plant code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, raw_info in data.items():
+        if not isinstance(raw_info, dict) or raw_info.get("source") != "plant":
+            continue
+        code = _entry_code(key, raw_info)
+        entries.append((key, code, _display_name(code, raw_info), raw_info))
+    entries.sort(key=lambda item: _normalize_code(item[1]))
+    return entries
+
+
+def _top_type_entries(
+    data: dict[str, Any],
+) -> tuple[float | int | None, list[tuple[str, str, str, dict[str, Any]]]]:
+    """Return the maximum current-day type value and all entries tied for it."""
+    valid_entries = [
+        entry
+        for entry in _current_type_entries(data)
+        if _is_finite_number(entry[3].get("value"))
+    ]
+    if not valid_entries:
+        return None, []
+    top_value = max(entry[3]["value"] for entry in valid_entries)
+    return top_value, [
+        entry for entry in valid_entries if entry[3]["value"] == top_value
+    ]
 
 
 class ForecastSensorMode(StrEnum):
@@ -200,6 +278,9 @@ async def async_setup_entry(
 
     sensors.extend(
         [
+            PlantsInSeasonTodaySensor(coordinator),
+            OverallPollenRiskTodaySensor(coordinator),
+            TopPollenTypesTodaySensor(coordinator),
             RegionSensor(coordinator),
             DateSensor(coordinator),
             LastUpdatedSensor(coordinator),
@@ -379,6 +460,163 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         }
 
 
+class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
+    """Provide base behavior for daily summary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator, group: str) -> None:
+        """Initialize a daily summary sensor."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+        device_id = f"{self.coordinator.entry_id}_{group}"
+        translation_keys = {"type": "types", "plant": "plants"}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "manufacturer": "Google",
+            "model": "Pollen API",
+            "translation_key": translation_keys[group],
+            "translation_placeholders": {
+                "title": self.coordinator.entry_title or DEFAULT_ENTRY_TITLE,
+                "latitude": f"{self.coordinator.lat:.6f}",
+                "longitude": f"{self.coordinator.lon:.6f}",
+            },
+        }
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return common daily summary attributes."""
+        return {ATTR_ATTRIBUTION: ATTRIBUTION}
+
+
+class PlantsInSeasonTodaySensor(_BaseSummarySensor):
+    """Represent the daily count of plants currently in season."""
+
+    _attr_translation_key = "plants_in_season_today"
+    _attr_icon = "mdi:sprout"
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+        """Initialize the plants in season summary sensor."""
+        super().__init__(coordinator, "plant")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_plants_in_season_today"
+
+    def _season_counts(self) -> dict[str, Any]:
+        """Return deterministic plant season counts and lists."""
+        entries = _current_plant_entries(self.coordinator.data or {})
+        plant_codes: list[str] = []
+        plant_names: list[str] = []
+        unknown_codes: list[str] = []
+        unknown_names: list[str] = []
+        in_season_count = 0
+        out_of_season_count = 0
+        unknown_season_count = 0
+
+        for _key, code, name, info in entries:
+            plant_codes.append(code)
+            plant_names.append(name)
+            in_season = info.get("inSeason")
+            if in_season is True:
+                in_season_count += 1
+            elif in_season is False:
+                out_of_season_count += 1
+            else:
+                unknown_season_count += 1
+                unknown_codes.append(code)
+                unknown_names.append(name)
+
+        return {
+            "plant_codes": plant_codes,
+            "plant_names": plant_names,
+            "in_season_count": in_season_count,
+            "out_of_season_count": out_of_season_count,
+            "unknown_season_count": unknown_season_count,
+            "total_plant_count": len(entries),
+            "unknown_season_codes": unknown_codes,
+            "unknown_season_names": unknown_names,
+        }
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number of plants explicitly marked as in season."""
+        counts = self._season_counts()
+        known_count = counts["in_season_count"] + counts["out_of_season_count"]
+        if counts["total_plant_count"] == 0 or known_count == 0:
+            return None
+        return counts["in_season_count"]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return plant season summary attributes."""
+        return super().extra_state_attributes | self._season_counts()
+
+
+class OverallPollenRiskTodaySensor(_BaseSummarySensor):
+    """Represent the highest current-day pollen type index."""
+
+    _attr_translation_key = "overall_pollen_risk_today"
+    _attr_icon = DEFAULT_ICON
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0  # type: ignore[assignment]
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+        """Initialize the overall pollen risk summary sensor."""
+        super().__init__(coordinator, "type")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_overall_pollen_risk_today"
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the maximum valid current-day pollen type value."""
+        top_value, _entries = _top_type_entries(self.coordinator.data or {})
+        return top_value
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return overall pollen risk summary attributes."""
+        _top_value, entries = _top_type_entries(self.coordinator.data or {})
+        first_info = entries[0][3] if entries else {}
+        return super().extra_state_attributes | {
+            "category": first_info.get("category"),
+            "description": first_info.get("description"),
+            "top_pollen_codes": [entry[1] for entry in entries],
+            "top_pollen_names": [entry[2] for entry in entries],
+            "top_pollen_categories": [entry[3].get("category") for entry in entries],
+            "tie_count": len(entries),
+        }
+
+
+class TopPollenTypesTodaySensor(_BaseSummarySensor):
+    """Represent the highest current-day pollen type names."""
+
+    _attr_translation_key = "top_pollen_types_today"
+    _attr_icon = DEFAULT_ICON
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+        """Initialize the top pollen types summary sensor."""
+        super().__init__(coordinator, "type")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_top_pollen_types_today"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the top pollen type name or comma-separated tied names."""
+        _top_value, entries = _top_type_entries(self.coordinator.data or {})
+        if not entries:
+            return None
+        return ", ".join(entry[2] for entry in entries)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return top pollen type summary attributes."""
+        top_value, entries = _top_type_entries(self.coordinator.data or {})
+        return super().extra_state_attributes | {
+            "top_value": top_value,
+            "top_pollen_codes": [entry[1] for entry in entries],
+            "top_pollen_names": [entry[2] for entry in entries],
+            "top_pollen_categories": [entry[3].get("category") for entry in entries],
+            "tie_count": len(entries),
+        }
+
+
 class _BaseMetaSensor(CoordinatorEntity, SensorEntity):
     """Provide base for metadata sensors."""
 
@@ -462,7 +700,7 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as _err:
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última actualització"
+      },
+      "plants_in_season_today": {
+        "name": "Plantes de temporada avui"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risc general de pol·len avui"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipus principals de pol·len avui"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Poslední aktualizace"
+      },
+      "plants_in_season_today": {
+        "name": "Rostliny dnes v sezóně"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Celkové pylové riziko dnes"
+      },
+      "top_pollen_types_today": {
+        "name": "Hlavní druhy pylu dnes"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Sidst opdateret"
+      },
+      "plants_in_season_today": {
+        "name": "Planter i sæson i dag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Samlet pollenrisiko i dag"
+      },
+      "top_pollen_types_today": {
+        "name": "Vigtigste pollentyper i dag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Letzte Aktualisierung"
+      },
+      "plants_in_season_today": {
+        "name": "Heute saisonale Pflanzen"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Gesamtes Pollenrisiko heute"
+      },
+      "top_pollen_types_today": {
+        "name": "Wichtigste Pollenarten heute"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Last Updated"
+      },
+      "plants_in_season_today": {
+        "name": "Plants in Season Today"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Overall Pollen Risk Today"
+      },
+      "top_pollen_types_today": {
+        "name": "Top Pollen Types Today"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última actualización"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas en temporada hoy"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Riesgo general de polen hoy"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipos de polen principales hoy"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Viimeksi päivitetty"
+      },
+      "plants_in_season_today": {
+        "name": "Tänään kaudella olevat kasvit"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Yleinen siitepölyriski tänään"
+      },
+      "top_pollen_types_today": {
+        "name": "Tärkeimmät siitepölytyypit tänään"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Dernière mise à jour"
+      },
+      "plants_in_season_today": {
+        "name": "Plantes de saison aujourd’hui"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risque pollinique global aujourd’hui"
+      },
+      "top_pollen_types_today": {
+        "name": "Principaux types de pollen aujourd’hui"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Utoljára frissítve"
+      },
+      "plants_in_season_today": {
+        "name": "Szezonális növények ma"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Mai általános pollenkockázat"
+      },
+      "top_pollen_types_today": {
+        "name": "Mai fő pollentípusok"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ultimo aggiornamento"
+      },
+      "plants_in_season_today": {
+        "name": "Piante in stagione oggi"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Rischio pollinico complessivo oggi"
+      },
+      "top_pollen_types_today": {
+        "name": "Principali tipi di polline oggi"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Sist oppdatert"
+      },
+      "plants_in_season_today": {
+        "name": "Planter i sesong i dag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Samlet pollenrisiko i dag"
+      },
+      "top_pollen_types_today": {
+        "name": "Viktigste pollentyper i dag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Laatst bijgewerkt"
+      },
+      "plants_in_season_today": {
+        "name": "Planten in het seizoen vandaag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Algemeen pollenrisico vandaag"
+      },
+      "top_pollen_types_today": {
+        "name": "Belangrijkste pollentypen vandaag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ostatnia aktualizacja"
+      },
+      "plants_in_season_today": {
+        "name": "Rośliny w sezonie dzisiaj"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Ogólne ryzyko pyłkowe dzisiaj"
+      },
+      "top_pollen_types_today": {
+        "name": "Najważniejsze typy pyłków dzisiaj"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última atualização"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas da estação hoje"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risco geral de pólen hoje"
+      },
+      "top_pollen_types_today": {
+        "name": "Principais tipos de pólen hoje"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última atualização"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas da época hoje"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risco geral de pólen hoje"
+      },
+      "top_pollen_types_today": {
+        "name": "Principais tipos de pólen hoje"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ultima actualizare"
+      },
+      "plants_in_season_today": {
+        "name": "Plante de sezon astăzi"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risc general de polen astăzi"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipuri principale de polen astăzi"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Последнее обновление"
+      },
+      "plants_in_season_today": {
+        "name": "Сезонные растения сегодня"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Общий риск пыльцы сегодня"
+      },
+      "top_pollen_types_today": {
+        "name": "Основные типы пыльцы сегодня"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Senaste uppdatering"
+      },
+      "plants_in_season_today": {
+        "name": "Växter i säsong idag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Samlad pollenrisk idag"
+      },
+      "top_pollen_types_today": {
+        "name": "Viktigaste pollentyperna idag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Останнє оновлення"
+      },
+      "plants_in_season_today": {
+        "name": "Сезонні рослини сьогодні"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Загальний ризик пилку сьогодні"
+      },
+      "top_pollen_types_today": {
+        "name": "Основні типи пилку сьогодні"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "上次更新时间"
+      },
+      "plants_in_season_today": {
+        "name": "今日当季植物"
+      },
+      "overall_pollen_risk_today": {
+        "name": "今日总体花粉风险"
+      },
+      "top_pollen_types_today": {
+        "name": "今日主要花粉类型"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "上次更新時間"
+      },
+      "plants_in_season_today": {
+        "name": "今日當季植物"
+      },
+      "overall_pollen_risk_today": {
+        "name": "今日整體花粉風險"
+      },
+      "top_pollen_types_today": {
+        "name": "今日主要花粉類型"
       }
     }
   }

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -100,7 +100,7 @@ def safe_parse_int(value: Any) -> int | None:
 
     try:
         parsed_float = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except (TypeError, ValueError, OverflowError) as _err:
         return None
 
     if not math.isfinite(parsed_float) or not parsed_float.is_integer():

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Pollen Levels",
-  "homeassistant": "2025.3.0",
+  "homeassistant": "2026.3.0",
   "content_in_root": false,
   "render_readme": true,
   "hacs": "2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@
 
 [project]
 name = "pollenlevels"
-version = "1.9.7"
-# Enforce the runtime floor aligned with upcoming HA Python 3.14 images.
+version = "2.1.0"
+# Enforce the runtime floor aligned with Home Assistant 2026.3 Python 3.14 images.
 requires-python = ">=3.14"
 
 [tool.black]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -134,7 +134,7 @@ config_validation_mod = ModuleType("homeassistant.helpers.config_validation")
 def _latitude(value=None):
     try:
         lat = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as _err:
         # Mirror Home Assistant's cv.latitude behavior for invalid types
         raise cf.vol.Invalid("latitude_type") from None
     if lat < -90 or lat > 90:
@@ -145,7 +145,7 @@ def _latitude(value=None):
 def _longitude(value=None):
     try:
         lon = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as _err:
         # Mirror Home Assistant's cv.longitude behavior for invalid types
         raise cf.vol.Invalid("longitude_type") from None
 
@@ -241,7 +241,7 @@ dt_mod = ModuleType("homeassistant.util.dt")
 def _parse_http_date(value: str):
     try:
         return email.utils.parsedate_to_datetime(value)
-    except (TypeError, ValueError, IndexError, OverflowError):
+    except (TypeError, ValueError, IndexError, OverflowError) as _err:
         return None
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -160,7 +160,7 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except (TypeError, ValueError, IndexError):
+    except (TypeError, ValueError, IndexError) as _err:
         return None
 
     if parsed is None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -90,6 +90,16 @@ exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
 exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
 sys.modules.setdefault("homeassistant.exceptions", exceptions_mod)
 
+config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+
+class _StubConfigEntry:  # pragma: no cover - type placeholder only
+    pass
+
+
+config_entries_mod.ConfigEntry = _StubConfigEntry
+sys.modules.setdefault("homeassistant.config_entries", config_entries_mod)
+
 helpers_mod = types.ModuleType("homeassistant.helpers")
 sys.modules.setdefault("homeassistant.helpers", helpers_mod)
 
@@ -206,7 +216,7 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except (TypeError, ValueError, IndexError):
+    except (TypeError, ValueError, IndexError) as _err:
         return None
 
     if parsed is None:
@@ -1241,6 +1251,327 @@ def test_coordinator_ignores_nonfinite_color_channels() -> None:
 
     assert data["type_grass"]["color_hex"] is None
     assert data["type_grass"]["color_rgb"] is None
+
+
+def _summary_coordinator(data: dict[str, Any]) -> types.SimpleNamespace:
+    """Return a minimal coordinator for summary sensor unit tests."""
+    return types.SimpleNamespace(
+        data=data,
+        entry_id="entry",
+        entry_title=sensor.DEFAULT_ENTRY_TITLE,
+        lat=1.0,
+        lon=2.0,
+    )
+
+
+def _state_class(entity: Any) -> Any:
+    """Return the test-visible sensor state class."""
+    return getattr(entity, "state_class", getattr(entity, "_attr_state_class", None))
+
+
+def test_plants_in_season_today_counts_mixed_values() -> None:
+    """Plants in season summary counts True, False, and unknown separately."""
+
+    entity = sensor.PlantsInSeasonTodaySensor(
+        _summary_coordinator(
+            {
+                "plants_oak": {
+                    "source": "plant",
+                    "displayName": "Oak",
+                    "inSeason": True,
+                },
+                "plants_birch": {
+                    "source": "plant",
+                    "displayName": "Birch",
+                    "inSeason": False,
+                },
+                "plants_alder": {
+                    "source": "plant",
+                    "displayName": "Alder",
+                },
+            }
+        )
+    )
+
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == 1
+    assert attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert attrs["plant_codes"] == ["ALDER", "BIRCH", "OAK"]
+    assert attrs["plant_names"] == ["Alder", "Birch", "Oak"]
+    assert attrs["in_season_count"] == 1
+    assert attrs["out_of_season_count"] == 1
+    assert attrs["unknown_season_count"] == 1
+    assert attrs["total_plant_count"] == 3
+    assert attrs["unknown_season_codes"] == ["ALDER"]
+    assert attrs["unknown_season_names"] == ["Alder"]
+
+
+def test_plants_in_season_today_returns_none_without_boolean_season() -> None:
+    """Plants in season summary is unknown when no plant has boolean season data."""
+
+    entity = sensor.PlantsInSeasonTodaySensor(
+        _summary_coordinator(
+            {
+                "plants_oak": {
+                    "source": "plant",
+                    "code": "OAK",
+                    "displayName": "Oak",
+                },
+                "plants_birch": {
+                    "source": "plant",
+                    "code": "BIRCH",
+                    "displayName": "Birch",
+                    "inSeason": "false",
+                },
+            }
+        )
+    )
+
+    assert entity.native_value is None
+    assert entity.extra_state_attributes["unknown_season_count"] == 2
+
+
+def test_plants_in_season_today_returns_none_without_plant_entries() -> None:
+    """Plants in season summary is unknown when no plant entries exist."""
+
+    entity = sensor.PlantsInSeasonTodaySensor(
+        _summary_coordinator(
+            {
+                "type_grass": {
+                    "source": "type",
+                    "code": "GRASS",
+                    "displayName": "Grass",
+                    "value": 2,
+                }
+            }
+        )
+    )
+
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value is None
+    assert attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert attrs["plant_codes"] == []
+    assert attrs["plant_names"] == []
+    assert attrs["in_season_count"] == 0
+    assert attrs["out_of_season_count"] == 0
+    assert attrs["unknown_season_count"] == 0
+    assert attrs["total_plant_count"] == 0
+    assert attrs["unknown_season_codes"] == []
+    assert attrs["unknown_season_names"] == []
+
+
+def test_overall_pollen_risk_today_returns_max_value_and_attribution() -> None:
+    """Overall pollen risk uses the maximum finite current-day type index."""
+
+    entity = sensor.OverallPollenRiskTodaySensor(
+        _summary_coordinator(
+            {
+                "type_grass": {
+                    "source": "type",
+                    "code": "GRASS",
+                    "displayName": "Grass",
+                    "value": 2,
+                    "category": "LOW",
+                    "description": "Low",
+                },
+                "type_tree": {
+                    "source": "type",
+                    "displayName": "Tree",
+                    "value": 4,
+                    "category": "HIGH",
+                    "description": "High",
+                },
+            }
+        )
+    )
+
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == 4
+    assert attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert attrs["category"] == "HIGH"
+    assert attrs["description"] == "High"
+    assert attrs["top_pollen_codes"] == ["TREE"]
+    assert attrs["top_pollen_names"] == ["Tree"]
+    assert attrs["top_pollen_categories"] == ["HIGH"]
+    assert attrs["tie_count"] == 1
+
+
+def test_top_pollen_types_today_returns_single_winner_name() -> None:
+    """Top pollen types summary returns one display name for a single winner."""
+
+    entity = sensor.TopPollenTypesTodaySensor(
+        _summary_coordinator(
+            {
+                "type_grass": {
+                    "source": "type",
+                    "code": "GRASS",
+                    "displayName": "Grass",
+                    "value": 5,
+                    "category": "VERY_HIGH",
+                },
+                "type_tree": {
+                    "source": "type",
+                    "code": "TREE",
+                    "displayName": "Tree",
+                    "value": 3,
+                    "category": "MODERATE",
+                },
+            }
+        )
+    )
+
+    assert entity.native_value == "Grass"
+    assert entity.extra_state_attributes["top_value"] == 5
+    assert entity.extra_state_attributes["tie_count"] == 1
+
+
+def test_top_pollen_types_today_returns_tied_names_and_attributes() -> None:
+    """Top pollen types summary keeps all tied current-day type winners."""
+
+    entity = sensor.TopPollenTypesTodaySensor(
+        _summary_coordinator(
+            {
+                "type_tree": {
+                    "source": "type",
+                    "code": "TREE",
+                    "displayName": "Tree",
+                    "value": 4,
+                    "category": "HIGH",
+                },
+                "type_grass": {
+                    "source": "type",
+                    "code": "GRASS",
+                    "displayName": "Grass",
+                    "value": 4,
+                    "category": "HIGH",
+                },
+                "type_weed": {
+                    "source": "type",
+                    "displayName": "Weed",
+                    "value": 1,
+                    "category": "LOW",
+                },
+            }
+        )
+    )
+
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == "Grass, Tree"
+    assert attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert attrs["top_value"] == 4
+    assert attrs["top_pollen_codes"] == ["GRASS", "TREE"]
+    assert attrs["top_pollen_names"] == ["Grass", "Tree"]
+    assert attrs["top_pollen_categories"] == ["HIGH", "HIGH"]
+    assert attrs["tie_count"] == 2
+
+
+def test_type_summary_sensors_return_none_without_valid_current_day_value() -> None:
+    """Type summaries are unknown when current-day type values are invalid."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "category": "LOW",
+            },
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": float("nan"),
+                "category": "HIGH",
+            },
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": "5",
+                "category": "VERY_HIGH",
+            },
+            "type_grass_d1": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass D+1",
+                "value": 5,
+                "category": "VERY_HIGH",
+            },
+        }
+    )
+
+    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
+    top = sensor.TopPollenTypesTodaySensor(coordinator)
+
+    risk_attrs = risk.extra_state_attributes
+    top_attrs = top.extra_state_attributes
+
+    assert risk.native_value is None
+    assert risk_attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert risk_attrs["category"] is None
+    assert risk_attrs["description"] is None
+    assert risk_attrs["top_pollen_codes"] == []
+    assert risk_attrs["top_pollen_names"] == []
+    assert risk_attrs["top_pollen_categories"] == []
+    assert risk_attrs["tie_count"] == 0
+    assert top.native_value is None
+    assert top_attrs[sensor.ATTR_ATTRIBUTION] == sensor.ATTRIBUTION
+    assert top_attrs["top_value"] is None
+    assert top_attrs["top_pollen_codes"] == []
+    assert top_attrs["top_pollen_names"] == []
+    assert top_attrs["top_pollen_categories"] == []
+    assert top_attrs["tie_count"] == 0
+
+
+def test_type_summary_sensors_ignore_per_day_entries() -> None:
+    """Current-day type summaries ignore D+1 and D+2 per-day sensors."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 2,
+                "category": "LOW",
+            },
+            "type_grass_d1": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass D+1",
+                "value": 5,
+                "category": "VERY_HIGH",
+            },
+            "type_tree_d2": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree D+2",
+                "value": 4,
+                "category": "HIGH",
+            },
+        }
+    )
+
+    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
+    top = sensor.TopPollenTypesTodaySensor(coordinator)
+
+    assert risk.native_value == 2
+    assert risk.extra_state_attributes["top_pollen_codes"] == ["GRASS"]
+    assert top.native_value == "Grass"
+    assert top.extra_state_attributes["top_pollen_codes"] == ["GRASS"]
+
+
+def test_summary_text_and_plant_count_sensors_have_no_measurement_state_class() -> None:
+    """Text and plant count summary sensors do not expose measurement state class."""
+
+    coordinator = _summary_coordinator({})
+
+    assert _state_class(sensor.TopPollenTypesTodaySensor(coordinator)) is None
+    assert _state_class(sensor.PlantsInSeasonTodaySensor(coordinator)) is None
 
 
 def test_coordinator_type_keys_are_deterministic_sorted() -> None:


### PR DESCRIPTION
### Motivation
- Provide convenient daily summary information (plants in season, overall pollen risk, and top pollen types) derived from existing coordinator data. 
- Align the integration and tooling with the upcoming Home Assistant baseline by raising the minimum supported Home Assistant version and Python runtime to `2026.3.0` / `>=3.14`. 
- Simplify CI to focus on the enforced Python baseline and tighten some defensive error handling and determinism across the integration.

### Description
- Added three daily summary sensors and supporting helpers in `custom_components/pollenlevels/sensor.py`: `PlantsInSeasonTodaySensor`, `OverallPollenRiskTodaySensor`, and `TopPollenTypesTodaySensor`, plus deterministic ordering and validation helpers. 
- Added unit tests covering the new summary sensors and related behavior in `tests/test_sensor.py`, and updated test stubs across `tests/` to match defensive exception handling. 
- Bumped package and integration metadata: `pyproject.toml` version to `2.1.0` and `requires-python = ">=3.14"`, `custom_components/pollenlevels/manifest.json` version to `2.1.0`, and `hacs.json` Home Assistant baseline to `2026.3.0`. 
- Updated CI workflow `/.github/workflows/tests.yml` to run on Python `3.14`, added translations for the new sensors, updated `README.md` and `CHANGELOG.md`, and applied minor defensive changes (uniform `except ... as _err`) and formatting adjustments.

### Testing
- Ran the test suite with `pytest -q`, including `tests/test_sensor.py`, `tests/test_init.py`, and `tests/test_config_flow.py`, and all tests completed successfully. 
- Verified the new summary sensor unit tests exercise counts, text summaries, tie handling, and ignore-per-day semantics, and they passed under the updated test harness. 
- Confirmed CI workflow simplified to a single Python runner for `3.14` as part of validation of the baseline change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc91a687248324ac732fdd1e79fa6f)