### PR TITLE
Add daily summary sensors for 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.0] - 2026-05-07
+### Added
+- Added daily summary sensors for plants in season, overall pollen risk, and top
+  pollen types.
+
 ## [2.0.0] - 2026-05-07
 ### Changed
 - **Breaking change:** Raised the minimum supported Home Assistant version to

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 
 - **Multi-language support** — UI in 21 languages (**EN, ES, CA, DE, FR, IT, PL, RU, UK, NL, ZH-Hans, SV, CS, PT-BR, DA, NB, PT-PT, RO, FI, HU, ZH-Hant**) + API responses in any language.
 - **Dynamic sensors** — Auto-creates sensors for all pollen types found in your location.  
+- **Daily summary sensors** — Adds plants in season today, overall pollen risk today, and top pollen types today.
 - **Multi-day forecast for TYPES & PLANTS** —
   - `forecast` list with `{offset, date, has_index, value, category, description, color_*}`
   - Convenience: `tomorrow_*` and `d2_*`

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.0.0"
+    "version": "2.1.0"
 }

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from collections.abc import Awaitable
 from datetime import date  # Added `date` for DATE device class native_value
 from enum import StrEnum
@@ -200,6 +201,14 @@ async def async_setup_entry(
 
     sensors.extend(
         [
+            PlantsInSeasonTodaySensor(coordinator),
+            OverallPollenRiskTodaySensor(coordinator),
+            TopPollenTypesTodaySensor(coordinator),
+        ]
+    )
+
+    sensors.extend(
+        [
             RegionSensor(coordinator),
             DateSensor(coordinator),
             LastUpdatedSensor(coordinator),
@@ -379,6 +388,236 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         }
 
 
+def _is_finite_number(value: Any) -> bool:
+    """Return whether value is a finite non-boolean number."""
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
+    """Return a deterministic uppercase code from API metadata or the data key."""
+    raw_code = info.get("code")
+    if isinstance(raw_code, str) and raw_code.strip():
+        return raw_code.strip().upper()
+
+    fallback = key
+    if fallback.startswith(prefix):
+        fallback = fallback[len(prefix) :]
+    fallback = fallback.split("_d", 1)[0]
+    return fallback.upper()
+
+
+def _current_day_plant_entries(
+    coordinator: PollenDataUpdateCoordinator,
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Collect current-day plant entries sorted by normalized plant code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, info in (coordinator.data or {}).items():
+        if not isinstance(info, dict) or info.get("source") != "plant":
+            continue
+        code = _normalize_entry_code(key, info, "plants_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def _current_day_type_entries(
+    coordinator: PollenDataUpdateCoordinator,
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Collect current-day pollen type entries sorted by normalized type code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, info in (coordinator.data or {}).items():
+        if key.endswith(("_d1", "_d2")):
+            continue
+        if not isinstance(info, dict) or info.get("source") != "type":
+            continue
+        if not _is_finite_number(info.get("value")):
+            continue
+        code = _normalize_entry_code(key, info, "type_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def _top_type_entries(
+    coordinator: PollenDataUpdateCoordinator,
+) -> tuple[float | int | None, list[tuple[str, str, str, dict[str, Any]]]]:
+    """Return the maximum current-day type value and all entries tied for it."""
+    entries = _current_day_type_entries(coordinator)
+    if not entries:
+        return None, []
+    top_value = max(info["value"] for _code, _name, _key, info in entries)
+    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
+    return top_value, top_entries
+
+
+class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
+    """Provide base behavior for daily summary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator, group: str) -> None:
+        """Initialize a summary sensor on an existing integration device group."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+
+        device_id = f"{self.coordinator.entry_id}_{group}"
+        translation_keys = {"type": "types", "plant": "plants"}
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device_id)},
+            "manufacturer": "Google",
+            "model": "Pollen API",
+            "translation_key": translation_keys[group],
+            "translation_placeholders": {
+                "title": self.coordinator.entry_title or DEFAULT_ENTRY_TITLE,
+                "latitude": f"{self.coordinator.lat:.6f}",
+                "longitude": f"{self.coordinator.lon:.6f}",
+            },
+        }
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose public attribution on all daily summary sensors."""
+        return {ATTR_ATTRIBUTION: ATTRIBUTION}
+
+
+class PlantsInSeasonTodaySensor(_BaseSummarySensor):
+    """Represent a count of plants explicitly marked in season today."""
+
+    _attr_translation_key = "plants_in_season_today"
+    _attr_icon = "mdi:sprout"
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
+        """Initialize the plants in season summary sensor."""
+        super().__init__(coordinator, "plant")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_plants_in_season_today"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number of plants explicitly marked in season today."""
+        entries = _current_day_plant_entries(self.coordinator)
+        in_season_count = sum(
+            1 for _code, _name, _key, info in entries if info.get("inSeason") is True
+        )
+        out_of_season_count = sum(
+            1 for _code, _name, _key, info in entries if info.get("inSeason") is False
+        )
+        if in_season_count + out_of_season_count == 0:
+            return None
+        return in_season_count
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return plant season summary attributes."""
+        attrs = super().extra_state_attributes
+        entries = _current_day_plant_entries(self.coordinator)
+        in_season_count = sum(
+            1 for _code, _name, _key, info in entries if info.get("inSeason") is True
+        )
+        out_of_season_count = sum(
+            1 for _code, _name, _key, info in entries if info.get("inSeason") is False
+        )
+        unknown_entries = [
+            (code, name)
+            for code, name, _key, info in entries
+            if not isinstance(info.get("inSeason"), bool)
+        ]
+        attrs.update(
+            {
+                "plant_codes": [code for code, _name, _key, _info in entries],
+                "plant_names": [name for _code, name, _key, _info in entries],
+                "in_season_count": in_season_count,
+                "out_of_season_count": out_of_season_count,
+                "unknown_season_count": len(unknown_entries),
+                "total_plant_count": len(entries),
+                "unknown_season_codes": [code for code, _name in unknown_entries],
+                "unknown_season_names": [name for _code, name in unknown_entries],
+            }
+        )
+        return attrs
+
+
+class OverallPollenRiskTodaySensor(_BaseSummarySensor):
+    """Represent the highest current-day pollen type value."""
+
+    _attr_translation_key = "overall_pollen_risk_today"
+    _attr_icon = DEFAULT_ICON
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0  # type: ignore[assignment]
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
+        """Initialize the overall pollen risk summary sensor."""
+        super().__init__(coordinator, "type")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_overall_pollen_risk_today"
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the maximum valid current-day pollen type value."""
+        top_value, _top_entries = _top_type_entries(self.coordinator)
+        return top_value
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return overall pollen risk summary attributes."""
+        attrs = super().extra_state_attributes
+        _top_value, top_entries = _top_type_entries(self.coordinator)
+        first_info = top_entries[0][3] if top_entries else {}
+        attrs.update(
+            {
+                "category": first_info.get("category"),
+                "description": first_info.get("description"),
+                "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+                "top_pollen_names": [name for _code, name, _key, _info in top_entries],
+                "top_pollen_categories": [
+                    info.get("category") for _code, _name, _key, info in top_entries
+                ],
+                "tie_count": len(top_entries),
+            }
+        )
+        return attrs
+
+
+class TopPollenTypesTodaySensor(_BaseSummarySensor):
+    """Represent the display names of the top current-day pollen types."""
+
+    _attr_translation_key = "top_pollen_types_today"
+    _attr_icon = DEFAULT_ICON
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
+        """Initialize the top pollen types summary sensor."""
+        super().__init__(coordinator, "type")
+        self._attr_unique_id = f"{self.coordinator.entry_id}_top_pollen_types_today"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the top pollen type names, preserving ties."""
+        _top_value, top_entries = _top_type_entries(self.coordinator)
+        if not top_entries:
+            return None
+        return ", ".join(name for _code, name, _key, _info in top_entries)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return top pollen type summary attributes."""
+        attrs = super().extra_state_attributes
+        top_value, top_entries = _top_type_entries(self.coordinator)
+        attrs.update(
+            {
+                "top_value": top_value,
+                "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+                "top_pollen_names": [name for _code, name, _key, _info in top_entries],
+                "top_pollen_categories": [
+                    info.get("category") for _code, _name, _key, info in top_entries
+                ],
+                "tie_count": len(top_entries),
+            }
+        )
+        return attrs
+
+
 class _BaseMetaSensor(CoordinatorEntity, SensorEntity):
     """Provide base for metadata sensors."""
 
@@ -462,7 +701,7 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -525,10 +525,15 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
             for code, name, _key, info in entries
             if not isinstance(info.get("inSeason"), bool)
         ]
+        in_season_entries = [
+            (code, name)
+            for code, name, _key, info in entries
+            if info.get("inSeason") is True
+        ]
         attrs.update(
             {
-                "plant_codes": [code for code, _name, _key, _info in entries],
-                "plant_names": [name for _code, name, _key, _info in entries],
+                "plant_codes": [code for code, _name in in_season_entries],
+                "plant_names": [name for _code, name in in_season_entries],
                 "in_season_count": in_season_count,
                 "out_of_season_count": out_of_season_count,
                 "unknown_season_count": len(unknown_entries),
@@ -701,7 +706,9 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except ValueError, TypeError:
+        # fmt: off
+        except (ValueError, TypeError):
+            # fmt: on
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última actualització"
+      },
+      "plants_in_season_today": {
+        "name": "Plantes en temporada avui"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risc general de pol·len avui"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipus de pol·len principals avui"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Poslední aktualizace"
+      },
+      "plants_in_season_today": {
+        "name": "Rostliny dnes v sezóně"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Celkové riziko pylu dnes"
+      },
+      "top_pollen_types_today": {
+        "name": "Hlavní typy pylu dnes"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Sidst opdateret"
+      },
+      "plants_in_season_today": {
+        "name": "Planter i sæson i dag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Samlet pollenrisiko i dag"
+      },
+      "top_pollen_types_today": {
+        "name": "Vigtigste pollentyper i dag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Letzte Aktualisierung"
+      },
+      "plants_in_season_today": {
+        "name": "Pflanzen heute in Saison"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Gesamtes Pollenrisiko heute"
+      },
+      "top_pollen_types_today": {
+        "name": "Wichtigste Pollenarten heute"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Last Updated"
+      },
+      "plants_in_season_today": {
+        "name": "Plants in season today"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Overall pollen risk today"
+      },
+      "top_pollen_types_today": {
+        "name": "Top pollen types today"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última actualización"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas en temporada hoy"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Riesgo general de polen hoy"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipos de polen principales hoy"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Viimeksi päivitetty"
+      },
+      "plants_in_season_today": {
+        "name": "Tänään kaudella olevat kasvit"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Yleinen siitepölyriski tänään"
+      },
+      "top_pollen_types_today": {
+        "name": "Tärkeimmät siitepölytyypit tänään"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Dernière mise à jour"
+      },
+      "plants_in_season_today": {
+        "name": "Plantes en saison aujourd’hui"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risque pollinique global aujourd’hui"
+      },
+      "top_pollen_types_today": {
+        "name": "Principaux types de pollen aujourd’hui"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Utoljára frissítve"
+      },
+      "plants_in_season_today": {
+        "name": "Ma szezonban lévő növények"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Általános pollenkockázat ma"
+      },
+      "top_pollen_types_today": {
+        "name": "Mai fő pollentípusok"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ultimo aggiornamento"
+      },
+      "plants_in_season_today": {
+        "name": "Piante in stagione oggi"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Rischio pollinico complessivo oggi"
+      },
+      "top_pollen_types_today": {
+        "name": "Tipi di polline principali oggi"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Sist oppdatert"
+      },
+      "plants_in_season_today": {
+        "name": "Planter i sesong i dag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Samlet pollenrisiko i dag"
+      },
+      "top_pollen_types_today": {
+        "name": "Viktigste pollentyper i dag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Laatst bijgewerkt"
+      },
+      "plants_in_season_today": {
+        "name": "Planten vandaag in het seizoen"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Algemeen pollenrisico vandaag"
+      },
+      "top_pollen_types_today": {
+        "name": "Belangrijkste pollentypen vandaag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ostatnia aktualizacja"
+      },
+      "plants_in_season_today": {
+        "name": "Rośliny w sezonie dzisiaj"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Ogólne ryzyko pyłkowe dzisiaj"
+      },
+      "top_pollen_types_today": {
+        "name": "Główne typy pyłków dzisiaj"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última atualização"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas na estação hoje"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risco geral de pólen hoje"
+      },
+      "top_pollen_types_today": {
+        "name": "Principais tipos de pólen hoje"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Última atualização"
+      },
+      "plants_in_season_today": {
+        "name": "Plantas na época hoje"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risco geral de pólen hoje"
+      },
+      "top_pollen_types_today": {
+        "name": "Principais tipos de pólen hoje"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Ultima actualizare"
+      },
+      "plants_in_season_today": {
+        "name": "Plante în sezon astăzi"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Risc general de polen astăzi"
+      },
+      "top_pollen_types_today": {
+        "name": "Principalele tipuri de polen astăzi"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Последнее обновление"
+      },
+      "plants_in_season_today": {
+        "name": "Растения в сезоне сегодня"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Общий риск пыльцы сегодня"
+      },
+      "top_pollen_types_today": {
+        "name": "Основные типы пыльцы сегодня"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Senaste uppdatering"
+      },
+      "plants_in_season_today": {
+        "name": "Växter i säsong idag"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Övergripande pollenrisk idag"
+      },
+      "top_pollen_types_today": {
+        "name": "Viktigaste pollentyperna idag"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "Останнє оновлення"
+      },
+      "plants_in_season_today": {
+        "name": "Рослини в сезоні сьогодні"
+      },
+      "overall_pollen_risk_today": {
+        "name": "Загальний ризик пилку сьогодні"
+      },
+      "top_pollen_types_today": {
+        "name": "Основні типи пилку сьогодні"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "上次更新时间"
+      },
+      "plants_in_season_today": {
+        "name": "今日应季植物"
+      },
+      "overall_pollen_risk_today": {
+        "name": "今日总体花粉风险"
+      },
+      "top_pollen_types_today": {
+        "name": "今日主要花粉类型"
       }
     }
   }

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -98,6 +98,15 @@
       },
       "last_updated": {
         "name": "上次更新時間"
+      },
+      "plants_in_season_today": {
+        "name": "今日應季植物"
+      },
+      "overall_pollen_risk_today": {
+        "name": "今日整體花粉風險"
+      },
+      "top_pollen_types_today": {
+        "name": "今日主要花粉類型"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.0.0"
+version = "2.1.0"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -90,6 +90,18 @@ exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
 exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
 sys.modules.setdefault("homeassistant.exceptions", exceptions_mod)
 
+config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+
+class _StubConfigEntry:
+    @classmethod
+    def __class_getitem__(cls, _item):
+        return cls
+
+
+config_entries_mod.ConfigEntry = _StubConfigEntry
+sys.modules.setdefault("homeassistant.config_entries", config_entries_mod)
+
 helpers_mod = types.ModuleType("homeassistant.helpers")
 sys.modules.setdefault("homeassistant.helpers", helpers_mod)
 
@@ -206,7 +218,9 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except (TypeError, ValueError, IndexError):
+    except (TypeError, ValueError, IndexError) as err:
+        if err.args is not None:
+            return None
         return None
 
     if parsed is None:
@@ -423,6 +437,285 @@ def _setup_registry_stub(
     )
 
     return registry
+
+
+def _summary_coordinator(data: dict[str, Any]):
+    """Build a minimal coordinator-like object for summary sensor tests."""
+    return types.SimpleNamespace(
+        data=data,
+        entry_id="entry",
+        entry_title="Home",
+        lat=1.0,
+        lon=2.0,
+    )
+
+
+def test_plants_in_season_counts_mixed_boolean_and_unknown_values() -> None:
+    """Plants in season counts True/False and treats missing/non-boolean as unknown."""
+
+    coordinator = _summary_coordinator(
+        {
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+            "plants_pine": {
+                "source": "plant",
+                "code": "PINE",
+                "displayName": "Pine",
+                "inSeason": False,
+            },
+            "plants_birch": {
+                "source": "plant",
+                "displayName": "Birch",
+            },
+            "plants_elm": {
+                "source": "plant",
+                "displayName": "Elm",
+                "inSeason": "yes",
+            },
+        }
+    )
+
+    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == 1
+    assert attrs["plant_codes"] == ["BIRCH", "ELM", "OAK", "PINE"]
+    assert attrs["plant_names"] == ["Birch", "Elm", "Oak", "Pine"]
+    assert attrs["in_season_count"] == 1
+    assert attrs["out_of_season_count"] == 1
+    assert attrs["unknown_season_count"] == 2
+    assert attrs["total_plant_count"] == 4
+    assert attrs["unknown_season_codes"] == ["BIRCH", "ELM"]
+    assert attrs["unknown_season_names"] == ["Birch", "Elm"]
+
+
+def test_plants_in_season_returns_none_without_boolean_season_data() -> None:
+    """Plants in season returns None when plant entries lack explicit booleans."""
+
+    coordinator = _summary_coordinator(
+        {
+            "plants_oak": {"source": "plant", "displayName": "Oak"},
+            "plants_pine": {
+                "source": "plant",
+                "displayName": "Pine",
+                "inSeason": "false",
+            },
+        }
+    )
+
+    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+
+    assert entity.native_value is None
+    assert entity.extra_state_attributes["unknown_season_count"] == 2
+
+
+def test_plants_in_season_returns_none_without_plant_entries() -> None:
+    """Plants in season returns None when coordinator data has no plant entries."""
+
+    coordinator = _summary_coordinator(
+        {"type_grass": {"source": "type", "displayName": "Grass", "value": 2}}
+    )
+
+    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+
+    assert entity.native_value is None
+    assert entity.extra_state_attributes["total_plant_count"] == 0
+
+
+def test_overall_pollen_risk_returns_max_current_day_type_value() -> None:
+    """Overall pollen risk returns the maximum valid current-day type index."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": 3,
+                "category": "Moderate",
+                "description": "Moderate risk",
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 5,
+                "category": "High",
+                "description": "High risk",
+            },
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": None,
+            },
+        }
+    )
+
+    entity = sensor.OverallPollenRiskTodaySensor(coordinator)
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == 5
+    assert attrs["category"] == "High"
+    assert attrs["description"] == "High risk"
+    assert attrs["top_pollen_codes"] == ["GRASS"]
+    assert attrs["top_pollen_names"] == ["Grass"]
+    assert attrs["tie_count"] == 1
+
+
+def test_top_pollen_types_returns_single_winner_name() -> None:
+    """Top pollen types returns one display name when there is a single winner."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_tree": {"source": "type", "displayName": "Tree", "value": 2},
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 4},
+        }
+    )
+
+    entity = sensor.TopPollenTypesTodaySensor(coordinator)
+
+    assert entity.native_value == "Grass"
+    assert entity.extra_state_attributes["top_value"] == 4
+
+
+def test_top_pollen_types_returns_tied_names_and_attributes() -> None:
+    """Top pollen types preserves all tied top values in state and attributes."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": 4,
+                "category": "High",
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 4,
+                "category": "High",
+            },
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": 1,
+                "category": "Low",
+            },
+        }
+    )
+
+    entity = sensor.TopPollenTypesTodaySensor(coordinator)
+    attrs = entity.extra_state_attributes
+
+    assert entity.native_value == "Grass, Weed"
+    assert attrs["top_value"] == 4
+    assert attrs["top_pollen_codes"] == ["GRASS", "WEED"]
+    assert attrs["top_pollen_names"] == ["Grass", "Weed"]
+    assert attrs["top_pollen_categories"] == ["High", "High"]
+    assert attrs["tie_count"] == 2
+
+
+def test_type_summary_sensors_ignore_per_day_d1_d2_values() -> None:
+    """Summary sensors ignore D+1 and D+2 per-day type sensors."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 2},
+            "type_grass_d1": {
+                "source": "type",
+                "displayName": "Grass D+1",
+                "value": 5,
+            },
+            "type_grass_d2": {
+                "source": "type",
+                "displayName": "Grass D+2",
+                "value": 6,
+            },
+        }
+    )
+
+    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
+    top = sensor.TopPollenTypesTodaySensor(coordinator)
+
+    assert risk.native_value == 2
+    assert risk.extra_state_attributes["top_pollen_names"] == ["Grass"]
+    assert top.native_value == "Grass"
+
+
+def test_summary_fallback_codes_are_uppercase_from_data_keys() -> None:
+    """Fallback summary codes from type_/plants_ keys are exposed uppercase."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 3},
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+        }
+    )
+
+    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
+    plants = sensor.PlantsInSeasonTodaySensor(coordinator)
+
+    assert risk.extra_state_attributes["top_pollen_codes"] == ["GRASS"]
+    assert plants.extra_state_attributes["plant_codes"] == ["OAK"]
+
+
+def test_summary_sensors_expose_attribution() -> None:
+    """Summary sensors expose attribution attributes."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 3},
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+        }
+    )
+
+    entities = [
+        sensor.PlantsInSeasonTodaySensor(coordinator),
+        sensor.OverallPollenRiskTodaySensor(coordinator),
+        sensor.TopPollenTypesTodaySensor(coordinator),
+    ]
+
+    assert all(
+        entity.extra_state_attributes["Attribution"] == sensor.ATTRIBUTION
+        for entity in entities
+    )
+
+
+def test_top_pollen_types_today_does_not_expose_measurement_state_class() -> None:
+    """Top pollen types summary is textual and does not expose measurement state."""
+
+    entity = sensor.TopPollenTypesTodaySensor(_summary_coordinator({}))
+
+    assert (
+        getattr(entity, "_attr_state_class", None)
+        != sensor.SensorStateClass.MEASUREMENT
+    )
+
+
+def test_plants_in_season_today_does_not_expose_measurement_state_class() -> None:
+    """Plants in season summary count does not expose measurement state."""
+
+    entity = sensor.PlantsInSeasonTodaySensor(_summary_coordinator({}))
+
+    assert (
+        getattr(entity, "_attr_state_class", None)
+        != sensor.SensorStateClass.MEASUREMENT
+    )
 
 
 def test_type_sensor_preserves_source_with_single_day(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -218,9 +218,9 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except (TypeError, ValueError, IndexError) as err:
-        if err.args is not None:
-            return None
+    # fmt: off
+    except (TypeError, ValueError, IndexError):
+        # fmt: on
         return None
 
     if parsed is None:
@@ -482,8 +482,8 @@ def test_plants_in_season_counts_mixed_boolean_and_unknown_values() -> None:
     attrs = entity.extra_state_attributes
 
     assert entity.native_value == 1
-    assert attrs["plant_codes"] == ["BIRCH", "ELM", "OAK", "PINE"]
-    assert attrs["plant_names"] == ["Birch", "Elm", "Oak", "Pine"]
+    assert attrs["plant_codes"] == ["OAK"]
+    assert attrs["plant_names"] == ["Oak"]
     assert attrs["in_season_count"] == 1
     assert attrs["out_of_season_count"] == 1
     assert attrs["unknown_season_count"] == 2


### PR DESCRIPTION
### Motivation

- Provide concise daily summary entities so users can quickly see plants in season, the overall pollen risk, and the top pollen types for the current day without scanning many dynamic sensors.
- Keep the existing coordinator-driven architecture and device grouping while adding explicit, stable sensors, not dynamic `PollenSensor` instances, for predictable unique IDs and translation keys.
- Prepare this feature as the next minor release after the 2.0.0 Home Assistant 2026.3 / Python 3.14 baseline.

### Description

- Added three explicit daily summary sensor classes in `custom_components/pollenlevels/sensor.py`:
  - `PlantsInSeasonTodaySensor`
  - `OverallPollenRiskTodaySensor`
  - `TopPollenTypesTodaySensor`
- Wired the new summary sensors into `async_setup_entry()` after regular pollen sensors and before metadata sensors.
- Added deterministic private helpers for:
  - finite numeric value checks
  - fallback code normalization
  - current-day plant entry collection
  - current-day pollen type entry collection
  - top pollen type tie handling
- Kept the new summary sensors separate from dynamic `PollenSensor` creation so textual/count summaries do not inherit index-oriented behavior accidentally.
- Preserved existing coordinator parsing, API fetching, config flow, options flow, diagnostics, services, workflows, and HACS baseline.
- Added stable unique IDs:
  - `{entry_id}_plants_in_season_today`
  - `{entry_id}_overall_pollen_risk_today`
  - `{entry_id}_top_pollen_types_today`
- Added translation keys and localized names for all bundled locales.
- Updated `README.md` with a concise mention of the new daily summary sensors.
- Added a `2.1.0` changelog entry.
- Bumped package/integration version from `2.0.0` to `2.1.0` in:
  - `custom_components/pollenlevels/manifest.json`
  - `pyproject.toml`

### Sensor behavior

#### `plants_in_season_today`

- Uses current-day plant entries from existing coordinator data.
- Counts only plants where `inSeason is True` as in season.
- Counts plants where `inSeason is False` as out of season.
- Treats missing or non-boolean `inSeason` as unknown, not false.
- Returns `None` when no plant has explicit boolean season data.
- Exposes in-season plant codes/names plus out-of-season, unknown, and total counts.

#### `overall_pollen_risk_today`

- Uses current-day pollen type entries only.
- Ignores `_d1` and `_d2` per-day type sensors.
- Ignores missing, invalid, non-finite, and boolean values.
- Returns the highest valid current-day pollen type index.
- Preserves ties in attributes instead of choosing an arbitrary winner.

#### `top_pollen_types_today`

- Uses the same current-day pollen type data as `overall_pollen_risk_today`.
- Returns the top pollen type display name.
- If multiple pollen types share the top value, returns their names joined by `", "`.
- Preserves all tied type codes, names, categories, and tie count in attributes.
- Does not expose `SensorStateClass.MEASUREMENT` because its state is textual.

### Scope notes

- This PR targets `2.1.0`.
- The `2.0.0` Home Assistant 2026.3 / Python 3.14 baseline is already in `main` and is not part of this PR.
- No changes were made to:
  - `hacs.json`
  - GitHub workflows
  - `AGENTS.md`
  - `config_flow.py`
  - `coordinator.py`
  - `client.py`
  - `diagnostics.py`
  - `util.py`
- No new options, binary sensors, advice summaries, top plant ranking, or forecast summary sensors were added.

### Testing

- `pytest -q tests/test_sensor.py` — passed.
- `pytest -q tests/test_translations.py` — passed.
- `pytest -q` — passed.
- `ruff check .` — passed.
- `black --check .` — passed in CI.
- GitHub Actions passed:
  - tests
  - Lint
  - hassfest
  - HACS validation