### PR TITLE
Deduplicate daily summary extraction helpers

### DIFF
--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -32,6 +32,7 @@ from .const import (
     MIN_FORECAST_DAYS,
 )
 from .runtime import PollenLevelsRuntimeData
+from .summary import daily_summary as _daily_summary
 from .util import redact_api_key, safe_parse_int
 
 # Redact potentially sensitive values from diagnostics.
@@ -48,133 +49,6 @@ def _iso_or_none(dt_obj: Any) -> str | None:
         return dt_obj.isoformat() if dt_obj is not None else None
     except Exception:
         return None
-
-
-def _is_finite_number(value: Any) -> bool:
-    """Return whether value is a finite non-boolean number."""
-    return (
-        isinstance(value, int | float)
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-    )
-
-
-def _normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
-    """Return a deterministic uppercase code from API metadata or the data key."""
-    raw_code = info.get("code")
-    if isinstance(raw_code, str) and raw_code.strip():
-        return raw_code.strip().upper()
-
-    fallback = key
-    if fallback.startswith(prefix):
-        fallback = fallback[len(prefix) :]
-    fallback = fallback.split("_d", 1)[0]
-    return fallback.upper()
-
-
-def _current_day_plant_entries(
-    data_map: dict[str, Any],
-) -> list[tuple[str, str, str, dict[str, Any]]]:
-    """Collect current-day plant entries sorted by normalized plant code."""
-    entries: list[tuple[str, str, str, dict[str, Any]]] = []
-    for key, info in data_map.items():
-        if not isinstance(info, dict) or info.get("source") != "plant":
-            continue
-        code = _normalize_entry_code(key, info, "plants_")
-        name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
-
-
-def _current_day_type_entries(
-    data_map: dict[str, Any],
-) -> list[tuple[str, str, str, dict[str, Any]]]:
-    """Collect current-day pollen type entries sorted by normalized type code."""
-    entries: list[tuple[str, str, str, dict[str, Any]]] = []
-    for key, info in data_map.items():
-        if key.endswith(("_d1", "_d2")):
-            continue
-        if not isinstance(info, dict) or info.get("source") != "type":
-            continue
-        if not _is_finite_number(info.get("value")):
-            continue
-        code = _normalize_entry_code(key, info, "type_")
-        name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
-
-
-def _top_type_entries(
-    data_map: dict[str, Any],
-) -> tuple[float | int | None, list[tuple[str, str, str, dict[str, Any]]]]:
-    """Return the maximum current-day type value and all entries tied for it."""
-    entries = _current_day_type_entries(data_map)
-    if not entries:
-        return None, []
-    top_value = max(info["value"] for _code, _name, _key, info in entries)
-    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
-    return top_value, top_entries
-
-
-def _daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
-    """Return diagnostics mirroring the three daily summary sensor payloads."""
-    plant_entries = _current_day_plant_entries(data_map)
-    in_season_entries = [
-        (code, name)
-        for code, name, _key, info in plant_entries
-        if info.get("inSeason") is True
-    ]
-    out_of_season_count = sum(
-        1 for _code, _name, _key, info in plant_entries if info.get("inSeason") is False
-    )
-    unknown_entries = [
-        (code, name)
-        for code, name, _key, info in plant_entries
-        if not isinstance(info.get("inSeason"), bool)
-    ]
-    in_season_count = len(in_season_entries)
-    season_state = (
-        in_season_count if in_season_count + out_of_season_count > 0 else None
-    )
-
-    top_value, top_entries = _top_type_entries(data_map)
-    top_names = [name for _code, name, _key, _info in top_entries]
-    first_info = top_entries[0][3] if top_entries else {}
-
-    return {
-        "plants_in_season_today": {
-            "state": season_state,
-            "plant_codes": [code for code, _name in in_season_entries],
-            "plant_names": [name for _code, name in in_season_entries],
-            "in_season_count": in_season_count,
-            "out_of_season_count": out_of_season_count,
-            "unknown_season_count": len(unknown_entries),
-            "total_plant_count": len(plant_entries),
-            "unknown_season_codes": [code for code, _name in unknown_entries],
-            "unknown_season_names": [name for _code, name in unknown_entries],
-        },
-        "overall_pollen_risk_today": {
-            "state": top_value,
-            "category": first_info.get("category"),
-            "description": first_info.get("description"),
-            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
-            "top_pollen_names": top_names,
-            "top_pollen_categories": [
-                info.get("category") for _code, _name, _key, info in top_entries
-            ],
-            "tie_count": len(top_entries),
-        },
-        "top_pollen_types_today": {
-            "state": ", ".join(top_names) if top_names else None,
-            "top_value": top_value,
-            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
-            "top_pollen_names": top_names,
-            "top_pollen_categories": [
-                info.get("category") for _code, _name, _key, info in top_entries
-            ],
-            "tie_count": len(top_entries),
-        },
-    }
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -418,6 +418,11 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
         return {ATTR_ATTRIBUTION: ATTRIBUTION}
 
 
