### PR TITLE
docs: clarify 2.1.0 daily summary and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Added
 - Added daily summary sensors for plants in season, overall pollen risk, and top
   pollen types.
+- Added a diagnostics `daily_summary` snapshot mirroring the daily summary
+  sensors for easier support troubleshooting.
 
 ## [2.0.0] - 2026-05-07
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - Your **API key** is stored by Home Assistant’s secure config entries.  
 - **We never log your API key.** As a safety net, if it ever appears in an error message, it is **redacted** as `***`.  
 - **We do not log request parameters** (coordinates). Debug logs only include non-sensitive metadata (e.g., forecast days and whether a language is set).  
+- Diagnostics include a redacted `daily_summary` snapshot to help troubleshoot
+  the daily summary sensors without exposing API keys or exact coordinates.
 - Avoid sharing full debug logs publicly; review them for sensitive information before posting.
 
 ---


### PR DESCRIPTION
### Motivation
- Make the 2.1.0 release notes and README accurately describe the already-merged daily summary sensors and the diagnostics `daily_summary` snapshot used for support/troubleshooting.

### Description
- Updated `CHANGELOG.md` `## [2.1.0] - 2026-05-07` `### Added` to include the diagnostics `daily_summary` snapshot mirroring the daily summary sensors.
- Added a single-line note to the README `Security & Privacy` section describing the redacted `daily_summary` diagnostics snapshot for troubleshooting.
- This PR is documentation-only and does not modify any runtime code, tests, version files, or translations.

### Testing
- Ran `ruff check --fix --select I . && ruff check .` and all checks passed.
- Ran `black --check .` which failed due to pre-existing formatting differences in runtime/test files (7 files would be reformatted), and no automatic reformatting was applied because this is a documentation-only change.
- Ran `pytest -q` and all tests passed (`176 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f2548c048324bc288c6db621473e)