### PR TITLE
Clean up formatter guards in sensor tests

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -706,10 +706,7 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except ValueError:
-            _LOGGER.error("Invalid date format received: %s", date_str)
-            return None
-        except TypeError:
+        except ValueError, TypeError:
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -706,9 +706,10 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        # fmt: off
-        except (ValueError, TypeError):
-            # fmt: on
+        except ValueError:
+            _LOGGER.error("Invalid date format received: %s", date_str)
+            return None
+        except TypeError:
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -218,9 +218,11 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    # fmt: off
-    except (TypeError, ValueError, IndexError):
-        # fmt: on
+    except TypeError:
+        return None
+    except ValueError:
+        return None
+    except IndexError:
         return None
 
     if parsed is None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -218,11 +218,7 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except TypeError:
-        return None
-    except ValueError:
-        return None
-    except IndexError:
+    except TypeError, ValueError, IndexError:
         return None
 
     if parsed is None:


### PR DESCRIPTION
### Motivation
- Remove `# fmt: off` / `# fmt: on` guards around exception handlers.
- Let Black format grouped exception handlers according to the Python 3.14 baseline.
- Keep exception handling concise and maintainable without duplicated blocks.

### Description
- Removed formatter guard comments in `custom_components/pollenlevels/sensor.py` and `tests/test_sensor.py`.
- Kept a single grouped exception handler where the handling logic is identical.
- Accepted Python 3.14 / Black formatting for grouped multi-exception handlers.
- Runtime behavior is unchanged.

### Testing
- `pytest -q tests/test_sensor.py` — passed.
- `pytest -q` — passed.
- `ruff check .` — passed.
- `black --check .` — passed in CI.
- GitHub Actions passed: tests, Lint, hassfest, and HACS validation.