### PR TITLE
Prepare 2.2.0-alpha1 pre-release

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -21,6 +21,40 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+          cache: "pip"
+
+      - name: Install validation dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade "black==25.*" "ruff==0.14.*" "pytest>=8,<9"
+
+      - name: Compile Python sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m compileall -q custom_components tests
+
+      - name: Ruff validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruff check .
+
+      - name: Black validation
+        shell: bash
+        run: |
+          set -euo pipefail
+          black --check .
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          pytest -q
+        env:
+          PYTHONPATH: .
 
       - name: Build release ZIP (integration root at ZIP root)
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [2.2.0a1] - 2026-05-16
+### Added
+- Added the first alpha pre-release for the upcoming 2.2.0 cycle to validate
+  hardening, validation, CI, and summary-sensor optimizations before the
+  remaining coordinator changes.
+
+### Changed
+- Hardened HTTP and validation error redaction so API keys and precise
+  coordinates are redacted from client and config-flow error messages.
+- Centralized latitude and longitude validation across config flow and runtime
+  setup.
+- Centralized forecast sensor mode and forecast-days compatibility validation
+  across setup and options flow.
+- Cached daily summary sensor payloads per coordinator data object to avoid
+  redundant `daily_summary(...)` recomputation for the same sensor update.
+- Aligned the manual Package Test workflow with the release validation gate by
+  running compile checks, Ruff, Black, and pytest before building the ZIP
+  artifact.
+
+### Fixed
+- Preserved authentication classification for invalid Google Pollen API key
+  messages while improving redaction coverage.
+- Ensured config-flow error placeholders use safe fallback messages when upstream
+  exception messages are empty.
+- Prevented precise invalid stored coordinates from being logged during runtime
+  setup failures.
+
+### Notes
+- This is an alpha pre-release for validation and feedback.
+- The remaining 2.2.0 plan still includes coordinator stale-data handling and
+  forecast extraction cleanup before beta/rc/final releases.
+
 ## [2.1.1] - 2026-05-12
 ### Fixed
 - Treated generic Google Pollen API 4xx responses containing invalid API key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.2.0-alpha1] - 2026-05-16
+## [2.2.0-alpha1] - 2026-05-17
 ### Added
 - Added the first alpha pre-release for the upcoming 2.2.0 cycle to validate
   hardening, validation, CI, and summary-sensor optimizations before the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.2.0a1] - 2026-05-16
+## [2.2.0-alpha1] - 2026-05-16
 ### Added
 - Added the first alpha pre-release for the upcoming 2.2.0 cycle to validate
   hardening, validation, CI, and summary-sensor optimizations before the
@@ -16,6 +16,9 @@
 - Aligned the manual Package Test workflow with the release validation gate by
   running compile checks, Ruff, Black, and pytest before building the ZIP
   artifact.
+- This is an alpha pre-release for validation and feedback.
+- The remaining 2.2.0 plan still includes coordinator stale-data handling and
+  forecast extraction cleanup before beta/rc/final releases.
 
 ### Fixed
 - Preserved authentication classification for invalid Google Pollen API key
@@ -24,11 +27,6 @@
   exception messages are empty.
 - Prevented precise invalid stored coordinates from being logged during runtime
   setup failures.
-
-### Notes
-- This is an alpha pre-release for validation and feedback.
-- The remaining 2.2.0 plan still includes coordinator stale-data handling and
-  forecast extraction cleanup before beta/rc/final releases.
 
 ## [2.1.1] - 2026-05-12
 ### Fixed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0a1"
+    "version": "2.2.0-alpha1"
 }

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.1.1"
+    "version": "2.2.0a1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0a1"
+version = "2.2.0-alpha1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.1.1"
+version = "2.2.0a1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation

- Prepare the first alpha pre-release for the upcoming `2.2.0` cycle.
- Validate the completed hardening, validation, CI, and summary-sensor optimization work before moving on to the remaining coordinator changes.
- Align the manual `Package Test` workflow with the release validation gate so it fails early on code-quality or test regressions before building a ZIP artifact.

### Description

- Bumped the integration/package version from `2.1.1` to `2.2.0-alpha1` in:
  - `custom_components/pollenlevels/manifest.json`
  - `pyproject.toml`
- Added a new `CHANGELOG.md` entry for `2.2.0-alpha1`.
- Updated `.github/workflows/package-test.yml` to run validation steps before building the release ZIP:
  - `python -m compileall -q custom_components tests`
  - `ruff check .`
  - `black --check .`
  - `pytest -q`
- Enabled pip caching for the manual package-test workflow.
- Preserved the existing ZIP build, ZIP structure validation, generated/cache file checks, and `pollenlevels-zip` artifact upload.
- Kept the workflow action versions aligned with the repository:
  - `actions/checkout@v6`
  - `actions/setup-python@v6`
  - `actions/upload-artifact@v7`

### Included changes since 2.1.1

- Hardened HTTP and validation error redaction so API keys and precise coordinates are redacted from client and config-flow error messages.
- Centralized latitude and longitude validation across config flow and runtime setup.
- Centralized forecast sensor mode and forecast-days compatibility validation across setup and options flow.
- Cached daily summary sensor payloads per coordinator data object to avoid redundant `daily_summary(...)` recomputation for the same sensor update.
- Aligned the manual Package Test workflow with the release validation gate.

### Behavior intentionally preserved

- No runtime integration code was changed in this release-preparation PR.
- No entity IDs, unique IDs, translation keys, public sensor payloads, diagnostics shape, Home Assistant minimum version, or Python requirement were changed.
- README and translations were not changed.
- The remaining `2.2.0` plan still includes coordinator stale-data handling and forecast extraction cleanup before beta/rc/final releases.

### Testing

- `ruff check .`
- `black --check .`
- `pytest -q`
- `python -m compileall -q custom_components tests`
- `python -m pip install .`

CI result:

- Lint: success
- tests: success, `269 passed`
- Validate with hassfest: success
- Validate with HACS: success

### Release notes

- This is an alpha pre-release for validation and feedback.
- After merge, create GitHub Release `v2.2.0-alpha1` and mark it as a pre-release.