### PR TITLE
Unify config validation helpers

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import math
 from collections.abc import Awaitable
 from typing import Any
 
@@ -42,7 +41,12 @@ from .const import (
 from .coordinator import PollenDataUpdateCoordinator
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .sensor import ForecastSensorMode
-from .util import normalize_sensor_mode, redact_api_key, safe_parse_int
+from .util import (
+    normalize_sensor_mode,
+    redact_api_key,
+    safe_parse_int,
+    validate_location_pair,
+)
 
 # Ensure YAML config is entry-only for this domain (no YAML schema).
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -224,27 +228,14 @@ async def async_setup_entry(
 
     raw_lat = entry.data.get(CONF_LATITUDE)
     raw_lon = entry.data.get(CONF_LONGITUDE)
-    try:
-        lat = float(raw_lat)
-        lon = float(raw_lon)
-    except (TypeError, ValueError) as err:
+    latlon = validate_location_pair(raw_lat, raw_lon)
+    if latlon is None:
         _LOGGER.warning(
             "Invalid config entry coordinates for entry %s",
             entry.entry_id,
         )
-        raise ConfigEntryNotReady from err
-
-    if (
-        not math.isfinite(lat)
-        or not math.isfinite(lon)
-        or not (-90.0 <= lat <= 90.0)
-        or not (-180.0 <= lon <= 180.0)
-    ):
-        _LOGGER.warning(
-            "Out-of-range or non-finite coordinates for entry %s",
-            entry.entry_id,
-        )
         raise ConfigEntryNotReady
+    lat, lon = latlon
 
     raw_title = entry.title or ""
     clean_title = raw_title.strip() or DEFAULT_ENTRY_TITLE

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -106,7 +106,7 @@ def _language_error_to_form_key(error: vol.Invalid) -> str:
     return "invalid_language_format"
 
 
-def _safe_coord(value: float | None, *, lat: bool) -> float | None:
+def _safe_coord(value: Any, *, lat: bool) -> float | None:
     """Return a validated latitude/longitude or None if unset/invalid."""
     if lat:
         return validate_latitude(value)

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -60,6 +60,7 @@ from .const import (
 from .util import (
     normalize_sensor_mode,
     redact_api_key,
+    redact_sensitive_values,
     safe_parse_int,
     validate_latitude,
     validate_location_pair,
@@ -134,6 +135,21 @@ def _safe_error_message(error: Exception | str, fallback: str) -> str:
     """Return a non-empty error message suitable for form placeholders."""
     message = str(error).strip()
     return message or fallback
+
+
+def _redact_validation_error(
+    error: object,
+    api_key: str | None,
+    latitude: float | None,
+    longitude: float | None,
+) -> str:
+    """Redact validation errors before logging or showing placeholders."""
+    return redact_sensitive_values(
+        error,
+        api_key=api_key,
+        latitude=latitude,
+        longitude=longitude,
+    ).strip()
 
 
 def _build_step_user_schema(hass: Any, user_input: dict[str, Any] | None) -> vol.Schema:
@@ -442,13 +458,13 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ConfigEntryAuthFailed as err:
             _LOGGER.warning("Authentication failed during validation")
             errors["base"] = "invalid_auth"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Authentication failed."
             )
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             if re.fullmatch(r"HTTP\s+429(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
             placeholders["error_message"] = _safe_error_message(
@@ -456,33 +472,36 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             if re.fullmatch(r"HTTP\s+\d+(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Failed to connect to the pollen service."
             )
         except TimeoutError as err:
-            _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
+            _LOGGER.warning(
+                "Validation timeout: %s",
+                _redact_validation_error(err, api_key, lat, lon),
+            )
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Validation request timed out."
             )
         except aiohttp.ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
-                redact_api_key(err, api_key),
+                _redact_validation_error(err, api_key, lat, lon),
             )
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Network error while connecting to the pollen service."
             )
         except Exception as err:  # defensive
             _LOGGER.exception(
                 "Unexpected error in Pollen Levels config flow while validating input: %s",
-                redact_api_key(err, api_key),
+                _redact_validation_error(err, api_key, lat, lon),
             )
             errors["base"] = "unknown"
             placeholders.pop("error_message", None)

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -18,7 +18,6 @@ import re
 from typing import Any
 
 import aiohttp
-import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, CONF_NAME
@@ -62,6 +61,9 @@ from .util import (
     normalize_sensor_mode,
     redact_api_key,
     safe_parse_int,
+    validate_latitude,
+    validate_location_pair,
+    validate_longitude,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,6 +71,7 @@ _LOGGER = logging.getLogger(__name__)
 FORECAST_DAYS_OPTIONS = [
     str(i) for i in range(MIN_FORECAST_DAYS, MAX_FORECAST_DAYS + 1)
 ]
+_FORECAST_MODE_MIN_DAYS = {"D+1": 2, "D+1+2": 3}
 
 # BCP-47-ish regex (common patterns, not full grammar).
 LANGUAGE_CODE_REGEX = re.compile(
@@ -105,12 +108,32 @@ def _language_error_to_form_key(error: vol.Invalid) -> str:
 
 def _safe_coord(value: float | None, *, lat: bool) -> float | None:
     """Return a validated latitude/longitude or None if unset/invalid."""
-    try:
-        if lat:
-            return cv.latitude(value)
-        return cv.longitude(value)
-    except vol.Invalid, TypeError, ValueError:
-        return None
+    if lat:
+        return validate_latitude(value)
+    return validate_longitude(value)
+
+
+def _required_forecast_days_for_mode(mode: str) -> int:
+    """Return the minimum forecast days required for a sensor mode."""
+    return _FORECAST_MODE_MIN_DAYS.get(mode, MIN_FORECAST_DAYS)
+
+
+def _normalize_forecast_mode_for_save(raw_value: Any) -> str:
+    """Normalize a forecast sensor mode before saving it."""
+    return normalize_sensor_mode(raw_value, _LOGGER)
+
+
+def _forecast_mode_combo_error(forecast_days: int, mode: str) -> str | None:
+    """Return an error key when forecast days and mode are incompatible."""
+    if forecast_days < _required_forecast_days_for_mode(mode):
+        return "invalid_option_combo"
+    return None
+
+
+def _safe_error_message(error: Exception | str, fallback: str) -> str:
+    """Return a non-empty error message suitable for form placeholders."""
+    message = str(error).strip()
+    return message or fallback
 
 
 def _build_step_user_schema(hass: Any, user_input: dict[str, Any] | None) -> vol.Schema:
@@ -204,16 +227,7 @@ def _validate_location_dict(
     lat_val = location.get(CONF_LATITUDE)
     lon_val = location.get(CONF_LONGITUDE)
 
-    if lat_val is None or lon_val is None:
-        return None
-
-    try:
-        lat = cv.latitude(lat_val)
-        lon = cv.longitude(lon_val)
-    except vol.Invalid, TypeError, ValueError:
-        return None
-
-    return lat, lon
+    return validate_location_pair(lat_val, lon_val)
 
 
 def _parse_int_option(
@@ -332,13 +346,12 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             placeholders.pop("error_message", None)
             return errors, None
 
-        mode = normalized.get(CONF_CREATE_FORECAST_SENSORS, FORECAST_SENSORS_CHOICES[0])
-        if mode not in FORECAST_SENSORS_CHOICES:
-            mode = FORECAST_SENSORS_CHOICES[0]
-            normalized[CONF_CREATE_FORECAST_SENSORS] = mode
-        needed = {"D+1": 2, "D+1+2": 3}.get(mode, 1)
-        if forecast_days < needed:
-            errors[CONF_CREATE_FORECAST_SENSORS] = "invalid_option_combo"
+        mode = _normalize_forecast_mode_for_save(
+            normalized.get(CONF_CREATE_FORECAST_SENSORS, FORECAST_SENSORS_CHOICES[0])
+        )
+        combo_error = _forecast_mode_combo_error(forecast_days, mode)
+        if combo_error:
+            errors[CONF_CREATE_FORECAST_SENSORS] = combo_error
             placeholders.pop("error_message", None)
             return errors, None
         normalized[CONF_CREATE_FORECAST_SENSORS] = mode
@@ -354,11 +367,10 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 placeholders.pop("error_message", None)
                 return errors, None
         else:
-            try:
-                lat = cv.latitude(user_input.get(CONF_LATITUDE))
-                lon = cv.longitude(user_input.get(CONF_LONGITUDE))
-                latlon = (lat, lon)
-            except vol.Invalid, TypeError:
+            latlon = validate_location_pair(
+                user_input.get(CONF_LATITUDE), user_input.get(CONF_LONGITUDE)
+            )
+            if latlon is None:
                 _LOGGER.debug(
                     "Invalid coordinates provided (values redacted): parsing failed"
                 )
@@ -431,26 +443,32 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.warning("Authentication failed during validation")
             errors["base"] = "invalid_auth"
             redacted = redact_api_key(err, api_key).strip()
-            placeholders["error_message"] = redacted or "Authentication failed."
+            placeholders["error_message"] = _safe_error_message(
+                redacted, "Authentication failed."
+            )
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
             redacted = redact_api_key(err, api_key).strip()
             if re.fullmatch(r"HTTP\s+429(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
-            placeholders["error_message"] = redacted or "Quota exceeded."
+            placeholders["error_message"] = _safe_error_message(
+                redacted, "Quota exceeded."
+            )
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key).strip()
             if re.fullmatch(r"HTTP\s+\d+(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
-            placeholders["error_message"] = (
-                redacted or "Failed to connect to the pollen service."
+            placeholders["error_message"] = _safe_error_message(
+                redacted, "Failed to connect to the pollen service."
             )
         except TimeoutError as err:
             _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key).strip()
-            placeholders["error_message"] = redacted or "Validation request timed out."
+            placeholders["error_message"] = _safe_error_message(
+                redacted, "Validation request timed out."
+            )
         except aiohttp.ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
@@ -458,8 +476,8 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors["base"] = "cannot_connect"
             redacted = redact_api_key(err, api_key).strip()
-            placeholders["error_message"] = (
-                redacted or "Network error while connecting to the pollen service."
+            placeholders["error_message"] = _safe_error_message(
+                redacted, "Network error while connecting to the pollen service."
             )
         except Exception as err:  # defensive
             _LOGGER.exception(
@@ -693,15 +711,16 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
                 normalized_input[CONF_LANGUAGE_CODE] = lang
 
                 days = normalized_input[CONF_FORECAST_DAYS]
-                mode = normalized_input.get(
-                    CONF_CREATE_FORECAST_SENSORS,
-                    current_mode,
+                mode = _normalize_forecast_mode_for_save(
+                    normalized_input.get(
+                        CONF_CREATE_FORECAST_SENSORS,
+                        current_mode,
+                    )
                 )
-                mode = normalize_sensor_mode(mode, _LOGGER)
                 normalized_input[CONF_CREATE_FORECAST_SENSORS] = mode
-                needed = {"D+1": 2, "D+1+2": 3}.get(mode, 1)
-                if days < needed:
-                    errors[CONF_CREATE_FORECAST_SENSORS] = "invalid_option_combo"
+                combo_error = _forecast_mode_combo_error(days, mode)
+                if combo_error:
+                    errors[CONF_CREATE_FORECAST_SENSORS] = combo_error
 
             except vol.Invalid as ve:
                 _LOGGER.warning(

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -138,6 +138,50 @@ def redact_api_key(text: object, api_key: str | None) -> str:
     return redact_sensitive_values(text, api_key=api_key)
 
 
+def parse_finite_float(value: Any) -> float | None:
+    """Parse a finite float value, rejecting bools and invalid input."""
+    if value is None or isinstance(value, bool):
+        return None
+
+    try:
+        parsed = float(value)
+    except TypeError, ValueError, OverflowError:
+        return None
+
+    if not math.isfinite(parsed):
+        return None
+
+    return parsed
+
+
+def validate_latitude(value: Any) -> float | None:
+    """Return a normalized latitude float or None when invalid."""
+    parsed = parse_finite_float(value)
+    if parsed is None or not -90.0 <= parsed <= 90.0:
+        return None
+
+    return parsed
+
+
+def validate_longitude(value: Any) -> float | None:
+    """Return a normalized longitude float or None when invalid."""
+    parsed = parse_finite_float(value)
+    if parsed is None or not -180.0 <= parsed <= 180.0:
+        return None
+
+    return parsed
+
+
+def validate_location_pair(latitude: Any, longitude: Any) -> tuple[float, float] | None:
+    """Return a normalized coordinate pair or None when either value is invalid."""
+    parsed_latitude = validate_latitude(latitude)
+    parsed_longitude = validate_longitude(longitude)
+    if parsed_latitude is None or parsed_longitude is None:
+        return None
+
+    return parsed_latitude, parsed_longitude
+
+
 def normalize_sensor_mode(mode: Any, logger: logging.Logger) -> str:
     """Normalize sensor mode, defaulting and logging a warning if invalid."""
     raw_mode = getattr(mode, "value", mode)
@@ -184,8 +228,12 @@ _redact_api_key = redact_api_key
 __all__ = [
     "extract_error_message",
     "normalize_sensor_mode",
+    "parse_finite_float",
     "redact_api_key",
     "redact_sensitive_values",
     "safe_parse_int",
+    "validate_latitude",
+    "validate_location_pair",
+    "validate_longitude",
     "_redact_api_key",
 ]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1169,6 +1169,181 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
     assert "error_message" not in placeholders
 
 
+@pytest.mark.parametrize(
+    ("forecast_days", "mode"),
+    [(1, "D+1"), (2, "D+1+2")],
+)
+def test_validate_input_invalid_forecast_mode_combinations(
+    forecast_days: int,
+    mode: str,
+) -> None:
+    """User flow should reject forecast modes requiring more forecast days."""
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            {
+                **_base_user_input(),
+                CONF_FORECAST_DAYS: forecast_days,
+                CONF_CREATE_FORECAST_SENSORS: mode,
+            },
+            check_unique_id=False,
+        )
+    )
+
+    assert errors == {CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"}
+    assert normalized is None
+
+
+@pytest.mark.parametrize(
+    ("forecast_days", "mode"),
+    [(2, "D+1"), (3, "D+1+2"), (1, "none")],
+)
+def test_validate_input_valid_forecast_mode_combinations_are_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+    forecast_days: int,
+    mode: str,
+) -> None:
+    """User flow should accept forecast mode combinations that have enough days."""
+
+    calls = _patch_client_fetch(monkeypatch, result={"dailyInfo": [{"day": "D0"}]})
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            {
+                **_base_user_input(),
+                CONF_FORECAST_DAYS: forecast_days,
+                CONF_CREATE_FORECAST_SENSORS: mode,
+            },
+            check_unique_id=False,
+        )
+    )
+
+    assert calls
+    assert errors == {}
+    assert normalized is not None
+    assert normalized[CONF_FORECAST_DAYS] == forecast_days
+    assert normalized[CONF_CREATE_FORECAST_SENSORS] == mode
+
+
+def test_validate_input_invalid_forecast_days_returns_error() -> None:
+    """Invalid forecast days should keep the dedicated field error key."""
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            {**_base_user_input(), CONF_FORECAST_DAYS: "not-a-number"},
+            check_unique_id=False,
+        )
+    )
+
+    assert errors == {CONF_FORECAST_DAYS: "invalid_forecast_days"}
+    assert normalized is None
+
+
+@pytest.mark.parametrize(
+    ("forecast_days", "mode"),
+    [(1, "D+1"), (2, "D+1+2")],
+)
+def test_options_flow_invalid_forecast_mode_combinations(
+    forecast_days: int,
+    mode: str,
+) -> None:
+    """Options flow should reject forecast modes requiring more forecast days."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
+    )
+    flow = cf.PollenLevelsOptionsFlow(entry)
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "form",
+        **kwargs,
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "create_entry",
+        **kwargs,
+    }
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {
+                CONF_FORECAST_DAYS: forecast_days,
+                CONF_CREATE_FORECAST_SENSORS: mode,
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"}
+
+
+@pytest.mark.parametrize(
+    ("forecast_days", "mode"),
+    [(2, "D+1"), (3, "D+1+2"), (1, "none")],
+)
+def test_options_flow_valid_forecast_mode_combinations_are_accepted(
+    forecast_days: int,
+    mode: str,
+) -> None:
+    """Options flow should accept forecast mode combinations with enough days."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
+    )
+    flow = cf.PollenLevelsOptionsFlow(entry)
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "form",
+        **kwargs,
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "create_entry",
+        **kwargs,
+    }
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {
+                CONF_FORECAST_DAYS: forecast_days,
+                CONF_CREATE_FORECAST_SENSORS: mode,
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_FORECAST_DAYS] == forecast_days
+    assert result["data"][CONF_CREATE_FORECAST_SENSORS] == mode
+
+
+def test_options_flow_invalid_forecast_days_returns_error() -> None:
+    """Options flow should keep the dedicated invalid forecast days field error."""
+
+    entry = cf.config_entries.ConfigEntry(data={CONF_FORECAST_DAYS: 3})
+    flow = cf.PollenLevelsOptionsFlow(entry)
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "form",
+        **kwargs,
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "create_entry",
+        **kwargs,
+    }
+
+    result = asyncio.run(flow.async_step_init({CONF_FORECAST_DAYS: "not-a-number"}))
+
+    assert result["type"] == "form"
+    assert result["errors"] == {CONF_FORECAST_DAYS: "invalid_forecast_days"}
+
+
 def test_validate_input_auth_error_sets_error_message_placeholder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1085,6 +1085,46 @@ def test_validate_input_http_500_sets_error_message_placeholder(
     assert placeholders.get("error_message")
 
 
+def test_validate_input_update_failed_redacts_api_key_and_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UpdateFailed placeholders should redact API keys and precise coordinates."""
+
+    user_input = _base_user_input()
+    latitude = "48.8566123"
+    longitude = "2.3522456"
+    user_input[CONF_LOCATION] = {CONF_LATITUDE: latitude, CONF_LONGITUDE: longitude}
+    api_key = user_input[CONF_API_KEY]
+    calls = _patch_client_fetch(
+        monkeypatch,
+        error=UpdateFailed(
+            f"API key {api_key} failed for "
+            f"location.latitude={latitude} location.longitude={longitude}"
+        ),
+    )
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            user_input,
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    error_message = placeholders.get("error_message", "")
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert api_key not in error_message
+    assert latitude not in error_message
+    assert longitude not in error_message
+    assert "***" in error_message
+
+
 def test_validate_input_clears_error_message_placeholder_on_validation_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -441,6 +441,26 @@ def test_setup_entry_invalid_coordinates_raise_not_ready() -> None:
         asyncio.run(integration.async_setup_entry(hass, entry))
 
 
+def test_setup_entry_invalid_coordinates_do_not_log_precise_values(caplog) -> None:
+    """Invalid coordinates should fail without logging precise coordinate values."""
+
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 91.123456,
+            integration.CONF_LONGITUDE: 2.654321,
+        }
+    )
+
+    with pytest.raises(integration.ConfigEntryNotReady):
+        asyncio.run(integration.async_setup_entry(hass, entry))
+
+    log_text = caplog.text
+    assert "91.123456" not in log_text
+    assert "2.654321" not in log_text
+
+
 def test_setup_entry_nonfinite_or_out_of_range_coordinates_raise_not_ready() -> None:
     """Non-finite or out-of-range coordinates should trigger ConfigEntryNotReady."""
 
@@ -463,6 +483,40 @@ def test_setup_entry_nonfinite_or_out_of_range_coordinates_raise_not_ready() -> 
 
         with pytest.raises(integration.ConfigEntryNotReady):
             asyncio.run(integration.async_setup_entry(hass, entry))
+
+
+def test_setup_entry_boolean_coordinates_raise_not_ready() -> None:
+    """Boolean coordinates should trigger ConfigEntryNotReady."""
+
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: True,
+            integration.CONF_LONGITUDE: 2.0,
+        }
+    )
+
+    with pytest.raises(integration.ConfigEntryNotReady):
+        asyncio.run(integration.async_setup_entry(hass, entry))
+
+
+def test_setup_entry_numeric_string_coordinates_are_allowed() -> None:
+    """Numeric string coordinates should still set up normally."""
+
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: "1.5",
+            integration.CONF_LONGITUDE: "2.5",
+        }
+    )
+
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.coordinator.lat == pytest.approx(1.5)
+    assert entry.runtime_data.coordinator.lon == pytest.approx(2.5)
 
 
 def test_setup_entry_boundary_coordinates_are_allowed() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -70,6 +70,10 @@ util_mod = _import_util_module()
 redact_api_key = util_mod.redact_api_key
 redact_sensitive_values = util_mod.redact_sensitive_values
 safe_parse_int = util_mod.safe_parse_int
+parse_finite_float = util_mod.parse_finite_float
+validate_latitude = util_mod.validate_latitude
+validate_location_pair = util_mod.validate_location_pair
+validate_longitude = util_mod.validate_longitude
 
 
 def test_redact_api_key_handles_non_utf8_bytes():
@@ -221,3 +225,78 @@ def test_safe_parse_int(value, expected):
     """safe_parse_int accepts integer-like values and rejects invalid input."""
 
     assert safe_parse_int(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, 0.0),
+        (12.5, 12.5),
+        ("12.5", 12.5),
+        (" -3 ", -3.0),
+    ],
+)
+def test_parse_finite_float_accepts_numeric_values(value, expected):
+    """parse_finite_float returns normalized floats for finite numeric input."""
+
+    assert parse_finite_float(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, "not-a-number", "nan", "inf", float("nan"), float("inf")],
+)
+def test_parse_finite_float_rejects_invalid_values(value):
+    """parse_finite_float rejects bools, empty values, and non-finite numbers."""
+
+    assert parse_finite_float(value) is None
+
+
+@pytest.mark.parametrize("value", [-90, -90.0, "-90", 0, "12.5", 90, "90"])
+def test_validate_latitude_accepts_valid_values(value):
+    """validate_latitude accepts numeric and numeric-string values in range."""
+
+    assert validate_latitude(value) == float(value)
+
+
+@pytest.mark.parametrize("value", [-180, -180.0, "-180", 0, "12.5", 180, "180"])
+def test_validate_longitude_accepts_valid_values(value):
+    """validate_longitude accepts numeric and numeric-string values in range."""
+
+    assert validate_longitude(value) == float(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, "not-a-number", "nan", "inf", -90.1, 90.1],
+)
+def test_validate_latitude_rejects_invalid_values(value):
+    """validate_latitude rejects invalid, non-finite, and out-of-range values."""
+
+    assert validate_latitude(value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, True, False, "not-a-number", "nan", "inf", -180.1, 180.1],
+)
+def test_validate_longitude_rejects_invalid_values(value):
+    """validate_longitude rejects invalid, non-finite, and out-of-range values."""
+
+    assert validate_longitude(value) is None
+
+
+def test_validate_location_pair_accepts_valid_pair():
+    """validate_location_pair returns normalized floats for valid coordinates."""
+
+    assert validate_location_pair("40.4168", "-3.7038") == (40.4168, -3.7038)
+
+
+@pytest.mark.parametrize(
+    ("latitude", "longitude"),
+    [(None, 1), (1, None), (91, 1), (1, 181), (True, 1), (1, "bad")],
+)
+def test_validate_location_pair_rejects_invalid_pair(latitude, longitude):
+    """validate_location_pair rejects pairs with any invalid coordinate."""
+
+    assert validate_location_pair(latitude, longitude) is None


### PR DESCRIPTION
### Motivation

- Reduce duplicated validation logic for coordinates and forecast options across the config flow, options flow, and runtime setup.
- Align latitude/longitude parsing and range checks between `config_flow.py` and `__init__.py` while preserving existing user-visible behavior.
- Centralize small helpers to keep validation behavior consistent and easier to test.
- Ensure validation error messages do not expose API keys or precise coordinates when exception strings include sensitive values.

### Description

- Added shared validation helpers in `custom_components/pollenlevels/util.py`:
  - `parse_finite_float`
  - `validate_latitude`
  - `validate_longitude`
  - `validate_location_pair`
- The new coordinate helpers reject:
  - `None`
  - booleans
  - non-numeric strings
  - `NaN`
  - `inf`
  - out-of-range values
- The new coordinate helpers return normalized floats for valid numeric or numeric-string inputs.
- Replaced ad-hoc latitude/longitude parsing in `custom_components/pollenlevels/config_flow.py` and `custom_components/pollenlevels/__init__.py` with the shared validation helpers.
- Removed duplicate coordinate parsing code paths while preserving the existing runtime failure path for invalid stored coordinates.
- Centralized forecast sensor mode / days compatibility logic in `config_flow.py` with:
  - `_FORECAST_MODE_MIN_DAYS`
  - `_required_forecast_days_for_mode(...)`
  - `_normalize_forecast_mode_for_save(...)`
  - `_forecast_mode_combo_error(...)`
- Preserved existing forecast validation error keys:
  - `invalid_forecast_days`
  - `invalid_option_combo`
- Added `_safe_error_message(...)` to keep config-flow `error_message` placeholders non-empty when exception messages are empty.
- Added `_redact_validation_error(...)` in `config_flow.py` to redact validation errors with `redact_sensitive_values(...)` once normalized coordinates are available.
- Updated validation exception handlers to redact:
  - API keys
  - `location.latitude`
  - `location.longitude`
  - explicit coordinate values present in exception strings
- Added unit tests and flow tests in:
  - `tests/test_util.py`
  - `tests/test_config_flow.py`
  - `tests/test_init.py`

### Behavior intentionally preserved

- Config entry data shape is unchanged.
- Options data shape is unchanged.
- Existing forecast validation error keys are unchanged.
- Runtime setup still raises `ConfigEntryNotReady` for invalid stored coordinates.
- Reauth and reconfigure remain API-key-only flows.
- No entity IDs, unique IDs, translation keys, public sensor payloads, diagnostics shape, Home Assistant minimum version, Python requirement, manifest version, or pyproject version were changed.
- README and CHANGELOG were not changed in this PR.
- The project continues to intentionally target Python 3.14+, so the existing PEP 758 exception syntax remains valid and consistent with the codebase.

### Testing

- `ruff check --fix --select I .`
- `ruff check .`
- `black .`
- `black --check .`
- `pytest -q tests/test_util.py`
- `pytest -q tests/test_config_flow.py`
- `pytest -q tests/test_init.py`
- `pytest -q`
- `python -m compileall -q custom_components tests`

CI result:

- Lint: success
- tests: success, `268 passed`
- Validate with hassfest: success
- Validate with HACS: success

### Release notes

- This PR intentionally does not update `CHANGELOG.md` or bump the version.
- The change will be accumulated for the planned `2.2.0-rc1` release.