+def _summary_attrs(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return summary attributes without the sensor state field."""
+    return {key: value for key, value in payload.items() if key != "state"}
+
+
 class PlantsInSeasonTodaySensor(_BaseSummarySensor):
     """Represent a count of plants explicitly marked in season today."""
 
@@ -440,11 +445,11 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return plant season summary attributes."""
         attrs = super().extra_state_attributes
-        summary = _daily_summary(self.coordinator.data or {})[
-            "plants_in_season_today"
-        ].copy()
-        summary.pop("state")
-        attrs.update(summary)
+        attrs.update(
+            _summary_attrs(
+                _daily_summary(self.coordinator.data or {})["plants_in_season_today"]
+            )
+        )
         return attrs
 
 
@@ -472,11 +477,11 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return overall pollen risk summary attributes."""
         attrs = super().extra_state_attributes
-        summary = _daily_summary(self.coordinator.data or {})[
-            "overall_pollen_risk_today"
-        ].copy()
-        summary.pop("state")
-        attrs.update(summary)
+        attrs.update(
+            _summary_attrs(
+                _daily_summary(self.coordinator.data or {})["overall_pollen_risk_today"]
+            )
+        )
         return attrs
 
 
@@ -502,11 +507,11 @@ class TopPollenTypesTodaySensor(_BaseSummarySensor):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return top pollen type summary attributes."""
         attrs = super().extra_state_attributes
-        summary = _daily_summary(self.coordinator.data or {})[
-            "top_pollen_types_today"
-        ].copy()
-        summary.pop("state")
-        attrs.update(summary)
+        attrs.update(
+            _summary_attrs(
+                _daily_summary(self.coordinator.data or {})["top_pollen_types_today"]
+            )
+        )
         return attrs
 
 

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import math
 from collections.abc import Awaitable
 from datetime import date  # Added `date` for DATE device class native_value
 from enum import StrEnum
@@ -53,6 +52,7 @@ from .const import (
 )
 from .coordinator import PollenDataUpdateCoordinator
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
+from .summary import daily_summary as _daily_summary
 from .util import safe_parse_int
 
 _LOGGER = logging.getLogger(__name__)
@@ -388,72 +388,6 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         }
 
 
-def _is_finite_number(value: Any) -> bool:
-    """Return whether value is a finite non-boolean number."""
-    return (
-        isinstance(value, int | float)
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-    )
-
-
-def _normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
-    """Return a deterministic uppercase code from API metadata or the data key."""
-    raw_code = info.get("code")
-    if isinstance(raw_code, str) and raw_code.strip():
-        return raw_code.strip().upper()
-
-    fallback = key
-    if fallback.startswith(prefix):
-        fallback = fallback[len(prefix) :]
-    fallback = fallback.split("_d", 1)[0]
-    return fallback.upper()
-
-
-def _current_day_plant_entries(
-    coordinator: PollenDataUpdateCoordinator,
-) -> list[tuple[str, str, str, dict[str, Any]]]:
-    """Collect current-day plant entries sorted by normalized plant code."""
-    entries: list[tuple[str, str, str, dict[str, Any]]] = []
-    for key, info in (coordinator.data or {}).items():
-        if not isinstance(info, dict) or info.get("source") != "plant":
-            continue
-        code = _normalize_entry_code(key, info, "plants_")
-        name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
-
-
-def _current_day_type_entries(
-    coordinator: PollenDataUpdateCoordinator,
-) -> list[tuple[str, str, str, dict[str, Any]]]:
-    """Collect current-day pollen type entries sorted by normalized type code."""
-    entries: list[tuple[str, str, str, dict[str, Any]]] = []
-    for key, info in (coordinator.data or {}).items():
-        if key.endswith(("_d1", "_d2")):
-            continue
-        if not isinstance(info, dict) or info.get("source") != "type":
-            continue
-        if not _is_finite_number(info.get("value")):
-            continue
-        code = _normalize_entry_code(key, info, "type_")
-        name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
-
-
-def _top_type_entries(
-    coordinator: PollenDataUpdateCoordinator,
-) -> tuple[float | int | None, list[tuple[str, str, str, dict[str, Any]]]]:
-    """Return the maximum current-day type value and all entries tied for it."""
-    entries = _current_day_type_entries(coordinator)
-    if not entries:
-        return None, []
-    top_value = max(info["value"] for _code, _name, _key, info in entries)
-    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
-    return top_value, top_entries
-
-
 class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
     """Provide base behavior for daily summary sensors."""
 
