### PR TITLE
Tighten Python 3.14 test stubs

### DIFF
--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -6,12 +6,7 @@ import math
 import random
 from typing import Any
 
-from aiohttp import ClientError, ClientSession, ClientTimeout
-
-try:  # pragma: no cover - fallback for environments with stubbed aiohttp
-    from aiohttp import ContentTypeError
-except ImportError:  # pragma: no cover - tests stub aiohttp without ContentTypeError
-    ContentTypeError = ValueError  # type: ignore[misc,assignment]
+from aiohttp import ClientError, ClientSession, ClientTimeout, ContentTypeError
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -54,7 +49,7 @@ class GooglePollenApiClient:
             if math.isfinite(parsed) and parsed > 0:
                 return parsed
             return 2.0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             retry_at = dt_util.parse_http_date(retry_after_raw)
             if retry_at is not None:
                 delay = (retry_at - dt_util.utcnow()).total_seconds()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import sys
+from types import ModuleType
 
 import pytest
+
+aiohttp_mod = sys.modules.setdefault("aiohttp", ModuleType("aiohttp"))
+if not hasattr(aiohttp_mod, "ContentTypeError"):
+    aiohttp_mod.ContentTypeError = ValueError
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,27 @@ from types import ModuleType
 import pytest
 
 aiohttp_mod = sys.modules.setdefault("aiohttp", ModuleType("aiohttp"))
+
+
+class _StubClientError(Exception):
+    pass
+
+
+class _StubClientSession:  # pragma: no cover - structure only
+    pass
+
+
+class _StubClientTimeout:
+    def __init__(self, total: float | None = None):
+        self.total = total
+
+
+if not hasattr(aiohttp_mod, "ClientError"):
+    aiohttp_mod.ClientError = _StubClientError
+if not hasattr(aiohttp_mod, "ClientSession"):
+    aiohttp_mod.ClientSession = _StubClientSession
+if not hasattr(aiohttp_mod, "ClientTimeout"):
+    aiohttp_mod.ClientTimeout = _StubClientTimeout
 if not hasattr(aiohttp_mod, "ContentTypeError"):
     aiohttp_mod.ContentTypeError = ValueError
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -102,6 +102,7 @@ class _StubClientTimeout:
 aiohttp_mod.ClientError = _StubClientError
 aiohttp_mod.ClientSession = _StubClientSession
 aiohttp_mod.ClientTimeout = _StubClientTimeout
+aiohttp_mod.ContentTypeError = ValueError
 sys.modules["aiohttp"] = aiohttp_mod
 
 cv_mod = sys.modules["homeassistant.helpers.config_validation"]
@@ -160,7 +161,7 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
     try:
         parsed = parsedate_to_datetime(value) if value is not None else None
-    except (TypeError, ValueError, IndexError):
+    except TypeError, ValueError, IndexError:
         return None
 
     if parsed is None:


### PR DESCRIPTION
### Summary
- Import `aiohttp.ContentTypeError` directly from the real aiohttp package in the client.
- Make the lightweight aiohttp test stubs expose all imports used by `client.py`: `ClientError`, `ClientSession`, `ClientTimeout`, and `ContentTypeError`.
- Keep existing aiohttp attributes intact when a real or fuller module is already present.
- Keep the only Black-driven syntax adjustment scoped to modified files and Python 3.14 multi-exception syntax.

### Review notes
- Gemini comments suggesting `except (TypeError, ValueError):` are false positives for this project. The project requires Python 3.14+, and PEP 758 makes `except TypeError, ValueError:` valid syntax.

### Scope notes
- No global Black formatting was applied.
- No versioning, release files, README, CHANGELOG, manifest, HACS metadata, or translations were changed.
- No entities, unique IDs, translation keys, public attributes, or payload shapes were changed.

### Validation
- `pytest -q tests/test_init.py` (`25 passed`)
- `pytest -q tests/test_config_flow.py` (`55 passed`)
- `pytest -q` (`176 passed`)
- `ruff check .`
- `black --check custom_components/pollenlevels/client.py tests/conftest.py tests/test_init.py`