### PR TITLE
Handle invalid API key messages on generic 4xx responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.1.1] - 2026-05-12
+### Fixed
+- Treated generic Google Pollen API 4xx responses containing invalid API key
+  messages as authentication failures so Home Assistant can trigger
+  reauthentication instead of reporting a connectivity error.
+
+### Changed
+- Refactored invalid API key classification in the Google Pollen API client to
+  reuse a shared private helper across HTTP 403 and generic 4xx handling.
+
 ## [2.1.0] - 2026-05-07
 ### Added
 - Added daily summary sensors for plants in season, overall pollen risk, and top

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -165,6 +165,8 @@ class GooglePollenApiClient:
                             await extract_error_message(resp, default=""), self._api_key
                         )
                         message = _format_http_message(resp.status, raw_message or None)
+                        if is_invalid_api_key_message(raw_message):
+                            raise ConfigEntryAuthFailed(message)
                         raise UpdateFailed(message)
 
                     if resp.status != 200:

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -26,6 +26,15 @@ def _format_http_message(status: int, raw_message: str | None) -> str:
     return f"HTTP {status}"
 
 
+def _raise_auth_failed_if_invalid_api_key(
+    raw_message: str | None, formatted_message: str
+) -> None:
+    """Raise an auth failure when the API response indicates an invalid key."""
+
+    if is_invalid_api_key_message(raw_message):
+        raise ConfigEntryAuthFailed(formatted_message)
+
+
 class PollenQuotaExceededError(UpdateFailed):
     """Raised when the Google Pollen API quota is exceeded (HTTP 429).
 
@@ -116,8 +125,7 @@ class GooglePollenApiClient:
                             await extract_error_message(resp, default=""), self._api_key
                         )
                         message = _format_http_message(resp.status, raw_message or None)
-                        if is_invalid_api_key_message(raw_message):
-                            raise ConfigEntryAuthFailed(message)
+                        _raise_auth_failed_if_invalid_api_key(raw_message, message)
                         raise UpdateFailed(message)
 
                     if resp.status == 429:
@@ -165,8 +173,7 @@ class GooglePollenApiClient:
                             await extract_error_message(resp, default=""), self._api_key
                         )
                         message = _format_http_message(resp.status, raw_message or None)
-                        if is_invalid_api_key_message(raw_message):
-                            raise ConfigEntryAuthFailed(message)
+                        _raise_auth_failed_if_invalid_api_key(raw_message, message)
                         raise UpdateFailed(message)
 
                     if resp.status != 200:

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.1.0"
+    "version": "2.1.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.1.0"
+version = "2.1.1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,6 +256,30 @@ async def test_client_redacts_api_key_from_http_error_body() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_treats_403_invalid_api_key_as_auth_failure() -> None:
+    """Invalid-key messages on HTTP 403 responses should trigger re-auth."""
+
+    api_key = "bad-key"
+    response = FakeResponse(
+        status=403,
+        json_results=[
+            {
+                "error": {
+                    "message": f"API key not valid. Please pass a valid API key: {api_key}"
+                }
+            }
+        ],
+    )
+
+    with pytest.raises(client_mod.ConfigEntryAuthFailed) as exc_info:
+        await _fetch_with_response(response, api_key=api_key)
+
+    message = str(exc_info.value)
+    assert api_key not in message
+    assert "***" in message
+
+
+@pytest.mark.asyncio
 async def test_client_treats_400_invalid_api_key_as_auth_failure() -> None:
     """Invalid-key messages on generic 4xx responses should trigger re-auth."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -277,3 +277,18 @@ async def test_client_treats_400_invalid_api_key_as_auth_failure() -> None:
     message = str(exc_info.value)
     assert api_key not in message
     assert "***" in message
+
+
+@pytest.mark.asyncio
+async def test_client_treats_400_non_auth_error_as_update_failed() -> None:
+    """Non-auth generic 4xx responses should remain update failures."""
+
+    response = FakeResponse(
+        status=400,
+        json_results=[
+            {"error": {"message": "Invalid value at 'days': value is out of range"}}
+        ],
+    )
+
+    with pytest.raises(client_mod.UpdateFailed, match="HTTP 400"):
+        await _fetch_with_response(response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,3 +253,27 @@ async def test_client_redacts_api_key_from_http_error_body() -> None:
     message = str(exc_info.value)
     assert api_key not in message
     assert "***" in message
+
+
+@pytest.mark.asyncio
+async def test_client_treats_400_invalid_api_key_as_auth_failure() -> None:
+    """Invalid-key messages on generic 4xx responses should trigger re-auth."""
+
+    api_key = "bad-key"
+    response = FakeResponse(
+        status=400,
+        json_results=[
+            {
+                "error": {
+                    "message": f"API key not valid. Please pass a valid API key: {api_key}"
+                }
+            }
+        ],
+    )
+
+    with pytest.raises(client_mod.ConfigEntryAuthFailed) as exc_info:
+        await _fetch_with_response(response, api_key=api_key)
+
+    message = str(exc_info.value)
+    assert api_key not in message
+    assert "***" in message


### PR DESCRIPTION
### Motivation

- Ensure Google Pollen API responses that return a generic HTTP 4xx status, but include an invalid API key message, are treated as authentication failures.
- Allow Home Assistant to trigger reauthentication instead of reporting those cases as connectivity errors.
- Keep API key redaction intact in raised error messages.
- Prepare the follow-up release as `2.1.1`.

### Description

- Updated `custom_components/pollenlevels/client.py` to classify generic HTTP 4xx responses containing invalid API key messages as `ConfigEntryAuthFailed`.
- Refactored invalid API key classification into a shared private helper reused by both HTTP 403 and generic 4xx handling.
- Preserved existing behavior for:
  - HTTP 401 authentication failures.
  - HTTP 429 quota handling.
  - HTTP 5xx retry/update failure handling.
  - Generic non-auth HTTP 4xx responses.
- Added direct client regression coverage for:
  - HTTP 403 with an invalid API key message still raising `ConfigEntryAuthFailed`.
  - HTTP 400 with an invalid API key message raising `ConfigEntryAuthFailed`.
  - HTTP 400 with a non-auth error message still raising `UpdateFailed`.
  - API key redaction in raised error messages.
- Bumped the integration/package version to `2.1.1`.
- Added the `2.1.1` changelog entry.

### Testing

- `ruff check --fix --select I`
- `ruff check .`
- `black .`
- `black --check .`
- `pytest -q tests/test_client.py`
- `pytest -q`
- `python -m compileall -q custom_components tests`

### Notes

- No entity IDs, unique IDs, translation keys, options, public sensor payloads, config entry structure, Home Assistant minimum version, or Python requirement were changed.
- The Gemini review suggestion to extract the duplicated invalid API key classification into a shared helper has been addressed.
- Follow-up Gemini reviews reported no further feedback.