### PR TITLE
Harden release asset validation

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -27,8 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -f "${{ github.workspace }}/pollenlevels.zip"
-          cd "${{ github.workspace }}/custom_components/pollenlevels"
-          zip "${{ github.workspace }}/pollenlevels.zip" -r ./
+          git archive --format=zip --output="${{ github.workspace }}/pollenlevels.zip" HEAD:custom_components/pollenlevels
 
       - name: Validate ZIP structure (zip_release-compatible)
         shell: bash
@@ -51,6 +50,18 @@ jobs:
               raise SystemExit(
                   "ZIP contains 'custom_components/' prefix; "
                   "zip must be integration-root only"
+              )
+
+          generated = [
+              n
+              for n in names
+              if "__pycache__/" in n
+              or n.endswith((".pyc", ".pyo"))
+              or n.startswith((".pytest_cache/", ".ruff_cache/"))
+          ]
+          if generated:
+              raise SystemExit(
+                  "ZIP contains generated/cache files: " + ", ".join(generated)
               )
 
           missing = sorted(required.difference(names))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -f "${{ github.workspace }}/pollenlevels.zip"
-          cd "${{ github.workspace }}/custom_components/pollenlevels"
-          zip "${{ github.workspace }}/pollenlevels.zip" -r ./
+          git archive --format=zip --output="${{ github.workspace }}/pollenlevels.zip" HEAD:custom_components/pollenlevels
 
       - name: Validate ZIP structure (zip_release-compatible)
         shell: bash
@@ -87,6 +86,18 @@ jobs:
               raise SystemExit(
                   "ZIP contains 'custom_components/' prefix; "
                   "zip must be integration-root only"
+              )
+
+          generated = [
+              n
+              for n in names
+              if "__pycache__/" in n
+              or n.endswith((".pyc", ".pyo"))
+              or n.startswith((".pytest_cache/", ".ruff_cache/"))
+          ]
+          if generated:
+              raise SystemExit(
+                  "ZIP contains generated/cache files: " + ", ".join(generated)
               )
 
           missing = sorted(required.difference(names))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,40 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+          cache: "pip"
+
+      - name: Install validation dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade "black==25.*" "ruff==0.14.*" "pytest>=8,<9"
+
+      - name: Compile Python sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m compileall -q custom_components tests
+
+      - name: Ruff validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruff check .
+
+      - name: Black validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          black --check .
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          pytest -q
+        env:
+          PYTHONPATH: .
 
       - name: Build release ZIP (integration root at ZIP root)
         shell: bash


### PR DESCRIPTION
### Motivation

- Prevent uploading the release asset unless the repository passes the same basic validation expected before publishing.
- Ensure `pollenlevels.zip` is built from tracked integration files only, avoiding generated bytecode/cache files.
- Keep the HACS `zip_release` layout stable and safe.

### Description

- Updated `.github/workflows/release.yml` to run validation steps before building and uploading `pollenlevels.zip` on Python `3.14`.
- Added release-time validation:
  - `python -m compileall -q custom_components tests`
  - `ruff check .`
  - `black --check .`
  - `pytest -q`
- Installed only the validation tooling required for those checks:
  - `black==25.*`
  - `ruff==0.14.*`
  - `pytest>=8,<9`
- Build both release and package-test ZIPs with `git archive` so only tracked integration files are included.
- Preserve the HACS `zip_release` layout:
  - `manifest.json` at ZIP root.
  - `__init__.py` at ZIP root.
  - no `custom_components/` prefix.
- Strengthened both ZIP validation steps to reject generated/cache files:
  - `__pycache__/`
  - `.pyc`
  - `.pyo`
  - `.pytest_cache/`
  - `.ruff_cache/`
- Aligned `.github/workflows/package-test.yml` with the release ZIP packaging strategy.
- Preserved explicit workflow `permissions`, `concurrency`, versioned actions, ZIP filename, upload behavior, and artifact behavior.

### Testing

- `ruff check --fix --select I`
- `ruff check .`
- `python -m compileall -q custom_components tests`
- `black --check .`
- `pytest -q` — `187 passed`
- Validated workflow YAML syntax with a Ruby YAML load.
- Simulated the archive command and ZIP validation logic:
  - `git archive --format=zip --output=/tmp/pollenlevels-test.zip HEAD:custom_components/pollenlevels`
  - confirmed `manifest.json` is at the ZIP root.
  - confirmed `__init__.py` is at the ZIP root.
  - confirmed there is no `custom_components/` prefix.
  - confirmed generated/cache files are rejected by the validation logic.

### Notes

- No runtime integration code was changed.
- No changes were made to `manifest.json`, `pyproject.toml`, README, CHANGELOG, translations, entity IDs, unique IDs, options, config entry structure, or public sensor payloads.
- The previous review concern about `compileall` generating `__pycache__/*.pyc` files before packaging has been addressed by using `git archive` and adding explicit ZIP validation.