### PR TITLE
Harden sensitive HTTP error redaction

### DIFF
--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import MAX_RETRIES, POLLEN_API_TIMEOUT, is_invalid_api_key_message
-from .util import extract_error_message, redact_api_key
+from .util import extract_error_message, redact_sensitive_values
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +81,39 @@ class GooglePollenApiClient:
         _LOGGER.warning(message, *base_args, delay, attempt + 1, max_retries)
         await asyncio.sleep(delay)
 
+    def _redact_sensitive_message(
+        self,
+        value: object,
+        *,
+        latitude: float | str | None,
+        longitude: float | str | None,
+    ) -> str:
+        """Redact sensitive values from messages surfaced by the API client."""
+
+        return redact_sensitive_values(
+            value,
+            api_key=self._api_key,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+    async def _async_redacted_http_message(
+        self,
+        resp: Any,
+        *,
+        default: str,
+        latitude: float | str | None,
+        longitude: float | str | None,
+    ) -> tuple[str, str]:
+        """Extract, redact, and format an HTTP error response message."""
+
+        raw_message = self._redact_sensitive_message(
+            await extract_error_message(resp, default=default),
+            latitude=latitude,
+            longitude=longitude,
+        )
+        return raw_message, _format_http_message(resp.status, raw_message or None)
+
     async def async_fetch_pollen_data(
         self,
         *,
@@ -114,17 +147,21 @@ class GooglePollenApiClient:
                     timeout=ClientTimeout(total=POLLEN_API_TIMEOUT),
                 ) as resp:
                     if resp.status == 401:
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        _, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         raise ConfigEntryAuthFailed(message)
 
                     if resp.status == 403:
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        raw_message, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         _raise_auth_failed_if_invalid_api_key(raw_message, message)
                         raise UpdateFailed(message)
 
@@ -144,10 +181,12 @@ class GooglePollenApiClient:
                             )
                             await asyncio.sleep(delay)
                             continue
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        _, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         raise PollenQuotaExceededError(message)
 
                     if 500 <= resp.status <= 599:
@@ -162,25 +201,31 @@ class GooglePollenApiClient:
                                 base_args=(resp.status,),
                             )
                             continue
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        _, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         raise UpdateFailed(message)
 
                     if 400 <= resp.status < 500 and resp.status not in (403, 429):
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        raw_message, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         _raise_auth_failed_if_invalid_api_key(raw_message, message)
                         raise UpdateFailed(message)
 
                     if resp.status != 200:
-                        raw_message = redact_api_key(
-                            await extract_error_message(resp, default=""), self._api_key
+                        _, message = await self._async_redacted_http_message(
+                            resp,
+                            default="",
+                            latitude=latitude,
+                            longitude=longitude,
                         )
-                        message = _format_http_message(resp.status, raw_message or None)
                         raise UpdateFailed(message)
 
                     try:
@@ -213,7 +258,9 @@ class GooglePollenApiClient:
                     )
                     continue
                 msg = (
-                    redact_api_key(err, self._api_key)
+                    self._redact_sensitive_message(
+                        err, latitude=latitude, longitude=longitude
+                    )
                     or "Google Pollen API call timed out"
                 )
                 raise UpdateFailed(f"Timeout: {msg}") from err
@@ -228,14 +275,19 @@ class GooglePollenApiClient:
                         ),
                     )
                     continue