@@ -498,50 +432,19 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> int | None:
         """Return the number of plants explicitly marked in season today."""
-        entries = _current_day_plant_entries(self.coordinator)
-        in_season_count = sum(
-            1 for _code, _name, _key, info in entries if info.get("inSeason") is True
-        )
-        out_of_season_count = sum(
-            1 for _code, _name, _key, info in entries if info.get("inSeason") is False
-        )
-        if in_season_count + out_of_season_count == 0:
-            return None
-        return in_season_count
+        return _daily_summary(self.coordinator.data or {})["plants_in_season_today"][
+            "state"
+        ]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return plant season summary attributes."""
         attrs = super().extra_state_attributes
-        entries = _current_day_plant_entries(self.coordinator)
-        in_season_count = sum(
-            1 for _code, _name, _key, info in entries if info.get("inSeason") is True
-        )
-        out_of_season_count = sum(
-            1 for _code, _name, _key, info in entries if info.get("inSeason") is False
-        )
-        unknown_entries = [
-            (code, name)
-            for code, name, _key, info in entries
-            if not isinstance(info.get("inSeason"), bool)
-        ]
-        in_season_entries = [
-            (code, name)
-            for code, name, _key, info in entries
-            if info.get("inSeason") is True
-        ]
-        attrs.update(
-            {
-                "plant_codes": [code for code, _name in in_season_entries],
-                "plant_names": [name for _code, name in in_season_entries],
-                "in_season_count": in_season_count,
-                "out_of_season_count": out_of_season_count,
-                "unknown_season_count": len(unknown_entries),
-                "total_plant_count": len(entries),
-                "unknown_season_codes": [code for code, _name in unknown_entries],
-                "unknown_season_names": [name for _code, name in unknown_entries],
-            }
-        )
+        summary = _daily_summary(self.coordinator.data or {})[
+            "plants_in_season_today"
+        ].copy()
+        summary.pop("state")
+        attrs.update(summary)
         return attrs
 
 
@@ -561,27 +464,19 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> float | int | None:
         """Return the maximum valid current-day pollen type value."""
-        top_value, _top_entries = _top_type_entries(self.coordinator)
-        return top_value
+        return _daily_summary(self.coordinator.data or {})["overall_pollen_risk_today"][
+            "state"
+        ]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return overall pollen risk summary attributes."""
         attrs = super().extra_state_attributes
