### PR TITLE
Redact coordinates in config-flow validation errors

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -60,6 +60,7 @@ from .const import (
 from .util import (
     normalize_sensor_mode,
     redact_api_key,
+    redact_sensitive_values,
     safe_parse_int,
     validate_latitude,
     validate_location_pair,
@@ -134,6 +135,21 @@ def _safe_error_message(error: Exception | str, fallback: str) -> str:
     """Return a non-empty error message suitable for form placeholders."""
     message = str(error).strip()
     return message or fallback
+
+
+def _redact_validation_error(
+    error: object,
+    api_key: str | None,
+    latitude: float | None,
+    longitude: float | None,
+) -> str:
+    """Redact validation errors before logging or showing placeholders."""
+    return redact_sensitive_values(
+        error,
+        api_key=api_key,
+        latitude=latitude,
+        longitude=longitude,
+    ).strip()
 
 
 def _build_step_user_schema(hass: Any, user_input: dict[str, Any] | None) -> vol.Schema:
@@ -442,13 +458,13 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except ConfigEntryAuthFailed as err:
             _LOGGER.warning("Authentication failed during validation")
             errors["base"] = "invalid_auth"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Authentication failed."
             )
         except PollenQuotaExceededError as err:
             errors["base"] = "quota_exceeded"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             if re.fullmatch(r"HTTP\s+429(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
             placeholders["error_message"] = _safe_error_message(
@@ -456,33 +472,36 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         except UpdateFailed as err:
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             if re.fullmatch(r"HTTP\s+\d+(?::)?", redacted, flags=re.IGNORECASE):
                 redacted = ""
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Failed to connect to the pollen service."
             )
         except TimeoutError as err:
-            _LOGGER.warning("Validation timeout: %s", redact_api_key(err, api_key))
+            _LOGGER.warning(
+                "Validation timeout: %s",
+                _redact_validation_error(err, api_key, lat, lon),
+            )
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Validation request timed out."
             )
         except aiohttp.ClientError as err:
             _LOGGER.error(
                 "Connection error: %s",
-                redact_api_key(err, api_key),
+                _redact_validation_error(err, api_key, lat, lon),
             )
             errors["base"] = "cannot_connect"
-            redacted = redact_api_key(err, api_key).strip()
+            redacted = _redact_validation_error(err, api_key, lat, lon)
             placeholders["error_message"] = _safe_error_message(
                 redacted, "Network error while connecting to the pollen service."
             )
         except Exception as err:  # defensive
             _LOGGER.exception(
                 "Unexpected error in Pollen Levels config flow while validating input: %s",
-                redact_api_key(err, api_key),
+                _redact_validation_error(err, api_key, lat, lon),
             )
             errors["base"] = "unknown"
             placeholders.pop("error_message", None)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1085,6 +1085,46 @@ def test_validate_input_http_500_sets_error_message_placeholder(
     assert placeholders.get("error_message")
 
 
+def test_validate_input_update_failed_redacts_api_key_and_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UpdateFailed placeholders should redact API keys and precise coordinates."""
+
+    user_input = _base_user_input()
+    latitude = "48.8566123"
+    longitude = "2.3522456"
+    user_input[CONF_LOCATION] = {CONF_LATITUDE: latitude, CONF_LONGITUDE: longitude}
+    api_key = user_input[CONF_API_KEY]
+    calls = _patch_client_fetch(
+        monkeypatch,
+        error=UpdateFailed(
+            f"API key {api_key} failed for "
+            f"location.latitude={latitude} location.longitude={longitude}"
+        ),
+    )
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+    placeholders: dict[str, str] = {}
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            user_input,
+            check_unique_id=False,
+            description_placeholders=placeholders,
+        )
+    )
+
+    error_message = placeholders.get("error_message", "")
+    assert calls
+    assert errors == {"base": "cannot_connect"}
+    assert normalized is None
+    assert api_key not in error_message
+    assert latitude not in error_message
+    assert longitude not in error_message
+    assert "***" in error_message
+
+
 def test_validate_input_clears_error_message_placeholder_on_validation_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent leaking precise latitude/longitude (and API keys) in config-flow validation logs and UI placeholders when validation errors include coordinates.
- Keep existing validation behavior and HTTP-status-only filtering while enhancing redaction to include coordinates once `lat`/`lon` are known.

### Description
- Import `redact_sensitive_values` from `.util` and add a new helper `_redact_validation_error(...)` that calls it to redact API key and explicit coordinates before use in logs/placeholders.
- Replace direct uses of `redact_api_key(...)` with `_redact_validation_error(...)` inside config-flow exception handlers where `lat` and `lon` are available (`ConfigEntryAuthFailed`, `PollenQuotaExceededError`, `UpdateFailed`, `TimeoutError`, `aiohttp.ClientError`, and the generic exception logger), preserving existing fallback and HTTP-status-only behavior.
- Preserve `redact_api_key(...)` for usage locations where coordinates are not available (unique ID setup, options flow defensive logging, etc.).
- Add a focused test `test_validate_input_update_failed_redacts_api_key_and_coordinates` in `tests/test_config_flow.py` that asserts `UpdateFailed` messages redact the API key and exact latitude/longitude while leaving a redaction marker.

### Testing
- Ran `ruff check .` and auto-fixed import ordering with `ruff`; the checks passed.
- Ran `black --check .` and formatting completed successfully after running `black .`.
- Ran unit tests with `pytest -q tests/test_config_flow.py` (68 passed), `pytest -q tests/test_util.py` (76 passed), `pytest -q tests/test_init.py` (28 passed), and full test suite `pytest -q` (268 passed), all succeeding.
- Verified bytecode compilation with `python -m compileall -q custom_components tests` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a02593408324be0bd16095a92a88)