### PR TITLE
Harden CI security configuration

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: hassfest-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -3,6 +3,10 @@ name: Package Test
 on:
   workflow_dispatch:
 
+concurrency:
+  group: package-test-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   package-and-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,10 @@ on:
 # No checkout needed; HACS action validates repo metadata remotely
 permissions: {}
 
+concurrency:
+  group: hacs-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| Latest 2.x release | Yes |
+| Older releases | No, unless explicitly stated |
+
+## Reporting a Vulnerability
+
+Please do not open public GitHub issues for security reports.
+
+Use GitHub Security Advisories or private vulnerability reporting if available.
+If those options are not available, contact the maintainer through GitHub.
+
+When reporting a vulnerability, include:
+
+- The affected Pollen Levels version.
+- The Home Assistant version in use.
+- Clear reproduction steps.
+- The expected impact.
+- Whether secrets, API keys, diagnostics exports, or sensitive location data may
+  have been exposed.
+
+## Security Expectations
+
+Do not share Google API keys, full debug logs, diagnostics exports, or exact
+coordinates publicly.
+
+If an API key or other secret was exposed, rotate it immediately and review its
+usage in the relevant provider console.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,9 @@ When reporting a vulnerability, include:
 
 ## Security Expectations
 
-Do not share Google API keys, full debug logs, diagnostics exports, or exact
-coordinates publicly.
+Do not share Google API keys, full debug logs, or exact coordinates publicly.
+
+Review diagnostics exports for any sensitive information before sharing them.
 
 If an API key or other secret was exposed, rotate it immediately and review its
 usage in the relevant provider console.


### PR DESCRIPTION
### Motivation
- Reduce CI race conditions and improve workflow safety by adding `concurrency` controls to long-running or repeatable workflows. 
- Provide a minimal repository security policy so GitHub `SECURITY.md` is present and the security policy feature can be enabled.

### Description
- Added `concurrency` blocks to `.github/workflows/hassfest.yml`, `.github/workflows/validate.yml`, `.github/workflows/package-test.yml`, and `.github/workflows/release.yml` with the project-specific group names and `cancel-in-progress` settings as suggested. 
- Preserved existing triggers, action versions, Python `3.14` setup, and least-privilege `permissions` in all modified workflows. 
- Verified steps that use `set -euo pipefail` already run with `shell: bash` in the touched workflows. 
- Added a minimal `SECURITY.md` at the repository root with supported-versions, vulnerability reporting guidance, and sensitive-data handling expectations.

### Testing
- Ran `ruff check --fix --select I .` and it passed.
- Ran `ruff check .` and it passed.
- Ran `pytest -q` and all tests passed (`173 passed`).
- GitHub Actions passed: Lint, tests, hassfest, and HACS validation.
- Validated workflow YAML parsing with Ruby YAML loader.
- `actionlint` was not run because it is not installed in the environment.

Notes/confirmations: No CodeQL workflow was added, no `manifest.json`/`pyproject.toml`/`CHANGELOG.md`/versioning changes were made, and no runtime Home Assistant integration code was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007604644c8324ad5fb085df507747)