-        _top_value, top_entries = _top_type_entries(self.coordinator)
-        first_info = top_entries[0][3] if top_entries else {}
-        attrs.update(
-            {
-                "category": first_info.get("category"),
-                "description": first_info.get("description"),
-                "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
-                "top_pollen_names": [name for _code, name, _key, _info in top_entries],
-                "top_pollen_categories": [
-                    info.get("category") for _code, _name, _key, info in top_entries
-                ],
-                "tie_count": len(top_entries),
-            }
-        )
+        summary = _daily_summary(self.coordinator.data or {})[
+            "overall_pollen_risk_today"
+        ].copy()
+        summary.pop("state")
+        attrs.update(summary)
         return attrs
 
 
@@ -599,27 +494,19 @@ class TopPollenTypesTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> str | None:
         """Return the top pollen type names, preserving ties."""
-        _top_value, top_entries = _top_type_entries(self.coordinator)
-        if not top_entries:
-            return None
-        return ", ".join(name for _code, name, _key, _info in top_entries)
+        return _daily_summary(self.coordinator.data or {})["top_pollen_types_today"][
+            "state"
+        ]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return top pollen type summary attributes."""
         attrs = super().extra_state_attributes
-        top_value, top_entries = _top_type_entries(self.coordinator)
-        attrs.update(
-            {
-                "top_value": top_value,
-                "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
-                "top_pollen_names": [name for _code, name, _key, _info in top_entries],
-                "top_pollen_categories": [
-                    info.get("category") for _code, _name, _key, info in top_entries
-                ],
-                "tie_count": len(top_entries),
-            }
-        )
+        summary = _daily_summary(self.coordinator.data or {})[
+            "top_pollen_types_today"
+        ].copy()
+        summary.pop("state")
+        attrs.update(summary)
         return attrs
 
 

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import math
-from typing import Any
+from typing import Any, NamedTuple
 
-SummaryEntry = tuple[str, str, str, dict[str, Any]]
+
+class SummaryEntry(NamedTuple):
+    """Represent a normalized daily summary entry."""
+
+    code: str
+    name: str
+    key: str
+    info: dict[str, Any]
 
 
 def is_finite_number(value: Any) -> bool:
@@ -38,8 +45,8 @@ def current_day_plant_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
             continue
         code = normalize_entry_code(key, info, "plants_")
         name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
+        entries.append(SummaryEntry(code, str(name), key, info))
+    return sorted(entries, key=lambda entry: entry.code)
 
 
 def current_day_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
@@ -54,8 +61,8 @@ def current_day_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
             continue
         code = normalize_entry_code(key, info, "type_")
         name = info.get("displayName") or code
-        entries.append((code, str(name), key, info))
-    return sorted(entries, key=lambda item: item[0])
+        entries.append(SummaryEntry(code, str(name), key, info))
+    return sorted(entries, key=lambda entry: entry.code)
 
 
 def top_type_entries(
@@ -65,8 +72,8 @@ def top_type_entries(
     entries = current_day_type_entries(data_map)
     if not entries:
         return None, []
-    top_value = max(info["value"] for _code, _name, _key, info in entries)
-    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
+    top_value = max(entry.info["value"] for entry in entries)
+    top_entries = [entry for entry in entries if entry.info["value"] == top_value]
     return top_value, top_entries
 
 
@@ -74,17 +81,15 @@ def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
     """Return payloads for the daily summary sensors."""
     plant_entries = current_day_plant_entries(data_map)
     in_season_entries = [
-        (code, name)
-        for code, name, _key, info in plant_entries
-        if info.get("inSeason") is True
+        entry for entry in plant_entries if entry.info.get("inSeason") is True
     ]
     out_of_season_count = sum(
-        1 for _code, _name, _key, info in plant_entries if info.get("inSeason") is False
+        1 for entry in plant_entries if entry.info.get("inSeason") is False
     )
     unknown_entries = [
-        (code, name)
-        for code, name, _key, info in plant_entries
-        if not isinstance(info.get("inSeason"), bool)
+        entry
+        for entry in plant_entries
+        if not isinstance(entry.info.get("inSeason"), bool)
     ]
     in_season_count = len(in_season_entries)
     season_state = (
@@ -92,39 +97,39 @@ def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
     )
 
     top_value, top_entries = top_type_entries(data_map)
-    top_names = [name for _code, name, _key, _info in top_entries]
-    first_info = top_entries[0][3] if top_entries else {}
+    top_names = [entry.name for entry in top_entries]
+    first_info = top_entries[0].info if top_entries else {}
 
     return {
         "plants_in_season_today": {
             "state": season_state,
-            "plant_codes": [code for code, _name in in_season_entries],
-            "plant_names": [name for _code, name in in_season_entries],
+            "plant_codes": [entry.code for entry in in_season_entries],
+            "plant_names": [entry.name for entry in in_season_entries],
             "in_season_count": in_season_count,
             "out_of_season_count": out_of_season_count,
             "unknown_season_count": len(unknown_entries),
             "total_plant_count": len(plant_entries),
-            "unknown_season_codes": [code for code, _name in unknown_entries],
-            "unknown_season_names": [name for _code, name in unknown_entries],
+            "unknown_season_codes": [entry.code for entry in unknown_entries],
+            "unknown_season_names": [entry.name for entry in unknown_entries],
         },
         "overall_pollen_risk_today": {
             "state": top_value,
             "category": first_info.get("category"),
             "description": first_info.get("description"),
-            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_codes": [entry.code for entry in top_entries],
             "top_pollen_names": top_names,
             "top_pollen_categories": [
-                info.get("category") for _code, _name, _key, info in top_entries
+                entry.info.get("category") for entry in top_entries
             ],
             "tie_count": len(top_entries),
         },
         "top_pollen_types_today": {
             "state": ", ".join(top_names) if top_names else None,
             "top_value": top_value,
-            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_codes": [entry.code for entry in top_entries],
             "top_pollen_names": top_names,
             "top_pollen_categories": [
-                info.get("category") for _code, _name, _key, info in top_entries
+                entry.info.get("category") for entry in top_entries
             ],
             "tie_count": len(top_entries),
         },

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -1,0 +1,131 @@
+"""Pure helpers for daily pollen summary extraction."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+SummaryEntry = tuple[str, str, str, dict[str, Any]]
+
+
+def is_finite_number(value: Any) -> bool:
+    """Return whether value is a finite non-boolean number."""
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
+    """Return a deterministic uppercase code from API metadata or the data key."""
+    raw_code = info.get("code")
+    if isinstance(raw_code, str) and raw_code.strip():
+        return raw_code.strip().upper()
+
+    fallback = key
+    if fallback.startswith(prefix):
+        fallback = fallback[len(prefix) :]
+    fallback = fallback.split("_d", 1)[0]
+    return fallback.upper()
+
+
+def current_day_plant_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
+    """Collect current-day plant entries sorted by normalized plant code."""
+    entries: list[SummaryEntry] = []
+    for key, info in data_map.items():
+        if not isinstance(info, dict) or info.get("source") != "plant":
+            continue
+        code = normalize_entry_code(key, info, "plants_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def current_day_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
+    """Collect current-day pollen type entries sorted by normalized type code."""
+    entries: list[SummaryEntry] = []
+    for key, info in data_map.items():
+        if key.endswith(("_d1", "_d2")):
+            continue
+        if not isinstance(info, dict) or info.get("source") != "type":
+            continue
+        if not is_finite_number(info.get("value")):
+            continue
+        code = normalize_entry_code(key, info, "type_")
+        name = info.get("displayName") or code
+        entries.append((code, str(name), key, info))
+    return sorted(entries, key=lambda item: item[0])
+
+
+def top_type_entries(
+    data_map: dict[str, Any],
+) -> tuple[float | int | None, list[SummaryEntry]]:
+    """Return the maximum current-day type value and all entries tied for it."""
+    entries = current_day_type_entries(data_map)
+    if not entries:
+        return None, []
+    top_value = max(info["value"] for _code, _name, _key, info in entries)
+    top_entries = [entry for entry in entries if entry[3]["value"] == top_value]
+    return top_value, top_entries
+
+
+def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
+    """Return payloads for the daily summary sensors."""
+    plant_entries = current_day_plant_entries(data_map)
+    in_season_entries = [
+        (code, name)
+        for code, name, _key, info in plant_entries
+        if info.get("inSeason") is True
+    ]
+    out_of_season_count = sum(
+        1 for _code, _name, _key, info in plant_entries if info.get("inSeason") is False
+    )
+    unknown_entries = [
+        (code, name)
+        for code, name, _key, info in plant_entries
+        if not isinstance(info.get("inSeason"), bool)
+    ]
+    in_season_count = len(in_season_entries)
+    season_state = (
+        in_season_count if in_season_count + out_of_season_count > 0 else None
+    )
+
+    top_value, top_entries = top_type_entries(data_map)
+    top_names = [name for _code, name, _key, _info in top_entries]
+    first_info = top_entries[0][3] if top_entries else {}
+
+    return {
+        "plants_in_season_today": {
+            "state": season_state,
+            "plant_codes": [code for code, _name in in_season_entries],
+            "plant_names": [name for _code, name in in_season_entries],
+            "in_season_count": in_season_count,
+            "out_of_season_count": out_of_season_count,
+            "unknown_season_count": len(unknown_entries),
+            "total_plant_count": len(plant_entries),
+            "unknown_season_codes": [code for code, _name in unknown_entries],
+            "unknown_season_names": [name for _code, name in unknown_entries],
+        },
+        "overall_pollen_risk_today": {
+            "state": top_value,
+            "category": first_info.get("category"),
+            "description": first_info.get("description"),
+            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_names": top_names,
+            "top_pollen_categories": [
+                info.get("category") for _code, _name, _key, info in top_entries
+            ],
+            "tie_count": len(top_entries),
+        },
+        "top_pollen_types_today": {
+            "state": ", ".join(top_names) if top_names else None,
+            "top_value": top_value,
+            "top_pollen_codes": [code for code, _name, _key, _info in top_entries],
+            "top_pollen_names": top_names,
+            "top_pollen_categories": [
+                info.get("category") for _code, _name, _key, info in top_entries
+            ],
+            "tie_count": len(top_entries),
+        },
+    }

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
-import sys
+import importlib.util
 from pathlib import Path
+from types import ModuleType
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
+SUMMARY_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "pollenlevels"
+    / "summary.py"
+)
 
