### PR TITLE
Add Google API key hygiene guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - Diagnostics include a redacted `daily_summary` snapshot to help troubleshoot
   the daily summary sensors without exposing API keys or exact coordinates.
 - Avoid sharing full debug logs publicly; review them for sensitive information before posting.
+- Never share real Google API keys publicly, and do not paste full Google Pollen
+  API URLs containing `key=...` into public issues. If a key was exposed,
+  rotate it in Google Cloud Console and restrict it to the required API and
+  allowed referrers/IPs where possible.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,8 @@ When reporting a vulnerability, include:
 ## Security Expectations
 
 Do not share Google API keys, full debug logs, or exact coordinates publicly.
+If you accidentally expose a Google API key, rotate it before sharing logs or
+diagnostics.
 
 Review diagnostics exports for any sensitive information before sharing them.
 

--- a/tests/test_secret_hygiene.py
+++ b/tests/test_secret_hygiene.py
@@ -11,6 +11,7 @@ IGNORED_DIRS = {
     ".git",
     ".mypy_cache",
     ".pytest_cache",
+    ".ruff_cache",
     ".venv",
     "__pycache__",
     "build",
@@ -31,6 +32,15 @@ def _is_allowed_placeholder(candidate: str) -> bool:
     return any(marker in candidate.upper() for marker in PLACEHOLDER_MARKERS)
 
 
+def _is_scanned_text_file(path: Path) -> bool:
+    """Return whether a file should be scanned as repository text."""
+    return (
+        path.suffix in TEXT_SUFFIXES
+        or path.name == ".env"
+        or path.name.startswith(".env.")
+    )
+
+
 def test_repository_does_not_contain_google_api_keys() -> None:
     """Prevent real-looking Google API keys from being committed."""
     findings: list[str] = []
@@ -40,16 +50,18 @@ def test_repository_does_not_contain_google_api_keys() -> None:
         if (
             not path.is_file()
             or _is_ignored(relative_path)
-            or path.suffix not in TEXT_SUFFIXES
+            or not _is_scanned_text_file(path)
         ):
             continue
 
-        content = path.read_text(encoding="utf-8")
-        for line_number, line in enumerate(content.splitlines(), start=1):
-            for match in GOOGLE_API_KEY_RE.finditer(line):
-                candidate = match.group(0)
-                if _is_allowed_placeholder(candidate):
-                    continue
-                findings.append(f"{relative_path}:{line_number}: {candidate}")
+        with path.open(encoding="utf-8", errors="ignore") as file_obj:
+            for line_number, line in enumerate(file_obj, start=1):
+                for match in GOOGLE_API_KEY_RE.finditer(line):
+                    candidate = match.group(0)
+                    if _is_allowed_placeholder(candidate):
+                        continue
+                    findings.append(
+                        f"{relative_path}:{line_number}: real-looking Google API key"
+                    )
 
     assert not findings, "Real-looking Google API keys found:\n" + "\n".join(findings)

--- a/tests/test_secret_hygiene.py
+++ b/tests/test_secret_hygiene.py
@@ -1,0 +1,55 @@
+"""Repository secret hygiene tests."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEXT_SUFFIXES = {".json", ".md", ".py", ".toml", ".txt", ".yaml", ".yml"}
+IGNORED_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".venv",
+    "__pycache__",
+    "build",
+    "dist",
+    "venv",
+}
+GOOGLE_API_KEY_RE = re.compile(r"AIza[0-9A-Za-z_-]{20,}")
+PLACEHOLDER_MARKERS = ("EXAMPLE", "FAKE", "PLACEHOLDER", "REDACTED")
+
+
+def _is_ignored(path: Path) -> bool:
+    """Return whether any part of a repository-relative path is ignored."""
+    return any(part in IGNORED_DIRS for part in path.parts)
+
+
+def _is_allowed_placeholder(candidate: str) -> bool:
+    """Allow obviously fictitious or redacted API key examples."""
+    return any(marker in candidate.upper() for marker in PLACEHOLDER_MARKERS)
+
+
+def test_repository_does_not_contain_google_api_keys() -> None:
+    """Prevent real-looking Google API keys from being committed."""
+    findings: list[str] = []
+
+    for path in sorted(ROOT.rglob("*")):
+        relative_path = path.relative_to(ROOT)
+        if (
+            not path.is_file()
+            or _is_ignored(relative_path)
+            or path.suffix not in TEXT_SUFFIXES
+        ):
+            continue
+
+        content = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            for match in GOOGLE_API_KEY_RE.finditer(line):
+                candidate = match.group(0)
+                if _is_allowed_placeholder(candidate):
+                    continue
+                findings.append(f"{relative_path}:{line_number}: {candidate}")
+
+    assert not findings, "Real-looking Google API keys found:\n" + "\n".join(findings)


### PR DESCRIPTION
### Motivation
- Prevent accidental inclusion or public sharing of real Google API keys in docs, examples, or tests by adding lightweight guidance and an automated hygiene check.

### Description
- Add a brief Security & Privacy note in `README.md` advising to never share real Google API keys, to avoid posting full Google Pollen API URLs containing `key=...`, and to rotate/restrict exposed keys in Google Cloud Console.
- Add a short guidance line in `SECURITY.md` advising to rotate an accidentally exposed Google API key before sharing logs or diagnostics.
- Add `tests/test_secret_hygiene.py`, a repository test that scans textual files for the regex `AIza[0-9A-Za-z_-]{20,}` while ignoring common build/virtualenv/cache dirs and allowing obvious placeholders (e.g., `REDACTED`, `FAKE`, `EXAMPLE`, `PLACEHOLDER`).
- No runtime code, manifest, translations, entity IDs, or changelog changes were made.

### Testing
- Ran `ruff check --fix --select I .` and `ruff check .` which passed without issues.
- Ran `black --check .` which passed.
- Ran `pytest -q` and all tests passed (`177 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01787320e0832491cd7479b62805d8)