-                msg = redact_api_key(err, self._api_key) or (
-                    "Network error while calling the Google Pollen API"
+                msg = (
+                    self._redact_sensitive_message(
+                        err, latitude=latitude, longitude=longitude
+                    )
+                    or "Network error while calling the Google Pollen API"
                 )
                 raise UpdateFailed(msg) from err
             except UpdateFailed:
                 raise
             except Exception as err:  # noqa: BLE001
-                msg = redact_api_key(err, self._api_key)
+                msg = self._redact_sensitive_message(
+                    err, latitude=latitude, longitude=longitude
+                )
                 if not msg:
                     msg = "Unexpected error while calling the Google Pollen API"
                 _LOGGER.error("Pollen API error: %s", msg)

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+import re
 from typing import TYPE_CHECKING, Any
 
 from .const import FORECAST_SENSORS_CHOICES
@@ -50,23 +51,82 @@ async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
     return normalized or default
 
 
+_REDACTION_PLACEHOLDER = "***"
+_KEY_PARAM_RE = re.compile(r"(?i)(^|[?&\s])(key(?:=|%3d))([^&\s]+)")
+_LOCATION_PARAM_RE = re.compile(
+    r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
+)
+
+
+def _stringify_for_redaction(value: object) -> str:
+    """Return a string representation of *value* for safe redaction."""
+
+    if value is None:
+        return ""
+
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return value.decode()
+        except UnicodeDecodeError:
+            return value.decode(errors="replace")
+
+    return str(value)
+
+
+def _coordinate_values(value: float | str | None) -> set[str]:
+    """Return stable coordinate string forms that may appear in URLs/errors."""
+
+    if value is None:
+        return set()
+
+    value_str = str(value)
+    values = {value_str}
+    try:
+        parsed = float(value_str)
+    except ValueError:
+        return {item for item in values if item}
+
+    if math.isfinite(parsed):
+        values.add(f"{parsed:.6f}")
+
+    return {item for item in values if item}
+
+
+def redact_sensitive_values(
+    value: object,
+    api_key: str | None = None,
+    latitude: float | str | None = None,
+    longitude: float | str | None = None,
+) -> str:
+    """Return *value* as text with API keys and precise coordinates redacted."""
+
+    s = _stringify_for_redaction(value)
+    if not s:
+        return ""
+
+    if api_key:
+        s = s.replace(api_key, _REDACTION_PLACEHOLDER)
+
+    s = _KEY_PARAM_RE.sub(
+        lambda match: (f"{match.group(1)}{match.group(2)}{_REDACTION_PLACEHOLDER}"),
+        s,
+    )
+    s = _LOCATION_PARAM_RE.sub(
+        lambda match: f"{match.group(1)}{_REDACTION_PLACEHOLDER}",
+        s,
+    )
+
+    coordinates = _coordinate_values(latitude) | _coordinate_values(longitude)
+    for coordinate in sorted(coordinates, key=len, reverse=True):
+        s = s.replace(coordinate, _REDACTION_PLACEHOLDER)
+
+    return s
+
+
 def redact_api_key(text: object, api_key: str | None) -> str:
     """Return a string representation of *text* with the API key redacted."""
 
-    if text is None:
-        return ""
-
-    if isinstance(text, (bytes, bytearray)):
-        try:
-            s = text.decode()
-        except UnicodeDecodeError:
-            s = text.decode(errors="replace")
-    else:
-        s = str(text)
-
-    if api_key:
-        s = s.replace(api_key, "***")
-    return s
+    return redact_sensitive_values(text, api_key=api_key)
 
 
 def normalize_sensor_mode(mode: Any, logger: logging.Logger) -> str:
@@ -116,6 +176,7 @@ __all__ = [
     "extract_error_message",
     "normalize_sensor_mode",
     "redact_api_key",
+    "redact_sensitive_values",
     "safe_parse_int",
     "_redact_api_key",
 ]

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -116,9 +116,18 @@ def redact_sensitive_values(
         s,
     )
 
-    coordinates = _coordinate_values(latitude) | _coordinate_values(longitude)
-    for coordinate in sorted(coordinates, key=len, reverse=True):
-        s = s.replace(coordinate, _REDACTION_PLACEHOLDER)
+    coordinates = sorted(
+        _coordinate_values(latitude) | _coordinate_values(longitude),
+        key=len,
+        reverse=True,
+    )
+    if coordinates:
+        pattern = "|".join(re.escape(coordinate) for coordinate in coordinates)
+        s = re.sub(
+            rf"(?<![\d.+-])({pattern})(?![\d.])",
+            _REDACTION_PLACEHOLDER,
+            s,
+        )
 
     return s
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -188,13 +188,30 @@ class FakeSession:
         return self.response
 
 
-async def _fetch_with_response(response: FakeResponse, api_key: str = "test") -> None:
+class RaisingSession:
+    """Raise an aiohttp-like client error for each GET call."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def get(self, *_args: Any, **_kwargs: Any) -> FakeResponse:
+        """Raise the configured error."""
+
+        raise self.error
+
+
+async def _fetch_with_response(
+    response: FakeResponse,
+    api_key: str = "test",
+    latitude: float = 1.0,
+    longitude: float = 2.0,
+) -> None:
     """Execute a direct client fetch using a fake session."""
 
     client = client_mod.GooglePollenApiClient(FakeSession(response), api_key)
     await client.async_fetch_pollen_data(
-        latitude=1.0,
-        longitude=2.0,
+        latitude=latitude,
+        longitude=longitude,
         days=1,
         language_code=None,
     )
@@ -252,6 +269,69 @@ async def test_client_redacts_api_key_from_http_error_body() -> None:
 
     message = str(exc_info.value)
     assert api_key not in message
+    assert "***" in message
+
+
+@pytest.mark.asyncio
+async def test_client_redacts_sensitive_values_from_url_like_http_error() -> None:
+    """URL-like HTTP error messages should not expose secrets or coordinates."""
+
+    api_key = "bad-key"
+    latitude = 40.4168
+    longitude = -3.7038
+    url = (
+        "https://pollen.googleapis.com/v1/forecast:lookup?"
+        f"key={api_key}&location.latitude={latitude}&"
+        f"location.longitude={longitude}&days=1"
+    )
+    response = FakeResponse(
+        status=400,
+        json_results=[ValueError("invalid JSON")],
+        text_body=f"Backend rejected request URL {url}",
+    )
+
+    with pytest.raises(client_mod.UpdateFailed) as exc_info:
+        await _fetch_with_response(
+            response, api_key=api_key, latitude=latitude, longitude=longitude
+        )
+
+    message = str(exc_info.value)
+    assert api_key not in message
+    assert str(latitude) not in message
+    assert str(longitude) not in message
+    assert "***" in message
+
+
+@pytest.mark.asyncio
+async def test_client_redacts_sensitive_values_from_client_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ClientError messages should not expose secrets or coordinates."""
+
+    monkeypatch.setattr(client_mod, "MAX_RETRIES", 0)
+    api_key = "bad-key"
+    latitude = 40.4168
+    longitude = -3.7038
+    error = client_mod.ClientError(
+        "request failed: "
+        "https://pollen.googleapis.com/v1/forecast:lookup?"
+        f"key={api_key}&location.latitude={latitude}&"
+        f"location.longitude={longitude}&days=1"
+    )
+    client = client_mod.GooglePollenApiClient(RaisingSession(error), api_key)
+
+    with pytest.raises(client_mod.UpdateFailed) as exc_info:
+        await client.async_fetch_pollen_data(
+            latitude=latitude,
+            longitude=longitude,
+            days=1,
+            language_code=None,
+        )
+
+    message = str(exc_info.value)
+    assert api_key not in message
+    assert str(latitude) not in message
+    assert str(longitude) not in message
     assert "***" in message
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from custom_components.pollenlevels.util import redact_api_key, safe_parse_int
+from custom_components.pollenlevels.util import (
+    redact_api_key,
+    redact_sensitive_values,
+    safe_parse_int,
+)
 
 
 def test_redact_api_key_handles_non_utf8_bytes():
@@ -23,6 +27,80 @@ def test_redact_api_key_returns_empty_string_for_none():
     """None inputs should yield an empty string."""
 
     assert redact_api_key(None, "anything") == ""
+
+
+def test_redact_sensitive_values_returns_empty_string_for_none():
+    """None inputs should yield an empty string."""
+
+    assert redact_sensitive_values(None, api_key="SECRET") == ""
+
+
+def test_redact_sensitive_values_redacts_exact_api_key():
+    """Exact API key values should be redacted."""
+
+    redacted = redact_sensitive_values("API key SECRET failed", api_key="SECRET")
+
+    assert "SECRET" not in redacted
+    assert "***" in redacted
+
+
+def test_redact_sensitive_values_redacts_key_query_parameter():
+    """Key query parameters should have their values redacted."""
+
+    redacted = redact_sensitive_values("https://example.test/?key=bad-key&days=5")
+
+    assert "bad-key" not in redacted
+    assert "key=***" in redacted
+    assert "days=5" in redacted
+
+
+def test_redact_sensitive_values_redacts_coordinate_query_parameters():
+    """Coordinate query parameters should have their values redacted."""
+
+    redacted = redact_sensitive_values(
+        "location.latitude=40.4168&location.longitude=-3.7038&days=5"
+    )
+
+    assert "40.4168" not in redacted
+    assert "-3.7038" not in redacted
+    assert "location.latitude=***" in redacted
+    assert "location.longitude=***" in redacted
+    assert "days=5" in redacted
+
+
+def test_redact_sensitive_values_redacts_url_encoded_coordinate_parameters():
+    """URL-encoded coordinate parameters should have their values redacted."""
+
+    redacted = redact_sensitive_values(
+        "location.latitude%3D40.4168&location.longitude%3D-3.7038"
+    )
+
+    assert "40.4168" not in redacted
+    assert "-3.7038" not in redacted
+    assert "location.latitude%3D***" in redacted
+    assert "location.longitude%3D***" in redacted
+
+
+def test_redact_sensitive_values_redacts_explicit_coordinates():
+    """Explicit coordinate values should be redacted when they appear in text."""
+
+    redacted = redact_sensitive_values(
+        "Coordinates 40.416800 and -3.703800 failed",
+        latitude=40.4168,
+        longitude=-3.7038,
+    )
+
+    assert "40.416800" not in redacted
+    assert "-3.703800" not in redacted
+    assert redacted.count("***") == 2
+
+
+def test_redact_sensitive_values_preserves_unrelated_numbers():
+    """Unrelated numbers should not be redacted."""
+
+    redacted = redact_sensitive_values("HTTP 400 days=5 Retry-After: 30")
+
+    assert redacted == "HTTP 400 days=5 Retry-After: 30"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,8 +1,22 @@
 """Tests for shared utilities."""
 
+import sys
+import types
+from pathlib import Path
+
 import pytest
 
-from custom_components.pollenlevels.util import (
+ROOT = Path(__file__).resolve().parents[1]
+custom_components_pkg = sys.modules.setdefault(
+    "custom_components", types.ModuleType("custom_components")
+)
+custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+pollenlevels_pkg = sys.modules.setdefault(
+    "custom_components.pollenlevels", types.ModuleType("custom_components.pollenlevels")
+)
+pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
+
+from custom_components.pollenlevels.util import (  # noqa: E402
     redact_api_key,
     redact_sensitive_values,
     safe_parse_int,
@@ -101,6 +115,41 @@ def test_redact_sensitive_values_preserves_unrelated_numbers():
     redacted = redact_sensitive_values("HTTP 400 days=5 Retry-After: 30")
 
     assert redacted == "HTTP 400 days=5 Retry-After: 30"
+
+
+@pytest.mark.parametrize(
+    ("message", "latitude"),
+    [
+        ("HTTP 404", "40"),
+        ("value 140", "40"),
+        ("value -40", "40"),
+    ],
+)
+def test_redact_sensitive_values_does_not_redact_partial_integer_coordinates(
+    message, latitude
+):
+    """Explicit integer coordinates should not redact partial numeric matches."""
+
+    assert redact_sensitive_values(message, latitude=latitude) == message
+
+
+@pytest.mark.parametrize("message", ["value 140.0", "value 40.01"])
+def test_redact_sensitive_values_does_not_redact_partial_decimal_coordinates(message):
+    """Explicit decimal coordinates should not redact partial decimal matches."""
+
+    assert redact_sensitive_values(message, latitude=40.0) == message
+
+
+@pytest.mark.parametrize("coordinate", ["40.0", "40.000000"])
+def test_redact_sensitive_values_still_redacts_exact_coordinate_values(coordinate):
+    """Exact explicit coordinate values should still be redacted."""
+
+    redacted = redact_sensitive_values(
+        f"Coordinates {coordinate} failed", latitude=40.0
+    )
+
+    assert coordinate not in redacted
+    assert "***" in redacted
 
 
 @pytest.mark.parametrize(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,20 +7,69 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-custom_components_pkg = sys.modules.setdefault(
-    "custom_components", types.ModuleType("custom_components")
-)
-custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-pollenlevels_pkg = sys.modules.setdefault(
-    "custom_components.pollenlevels", types.ModuleType("custom_components.pollenlevels")
-)
-pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
+_SENTINEL = object()
 
-from custom_components.pollenlevels.util import (  # noqa: E402
-    redact_api_key,
-    redact_sensitive_values,
-    safe_parse_int,
-)
+
+def _set_module(
+    snapshot: dict[str, object], name: str, module: types.ModuleType
+) -> None:
+    """Set a temporary module while preserving its previous value."""
+
+    snapshot.setdefault(name, sys.modules.get(name, _SENTINEL))
+    sys.modules[name] = module
+
+
+def _restore_modules(snapshot: dict[str, object]) -> None:
+    """Restore modules changed only for importing the util module under test."""
+
+    for name, module in reversed(snapshot.items()):
+        if module is _SENTINEL:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module  # type: ignore[assignment]
+
+
+def _install_util_import_stubs() -> dict[str, object]:
+    """Install package stubs required to import util.py directly."""
+
+    snapshot: dict[str, object] = {}
+
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+    _set_module(snapshot, "custom_components", custom_components_pkg)
+
+    pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
+    pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
+    _set_module(snapshot, "custom_components.pollenlevels", pollenlevels_pkg)
+
+    for name in (
+        "custom_components.pollenlevels.const",
+        "custom_components.pollenlevels.util",
+    ):
+        snapshot.setdefault(name, sys.modules.get(name, _SENTINEL))
+
+    return snapshot
+
+
+def _import_util_module() -> types.ModuleType:
+    """Import util.py with local stubs and avoid leaking them globally."""
+
+    snapshot = _install_util_import_stubs()
+    try:
+        from custom_components.pollenlevels import util as imported_util
+
+        return imported_util
+    finally:
+        pollenlevels_pkg = sys.modules.get("custom_components.pollenlevels")
+        if pollenlevels_pkg is not None and hasattr(pollenlevels_pkg, "util"):
+            delattr(pollenlevels_pkg, "util")
+        _restore_modules(snapshot)
+
+
+util_mod = _import_util_module()
+redact_api_key = util_mod.redact_api_key
+redact_sensitive_values = util_mod.redact_sensitive_values
+safe_parse_int = util_mod.safe_parse_int
 
 
 def test_redact_api_key_handles_non_utf8_bytes():


### PR DESCRIPTION

### Motivation

- Prevent accidental leakage of API keys and precise coordinates when exception messages or full URLs appear in HTTP error bodies or network errors.
- Reduce duplicated HTTP error extraction, redaction, and formatting logic in the client.
- Centralize privacy handling while preserving the existing HTTP error semantics.

### Description

- Added `redact_sensitive_values(value, api_key=None, latitude=None, longitude=None)` in `custom_components/pollenlevels/util.py`.
- Redacts:
  - Exact API key values.
  - `key=` query parameters.
  - `location.latitude` and `location.longitude` query parameters.
  - URL-encoded coordinate query parameters using `%3D`.
  - Explicit latitude and longitude values passed by the caller.
- Avoids over-redaction of unrelated or partial numeric matches, such as `40` inside `404` or `140`.
- Kept `redact_api_key(...)` as a backwards-compatible thin wrapper around `redact_sensitive_values(...)`.
- Centralized client-side HTTP error message handling in `custom_components/pollenlevels/client.py` by introducing:
  - `_redact_sensitive_message(...)`
  - `_async_redacted_http_message(...)`
- Replaced repeated `extract_error_message(...)` + redaction + `_format_http_message(...)` sequences for:
  - HTTP 401
  - HTTP 403
  - HTTP 429
  - HTTP 5xx
  - Generic HTTP 4xx
  - Non-200 fallback responses
- Redacted sensitive values from non-HTTP error paths:
  - `TimeoutError`
  - `ClientError`
  - Generic unexpected exceptions
- Added focused regression tests for:
  - URL-like HTTP error bodies containing API key and coordinates.
  - `ClientError` messages containing full URLs.
  - API key redaction.
  - `key=` query parameter redaction.
  - `location.latitude` / `location.longitude` redaction.
  - URL-encoded coordinate parameter redaction.
  - Explicit coordinate value redaction.
  - Avoiding partial numeric over-redaction.
  - Isolated `util.py` import stubs without leaking package stubs through `sys.modules`.

### Behavior preserved

- HTTP 401 still raises `ConfigEntryAuthFailed`.
- HTTP 403 with an invalid API key message still raises `ConfigEntryAuthFailed`.
- HTTP 403 without an invalid API key message still raises `UpdateFailed`.
- HTTP 429 still raises `PollenQuotaExceededError`.
- HTTP 5xx retry behavior is unchanged.
- Generic HTTP 4xx responses with invalid API key messages still raise `ConfigEntryAuthFailed`.
- Generic non-auth HTTP 4xx responses still raise `UpdateFailed`.
- No entity IDs, unique IDs, translation keys, config entry data/options, public sensor payloads, diagnostics shape, Home Assistant minimum version, Python requirement, or version numbers were changed.

### Testing

- `ruff check .`
- `black --check .`
- `pytest -q tests/test_util.py`
- `pytest -q tests/test_client.py`
- `pytest -q`
- `python -m compileall -q custom_components tests`

CI result:

- Lint: success
- tests: success, `203 passed`
- Validate with hassfest: success
- Validate with HACS: success

### Release notes

- This PR intentionally does not update `CHANGELOG.md` or bump the version.
- The change will be accumulated for the planned `2.2.0-rc1` release.