### PR TITLE
Document daily summary sensors and add setup coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,29 @@ Go to **Settings → Devices & Services → Pollen Levels → Configure**.
 
 ---
 
+## Daily summary sensors
+
+The integration creates three current-day summary sensors in addition to the
+individual pollen type and plant sensors:
+
+- `plants_in_season_today`
+  - State: number of plants explicitly marked as in season today.
+  - Key attributes: `plant_codes`, `plant_names`, `in_season_count`,
+    `out_of_season_count`, `unknown_season_count`, `total_plant_count`,
+    `unknown_season_codes`, and `unknown_season_names`.
+  - Missing or non-boolean `inSeason` values are treated as unknown, not false.
+- `overall_pollen_risk_today`
+  - State: highest current-day pollen type index value.
+  - Key attributes: `category`, `description`, `top_pollen_codes`,
+    `top_pollen_names`, `top_pollen_categories`, and `tie_count`.
+  - Tied top pollen types are preserved in the attributes.
+- `top_pollen_types_today`
+  - State: top pollen type name, or comma-separated names when tied.
+  - Key attributes: `top_value`, `top_pollen_codes`, `top_pollen_names`,
+    `top_pollen_categories`, and `tie_count`.
+
+---
+
 ## 🗝️ Getting a Google API Key
 
 You need a valid Google Cloud API key with access to the **Maps Pollen API**.
@@ -139,7 +162,7 @@ entities:
     entity: sensor.type_grass
     attribute: description
     name: Index description
-````
+```
 
 > Simple and robust. It shows attributes clearly but **doesn’t color** the icon.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2197,6 +2197,73 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
+    """Setup creates the three daily summary sensors."""
+
+    entry_id = "summary_entry"
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={
+            sensor.CONF_API_KEY: "key",
+            sensor.CONF_LATITUDE: 1.0,
+            sensor.CONF_LONGITUDE: 2.0,
+            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+        },
+        entry_id=entry_id,
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "date": {"source": "meta", "value": "2026-05-08"},
+            "region": {"source": "meta", "value": "us_ca_san_francisco"},
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+            },
+            "plants_oak": {
+                "source": "plant",
+                "code": "OAK",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+        },
+        entry_id=entry_id,
+        entry_title="Home",
+        lat=1.0,
+        lon=2.0,
+        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        create_d1=False,
+        create_d2=False,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+        coordinator=coordinator, client=object()
+    )
+
+    captured: list[Any] = []
+
+    def _capture_entities(entities, _update_before_add=False):
+        captured.extend(entities)
+
+    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    unique_ids = {
+        entity.unique_id
+        for entity in captured
+        if getattr(entity, "unique_id", None) is not None
+    }
+
+    assert {
+        f"{entry_id}_plants_in_season_today",
+        f"{entry_id}_overall_pollen_risk_today",
+        f"{entry_id}_top_pollen_types_today",
+    }.issubset(unique_ids)
+
+
+@pytest.mark.asyncio
 async def test_device_info_uses_default_title_when_blank(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Add a small hardening/docs change before finalizing the 2.1.0 release to ensure the three daily summary sensors are created by `async_setup_entry()` and that their behavior and attributes are documented. 
- Provide deterministic unit test coverage for setup behavior so regressions in entity creation are caught early. 

### Description
- Added an async test `test_async_setup_entry_adds_daily_summary_sensors` to `tests/test_sensor.py` that constructs a fake config entry and coordinator-like `runtime_data`, calls `sensor.async_setup_entry(...)`, captures the created entities, and asserts the three summary unique IDs are present. 
- Added a concise `Daily summary sensors` section to `README.md` documenting `plants_in_season_today`, `overall_pollen_risk_today`, and `top_pollen_types_today` with states, key attributes, and notes about non-boolean `inSeason` handling and tie preservation, and fixed a mismatched Markdown fence in the YAML example. 
- Files changed: `tests/test_sensor.py`, `README.md`. 
- Runtime behavior is unchanged; no sensor definitions, unique IDs, or integration behavior were modified. 

### Testing
- Ran `ruff check --fix --select I tests/test_sensor.py README.md` which passed with `All checks passed!`. 
- Ran `black tests/test_sensor.py` which reported `1 file left unchanged.`. 
- Ran `pytest -q tests/test_sensor.py` which passed with `49 passed in 0.29s`. 
- Ran `pytest -q` which passed with `171 passed in 0.76s`. 
- Ran `ruff check .` which passed with `All checks passed!`. 
- Ran `black --check .` which reported unrelated pre-existing formatting issues outside the allowed scope (would reformat several files in `custom_components/pollenlevels` and a couple of test files), and therefore those files were not modified as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd751c67b48324b356462a09a0affb)