### PR TITLE
Add daily summary diagnostics

### DIFF
--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -4,6 +4,7 @@ This exposes non-sensitive runtime details useful for support:
 - Entry data/options (with API key and location redacted)
 - Coordinator snapshot (last_updated, forecast_days, language, flags)
 - Forecast summaries for TYPES & PLANTS (attributes-only for plants)
+- Daily summary sensor snapshot derived from coordinator data
 - A sample of the request params with the API key redacted
 
 No network I/O is performed.
@@ -41,12 +42,139 @@ TO_REDACT = {
 }
 
 
-def _iso_or_none(dt_obj) -> str | None:
+def _iso_or_none(dt_obj: Any) -> str | None:
     """Return UTC ISO8601 string for datetimes, else None."""
     try:
         return dt_obj.isoformat() if dt_obj is not None else None
     except Exception:
         return None
+
+
+def _is_finite_number(value: Any) -> bool:
+    """Return whether value is a finite non-boolean number."""
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
+    """Return a deterministic uppercase code from API metadata or the data key."""
+    raw_code = info.get("code")
+    if isinstance(raw_code, str) and raw_code.strip():
+        return raw_code.strip().upper()
+
+    fallback = key
+    if fallback.startswith(prefix):
+        fallback = fallback[len(prefix) :]
+    fallback = fallback.split("_d", 1)[0]
+    return fallback.upper()
+
+
+def _current_day_plant_entries(
+    data_map: dict[str, Any],
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Collect current-day plant entries sorted by normalized plant code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, info in data_map.items():
+        if not isinstance(info, dict) or info.get("source") != "plant":
+            continue
+        code = _normalize_entry_code(key, info, "plants_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def _current_day_type_entries(
+    data_map: dict[str, Any],
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Collect current-day pollen type entries sorted by normalized type code."""
+    entries: list[tuple[str, str, str, dict[str, Any]]] = []
+    for key, info in data_map.items():
+        if key.endswith(("_d1", "_d2")):
+            continue
+        if not isinstance(info, dict) or info.get("source") != "type":
+            continue
+        if not _is_finite_number(info.get("value")):
+            continue
+        code = _normalize_entry_code(key, info, "type_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def _top_type_entries(
+    data_map: dict[str, Any],
+) -> tuple[float | int | None, list[tuple[str, str, str, dict[str, Any]]]]:
+    """Return the maximum current-day type value and all entries tied for it."""
+    entries = _current_day_type_entries(data_map)
+    if not entries:
+        return None, []
+    top_value = max(info["value"] for _code, _name, _key, info in entries)
+    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
+    return top_value, top_entries
+
+
+def _daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
+    """Return diagnostics mirroring the three daily summary sensor payloads."""
+    plant_entries = _current_day_plant_entries(data_map)
+    in_season_entries = [
+        (code, name)
+        for code, name, _key, info in plant_entries
+        if info.get("inSeason") is True
+    ]
+    out_of_season_count = sum(
+        1 for _code, _name, _key, info in plant_entries if info.get("inSeason") is False
+    )
+    unknown_entries = [
+        (code, name)
+        for code, name, _key, info in plant_entries
+        if not isinstance(info.get("inSeason"), bool)
+    ]
+    in_season_count = len(in_season_entries)
+    season_state = (
+        in_season_count if in_season_count + out_of_season_count > 0 else None
+    )
+
+    top_value, top_entries = _top_type_entries(data_map)
+    top_names = [name for _code, name, _key, _info in top_entries]
+    first_info = top_entries[0][3] if top_entries else {}
+
+    return {
+        "plants_in_season_today": {
+            "state": season_state,
+            "plant_codes": [code for code, _name in in_season_entries],
+            "plant_names": [name for _code, name in in_season_entries],
+            "in_season_count": in_season_count,
+            "out_of_season_count": out_of_season_count,
+            "unknown_season_count": len(unknown_entries),
+            "total_plant_count": len(plant_entries),
+            "unknown_season_codes": [code for code, _name in unknown_entries],
+            "unknown_season_names": [name for _code, name in unknown_entries],
+        },
+        "overall_pollen_risk_today": {
+            "state": top_value,
+            "category": first_info.get("category"),
+            "description": first_info.get("description"),
+            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_names": top_names,
+            "top_pollen_categories": [
+                info.get("category") for _code, _name, _key, info in top_entries
+            ],
+            "tie_count": len(top_entries),
+        },
+        "top_pollen_types_today": {
+            "state": ", ".join(top_names) if top_names else None,
+            "top_value": top_value,
+            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_names": top_names,
+            "top_pollen_categories": [
+                info.get("category") for _code, _name, _key, info in top_entries
+            ],
+            "tie_count": len(top_entries),
+        },
+    }
 
 
 async def async_get_config_entry_diagnostics(
@@ -66,7 +194,7 @@ async def async_get_config_entry_diagnostics(
     def _rounded(value: Any) -> float | None:
         try:
             f = float(value)
-        except (TypeError, ValueError, OverflowError):
+        except TypeError, ValueError, OverflowError:
             return None
         if not math.isfinite(f):
             return None
@@ -108,6 +236,7 @@ async def async_get_config_entry_diagnostics(
     # --- Coordinator snapshot ------------------------------------------------
     coord_info: dict[str, Any] = {}
     forecast_summary: dict[str, Any] = {}
+    daily_summary: dict[str, Any] = {}
     if coordinator is not None:
         # Base coordinator info
         coord_info = {
@@ -126,6 +255,7 @@ async def async_get_config_entry_diagnostics(
 
         # ---------- Forecast summaries (TYPES & PLANTS) ----------
         data_map: dict[str, Any] = getattr(coordinator, "data", {}) or {}
+        daily_summary = _daily_summary(data_map)
 
         # TYPES (main vs per-day)
         type_main_keys = [
@@ -195,6 +325,7 @@ async def async_get_config_entry_diagnostics(
         "approximate_location": approx_location,
         "coordinator": coord_info,
         "forecast_summary": forecast_summary,
+        "daily_summary": daily_summary,
         "request_params_example": params_example,
     }
 

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -194,7 +194,11 @@ async def async_get_config_entry_diagnostics(
     def _rounded(value: Any) -> float | None:
         try:
             f = float(value)
-        except TypeError, ValueError, OverflowError:
+        except TypeError:
+            return None
+        except ValueError:
+            return None
+        except OverflowError:
             return None
         if not math.isfinite(f):
             return None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import sys
+from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
@@ -67,6 +68,12 @@ class _HomeAssistant:
 
 core_mod.HomeAssistant = _HomeAssistant
 _force_module("homeassistant.core", core_mod)
+
+pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
+pollenlevels_pkg.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels")
+]
+_force_module("custom_components.pollenlevels", pollenlevels_pkg)
 
 from custom_components.pollenlevels import diagnostics as diag  # noqa: E402
 from custom_components.pollenlevels.const import (  # noqa: E402
@@ -193,3 +200,136 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples() -> No
     assert diagnostics["approximate_location"]["longitude_rounded"] is None
     assert diagnostics["request_params_example"]["location.latitude"] is None
     assert diagnostics["request_params_example"]["location.longitude"] is None
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_includes_daily_summary_sensor_snapshot() -> None:
+    """Diagnostics should summarize the daily summary sensors from coordinator data."""
+
+    data = {
+        CONF_LATITUDE: 12.3,
+        CONF_LONGITUDE: 45.6,
+        CONF_LANGUAGE_CODE: "en",
+    }
+    options = {CONF_FORECAST_DAYS: 3}
+
+    entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
+
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        forecast_days=3,
+        language="en",
+        create_d1=True,
+        create_d2=True,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        data={
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+            "plants_pine": {
+                "source": "plant",
+                "code": "PINE",
+                "displayName": "Pine",
+                "inSeason": False,
+            },
+            "plants_birch": {"source": "plant", "displayName": "Birch"},
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 5,
+                "category": "High",
+                "description": "High risk",
+            },
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": 5,
+                "category": "High",
+            },
+            "type_tree": {
+                "source": "type",
+                "displayName": "Tree",
+                "value": 2,
+                "category": "Low",
+            },
+            "type_grass_d1": {
+                "source": "type",
+                "displayName": "Grass tomorrow",
+                "value": 6,
+                "category": "Very High",
+            },
+            "type_mold": {
+                "source": "type",
+                "displayName": "Mold",
+                "value": float("nan"),
+            },
+        },
+    )
+    entry.runtime_data = PollenLevelsRuntimeData(
+        coordinator=coordinator, client=object()
+    )
+
+    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+
+    daily_summary = diagnostics["daily_summary"]
+    assert daily_summary["plants_in_season_today"] == {
+        "state": 1,
+        "plant_codes": ["OAK"],
+        "plant_names": ["Oak"],
+        "in_season_count": 1,
+        "out_of_season_count": 1,
+        "unknown_season_count": 1,
+        "total_plant_count": 3,
+        "unknown_season_codes": ["BIRCH"],
+        "unknown_season_names": ["Birch"],
+    }
+    assert daily_summary["overall_pollen_risk_today"] == {
+        "state": 5,
+        "category": "High",
+        "description": "High risk",
+        "top_pollen_codes": ["GRASS", "WEED"],
+        "top_pollen_names": ["Grass", "Weed"],
+        "top_pollen_categories": ["High", "High"],
+        "tie_count": 2,
+    }
+    assert daily_summary["top_pollen_types_today"] == {
+        "state": "Grass, Weed",
+        "top_value": 5,
+        "top_pollen_codes": ["GRASS", "WEED"],
+        "top_pollen_names": ["Grass", "Weed"],
+        "top_pollen_categories": ["High", "High"],
+        "tie_count": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_daily_summary_uses_empty_states_without_data() -> None:
+    """Diagnostics daily summary should be present even without coordinator data."""
+
+    entry = _ConfigEntry(data={}, options={}, entry_id="entry", title="Home")
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        forecast_days=1,
+        language=None,
+        create_d1=False,
+        create_d2=False,
+        last_updated=None,
+        data={},
+    )
+    entry.runtime_data = PollenLevelsRuntimeData(
+        coordinator=coordinator, client=object()
+    )
+
+    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+
+    daily_summary = diagnostics["daily_summary"]
+    assert daily_summary["plants_in_season_today"]["state"] is None
+    assert daily_summary["plants_in_season_today"]["total_plant_count"] == 0
+    assert daily_summary["overall_pollen_risk_today"]["state"] is None
+    assert daily_summary["overall_pollen_risk_today"]["tie_count"] == 0
+    assert daily_summary["top_pollen_types_today"]["state"] is None
+    assert daily_summary["top_pollen_types_today"]["tie_count"] == 0

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -69,6 +69,12 @@ class _HomeAssistant:
 core_mod.HomeAssistant = _HomeAssistant
 _force_module("homeassistant.core", core_mod)
 
+custom_components_pkg = ModuleType("custom_components")
+custom_components_pkg.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "custom_components")
+]
+_force_module("custom_components", custom_components_pkg)
+
 pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
 pollenlevels_pkg.__path__ = [
     str(Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels")


### PR DESCRIPTION
### Motivation
- Provide a concise, non-sensitive diagnostics snapshot that mirrors the three daily summary sensors (`plants_in_season_today`, `overall_pollen_risk_today`, `top_pollen_types_today`) so support dumps show what the integration would expose without requiring users to inspect entities manually.

### Description
- Add helper extraction functions to `custom_components/pollenlevels/diagnostics.py` to compute current-day plant/type entries, normalize fallback codes, filter non-finite values and exclude D+1/D+2 type entries. 
- Add `_daily_summary()` which produces a `daily_summary` dict with the three sensor-like payloads (states and attributes) derived from the coordinator `data` map. 
- Expose the new `daily_summary` top-level key from `async_get_config_entry_diagnostics()` while preserving existing redaction and ensuring no network I/O or runtime behavior changes. 
- Update tests in `tests/test_diagnostics.py` to validate populated and empty `daily_summary` payloads and adjust test module import path to load diagnostics in isolation.

### Testing
- Ran import-order fixes and linting with `ruff check --fix --select I custom_components/pollenlevels/diagnostics.py tests/test_diagnostics.py` and `ruff check custom_components/pollenlevels/diagnostics.py tests/test_diagnostics.py`, which passed. 
- Ran formatting check with `black --check custom_components/pollenlevels/diagnostics.py tests/test_diagnostics.py`, which passed. 
- Ran unit tests with `PYTHONPATH=. pytest tests/test_diagnostics.py`, and all diagnostics tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7c6bc1488324bb31f8845dd7f75d)