### PR TITLE
Cache daily summary sensor payloads

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -411,6 +411,17 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
                 "longitude": f"{self.coordinator.lon:.6f}",
             },
         }
+        self._summary_data_ref: object = object()
+        self._summary_cache: dict[str, dict[str, Any]] = {}
+
+    def _summary_payload(self, key: str) -> dict[str, Any]:
+        """Return a cached summary payload for the current coordinator data."""
+        data = self.coordinator.data
+        if data is not self._summary_data_ref:
+            self._summary_data_ref = data
+            self._summary_cache = _daily_summary(data or {})
+
+        return self._summary_cache[key]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -437,19 +448,13 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> int | None:
         """Return the number of plants explicitly marked in season today."""
-        return _daily_summary(self.coordinator.data or {})["plants_in_season_today"][
-            "state"
-        ]
+        return self._summary_payload("plants_in_season_today")["state"]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return plant season summary attributes."""
         attrs = super().extra_state_attributes
-        attrs.update(
-            _summary_attrs(
-                _daily_summary(self.coordinator.data or {})["plants_in_season_today"]
-            )
-        )
+        attrs.update(_summary_attrs(self._summary_payload("plants_in_season_today")))
         return attrs
 
 
@@ -469,19 +474,13 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> float | int | None:
         """Return the maximum valid current-day pollen type value."""
-        return _daily_summary(self.coordinator.data or {})["overall_pollen_risk_today"][
-            "state"
-        ]
+        return self._summary_payload("overall_pollen_risk_today")["state"]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return overall pollen risk summary attributes."""
         attrs = super().extra_state_attributes
-        attrs.update(
-            _summary_attrs(
-                _daily_summary(self.coordinator.data or {})["overall_pollen_risk_today"]
-            )
-        )
+        attrs.update(_summary_attrs(self._summary_payload("overall_pollen_risk_today")))
         return attrs
 
 
@@ -499,19 +498,13 @@ class TopPollenTypesTodaySensor(_BaseSummarySensor):
     @property
     def native_value(self) -> str | None:
         """Return the top pollen type names, preserving ties."""
-        return _daily_summary(self.coordinator.data or {})["top_pollen_types_today"][
-            "state"
-        ]
+        return self._summary_payload("top_pollen_types_today")["state"]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return top pollen type summary attributes."""
         attrs = super().extra_state_attributes
-        attrs.update(
-            _summary_attrs(
-                _daily_summary(self.coordinator.data or {})["top_pollen_types_today"]
-            )
-        )
+        attrs.update(_summary_attrs(self._summary_payload("top_pollen_types_today")))
         return attrs
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -523,6 +523,40 @@ def test_plants_in_season_returns_none_without_plant_entries() -> None:
     assert entity.extra_state_attributes["total_plant_count"] == 0
 
 
+def test_summary_sensor_caches_payload_for_current_data_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Summary computation is cached per sensor while coordinator data is unchanged."""
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_daily_summary(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        calls.append(data)
+        call_count = len(calls)
+        return {
+            "plants_in_season_today": {
+                "state": call_count,
+                "plant_names": [f"Plant {call_count}"],
+            }
+        }
+
+    monkeypatch.setattr(sensor, "_daily_summary", fake_daily_summary)
+    initial_data = {"plants_oak": {"source": "plant", "inSeason": True}}
+    coordinator = _summary_coordinator(initial_data)
+    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+
+    assert entity.native_value == 1
+    assert entity.extra_state_attributes["plant_names"] == ["Plant 1"]
+    assert calls == [initial_data]
+
+    updated_data = {"plants_pine": {"source": "plant", "inSeason": True}}
+    coordinator.data = updated_data
+
+    assert entity.native_value == 2
+    assert entity.extra_state_attributes["plant_names"] == ["Plant 2"]
+    assert calls == [initial_data, updated_data]
+
+
 def test_overall_pollen_risk_returns_max_current_day_type_value() -> None:
     """Overall pollen risk returns the maximum valid current-day type index."""
 


### PR DESCRIPTION
### Motivation
- Summary sensors repeatedly called `daily_summary(...)` from both `native_value` and `extra_state_attributes`, causing redundant recomputation for the same `coordinator.data` object.
- Introduce a lightweight per-entity cache keyed by the identity of `coordinator.data` to avoid unnecessary work while preserving all public outputs and behaviors.

### Description
- Add a per-summary-sensor cache to `_BaseSummarySensor` by storing the last seen `coordinator.data` object reference and the last computed `_daily_summary(...)` result, and expose a helper `def _summary_payload(self, key: str) -> dict[str, Any]` to return cached payloads.
- Replace direct calls to `_daily_summary(self.coordinator.data or {})` in `PlantsInSeasonTodaySensor`, `OverallPollenRiskTodaySensor`, and `TopPollenTypesTodaySensor` for both `native_value` and `extra_state_attributes` with the new `_summary_payload(...)` helper.
- Keep all public states, attribute names, attribution handling, missing-data fallbacks, unique IDs, translation keys, device info, and other integration boundaries unchanged.
- Files changed: `custom_components/pollenlevels/sensor.py` and `tests/test_sensor.py` (targeted unit test added to verify caching behavior).

### Testing
- Ran `ruff check .` and `black --check .`, both completed without issues.
- Ran `pytest -q tests/test_sensor.py` and the test file passed (targeted cache test included); `pytest -q` ran the full suite and all tests passed (no failures).
- Ran `python -m compileall -q custom_components tests` and byte-compile verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a31ca1b4832485af11d943da98dc)