### PR TITLE
Apply Black formatting

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -210,7 +210,7 @@ async def async_setup_entry(
     normalized_mode = normalize_sensor_mode(raw_mode, _LOGGER)
     try:
         mode = ForecastSensorMode(normalized_mode)
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         mode = ForecastSensorMode.NONE
     create_d1 = (
         mode in (ForecastSensorMode.D1, ForecastSensorMode.D1_D2) and forecast_days >= 2
@@ -281,7 +281,7 @@ async def async_setup_entry(
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
-    except (ConfigEntryAuthFailed, ConfigEntryNotReady):
+    except ConfigEntryAuthFailed, ConfigEntryNotReady:
         entry.runtime_data = None
         raise
     except Exception as err:

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -109,7 +109,7 @@ def _safe_coord(value: float | None, *, lat: bool) -> float | None:
         if lat:
             return cv.latitude(value)
         return cv.longitude(value)
-    except (vol.Invalid, TypeError, ValueError):
+    except vol.Invalid, TypeError, ValueError:
         return None
 
 
@@ -210,7 +210,7 @@ def _validate_location_dict(
     try:
         lat = cv.latitude(lat_val)
         lon = cv.longitude(lon_val)
-    except (vol.Invalid, TypeError, ValueError):
+    except vol.Invalid, TypeError, ValueError:
         return None
 
     return lat, lon
@@ -358,7 +358,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 lat = cv.latitude(user_input.get(CONF_LATITUDE))
                 lon = cv.longitude(user_input.get(CONF_LONGITUDE))
                 latlon = (lat, lon)
-            except (vol.Invalid, TypeError):
+            except vol.Invalid, TypeError:
                 _LOGGER.debug(
                     "Invalid coordinates provided (values redacted): parsing failed"
                 )

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -35,7 +35,7 @@ def _normalize_channel(v: Any) -> int | None:
     """
     try:
         f = float(v)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
     if not math.isfinite(f):
         return None
@@ -422,7 +422,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                 # Use day-specific 'inSeason' and 'advice' from the forecast day.
                 try:
                     day_obj = daily[off]
-                except (IndexError, TypeError):
+                except IndexError, TypeError:
                     day_obj = None
                 day_item = type_by_day_code[off].get(_tcode) if day_obj else None
                 day_in_season = (

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -100,7 +100,7 @@ def safe_parse_int(value: Any) -> int | None:
 
     try:
         parsed_float = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
 
     if not math.isfinite(parsed_float) or not parsed_float.is_integer():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -134,7 +134,7 @@ config_validation_mod = ModuleType("homeassistant.helpers.config_validation")
 def _latitude(value=None):
     try:
         lat = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # Mirror Home Assistant's cv.latitude behavior for invalid types
         raise cf.vol.Invalid("latitude_type") from None
     if lat < -90 or lat > 90:
@@ -145,7 +145,7 @@ def _latitude(value=None):
 def _longitude(value=None):
     try:
         lon = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # Mirror Home Assistant's cv.longitude behavior for invalid types
         raise cf.vol.Invalid("longitude_type") from None
 
@@ -241,7 +241,7 @@ dt_mod = ModuleType("homeassistant.util.dt")
 def _parse_http_date(value: str):
     try:
         return email.utils.parsedate_to_datetime(value)
-    except (TypeError, ValueError, IndexError, OverflowError):
+    except TypeError, ValueError, IndexError, OverflowError:
         return None
 
 


### PR DESCRIPTION
### Motivation
- Normalize code style across the repository by applying Black with the repo's current configuration.
- Keep the change strictly style-only with no functional, API, naming, translation, or changelog edits.

### Description
- Ran `black .` using the repository configuration and reformatted files without any manual semantic changes.
- Reformatted files: `custom_components/pollenlevels/__init__.py`, `custom_components/pollenlevels/config_flow.py`, `custom_components/pollenlevels/coordinator.py`, `custom_components/pollenlevels/util.py`, and `tests/test_config_flow.py`.
- No version, metadata, README, CHANGELOG, SECURITY, translation keys, unique_id patterns, or public API surface were modified.

### Testing
- Verified formatting and linting with `black --check .` and `ruff check .`, both of which passed.
- Ran unit tests with `pytest -q`, which completed successfully (`176 passed`).
- Confirmed the repository diff contains only formatting changes to the files listed above and no behavioral edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01711ec7d08324b24a21a3008bdd2a)