-from custom_components.pollenlevels.summary import daily_summary  # noqa: E402
+
+def _load_summary_module() -> ModuleType:
+    """Load summary.py directly without importing the integration package."""
+    spec = importlib.util.spec_from_file_location("pollenlevels_summary", SUMMARY_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+daily_summary = _load_summary_module().daily_summary
 
 
 def test_daily_summary_uses_empty_states_without_data() -> None:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,120 @@
+"""Unit tests for shared daily summary helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from custom_components.pollenlevels.summary import daily_summary  # noqa: E402
+
+
+def test_daily_summary_uses_empty_states_without_data() -> None:
+    """Daily summary should expose empty payloads without coordinator data."""
+
+    summary = daily_summary({})
+
+    assert summary["plants_in_season_today"]["state"] is None
+    assert summary["plants_in_season_today"]["total_plant_count"] == 0
+    assert summary["overall_pollen_risk_today"]["state"] is None
+    assert summary["overall_pollen_risk_today"]["tie_count"] == 0
+    assert summary["top_pollen_types_today"]["state"] is None
+    assert summary["top_pollen_types_today"]["tie_count"] == 0
+
+
+def test_daily_summary_preserves_ties_and_ignores_future_and_nonfinite_values() -> None:
+    """Type summaries keep current-day ties and ignore D+ and non-finite values."""
+
+    summary = daily_summary(
+        {
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": 4,
+                "category": "High",
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 4,
+                "category": "High",
+            },
+            "type_tree": {
+                "source": "type",
+                "displayName": "Tree",
+                "value": float("nan"),
+                "category": "Low",
+            },
+            "type_grass_d1": {
+                "source": "type",
+                "displayName": "Grass tomorrow",
+                "value": 6,
+                "category": "Very High",
+            },
+            "type_weed_d2": {
+                "source": "type",
+                "displayName": "Weed D+2",
+                "value": 7,
+                "category": "Very High",
+            },
+        }
+    )
+
+    assert summary["overall_pollen_risk_today"] == {
+        "state": 4,
+        "category": "High",
+        "description": None,
+        "top_pollen_codes": ["GRASS", "WEED"],
+        "top_pollen_names": ["Grass", "Weed"],
+        "top_pollen_categories": ["High", "High"],
+        "tie_count": 2,
+    }
+    assert summary["top_pollen_types_today"] == {
+        "state": "Grass, Weed",
+        "top_value": 4,
+        "top_pollen_codes": ["GRASS", "WEED"],
+        "top_pollen_names": ["Grass", "Weed"],
+        "top_pollen_categories": ["High", "High"],
+        "tie_count": 2,
+    }
+
+
+def test_daily_summary_tracks_unknown_plant_season_values() -> None:
+    """Plant summaries count only boolean season values as known."""
+
+    summary = daily_summary(
+        {
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "inSeason": True,
+            },
+            "plants_pine": {
+                "source": "plant",
+                "displayName": "Pine",
+                "inSeason": False,
+            },
+            "plants_birch": {
+                "source": "plant",
+                "displayName": "Birch",
+                "inSeason": "false",
+            },
+            "plants_elm": {"source": "plant", "displayName": "Elm"},
+        }
+    )
+
+    assert summary["plants_in_season_today"] == {
+        "state": 1,
+        "plant_codes": ["OAK"],
+        "plant_names": ["Oak"],
+        "in_season_count": 1,
+        "out_of_season_count": 1,
+        "unknown_season_count": 2,
+        "total_plant_count": 4,
+        "unknown_season_codes": ["BIRCH", "ELM"],
+        "unknown_season_names": ["Birch", "Elm"],
+    }


### PR DESCRIPTION
### Motivation
- Reduce duplicated pure logic between `sensor.py` and `diagnostics.py` by centralizing current-day summary extraction and tie-handling in a shared helper module while preserving all public behavior and payload shapes.

### Description
- Add `custom_components/pollenlevels/summary.py` implementing finite-number guard, entry code normalization, current-day plant/type collection, top-type tie handling, and `daily_summary` payload builder.
- Update `custom_components/pollenlevels/sensor.py` to consume the shared `daily_summary` payload for the three summary sensors while keeping their `unique_id`, `translation_key`, states, attributes, and ordering unchanged.
- Update `custom_components/pollenlevels/diagnostics.py` to use the shared `daily_summary` builder so diagnostics continue to expose the same top-level keys and `daily_summary` structure with the same redaction and no-network guarantees.
- Add `tests/test_summary.py` with direct unit tests for empty data, tie preservation, ignoring D+1/D+2 entries, non-finite values, and unknown plant season values.

### Testing
- Ran `ruff check --fix --select I .` and `ruff check .`, both passed.
- Ran `black --check` on the modified files (`custom_components/pollenlevels/summary.py`, `custom_components/pollenlevels/sensor.py`, `custom_components/pollenlevels/diagnostics.py`, `tests/test_summary.py`) and it passed for those files; a full `black --check .` shows unrelated pre-existing formatting differences in other files which were intentionally left untouched to keep the PR minimal.
- Ran `pytest -q` and all tests passed (`176 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00eaee83e88324b830c25a03c90dd3)