### PR TITLE
Expire stale coordinator data

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -138,7 +138,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.data: dict[str, dict] = {}
         self.last_updated = None
 
-    def _utcnow(self):
+    def _utcnow(self) -> datetime:
         """Return the current UTC time."""
         return dt_util.utcnow()
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -111,7 +111,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             name=f"{DOMAIN}_{entry_id}",
             update_interval=update_interval,
         )
-        self._pollen_update_interval = update_interval
         self.api_key = api_key
         self.lat = lat
         self.lon = lon
@@ -145,7 +144,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _stale_data_ttl(self) -> timedelta:
         """Return how long successful data may be reused after malformed payloads."""
-        update_interval = getattr(self, "update_interval", self._pollen_update_interval)
+        update_interval = self.update_interval
         if update_interval is None:
             return STALE_DATA_MIN_TTL
         return max(STALE_DATA_MIN_TTL, update_interval * 2)

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
+STALE_DATA_MIN_TTL = timedelta(hours=24)
 
 
 def _normalize_channel(v: Any) -> int | None:
@@ -103,12 +104,14 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         entry_title: str = DEFAULT_ENTRY_TITLE,
     ):
         """Initialize coordinator with configuration and interval."""
+        update_interval = timedelta(hours=hours)
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{entry_id}",
-            update_interval=timedelta(hours=hours),
+            update_interval=update_interval,
         )
+        self._pollen_update_interval = update_interval
         self.api_key = api_key
         self.lat = lat
         self.lon = lon
@@ -131,9 +134,27 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.create_d2 = create_d2
         self._client = client
         self._missing_dailyinfo_warned = False
+        self._stale_dailyinfo_warned = False
 
         self.data: dict[str, dict] = {}
         self.last_updated = None
+
+    def _utcnow(self):
+        """Return the current UTC time."""
+        return dt_util.utcnow()
+
+    def _stale_data_ttl(self) -> timedelta:
+        """Return how long successful data may be reused after malformed payloads."""
+        update_interval = getattr(self, "update_interval", self._pollen_update_interval)
+        if update_interval is None:
+            return STALE_DATA_MIN_TTL
+        return max(STALE_DATA_MIN_TTL, update_interval * 2)
+
+    def _has_fresh_cached_data(self) -> bool:
+        """Return whether cached data is still within the stale-data tolerance."""
+        if not self.data or self.last_updated is None:
+            return False
+        return self._utcnow() - self.last_updated <= self._stale_data_ttl()
 
     # ------------------------------
     # DRY helper for forecast attrs
@@ -239,16 +260,30 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             daily = None
 
         if not daily:
-            if self.data:
+            if self._has_fresh_cached_data():
                 if not self._missing_dailyinfo_warned:
+                    cache_age = self._utcnow() - self.last_updated
                     _LOGGER.warning(
                         "API response missing or invalid dailyInfo; "
-                        "keeping last successful data"
+                        "keeping last successful data within TTL "
+                        "(cache_age=%s, ttl=%s)",
+                        cache_age,
+                        self._stale_data_ttl(),
                     )
                     self._missing_dailyinfo_warned = True
                 return self.data
+            if self.data:
+                if not self._stale_dailyinfo_warned:
+                    _LOGGER.warning(
+                        "API response missing or invalid dailyInfo; cached data expired"
+                    )
+                    self._stale_dailyinfo_warned = True
+                raise UpdateFailed(
+                    "API response missing or invalid dailyInfo; cached data expired"
+                )
             raise UpdateFailed("API response missing or invalid dailyInfo")
         self._missing_dailyinfo_warned = False
+        self._stale_dailyinfo_warned = False
 
         # date (today)
         first_day = daily[0]
@@ -494,7 +529,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             new_data[key] = base
 
         self.data = new_data
-        self.last_updated = dt_util.utcnow()
+        self.last_updated = self._utcnow()
         if _LOGGER.isEnabledFor(logging.DEBUG):
             total = len(new_data)
             types = 0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -213,6 +213,7 @@ class _StubDataUpdateCoordinator:
     def __init__(self, *args, **kwargs):
         self.hass = args[0] if args else None
         self.data = None
+        self.update_interval = kwargs.get("update_interval")
 
     async def async_refresh(self):
         return None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -382,6 +382,30 @@ class SequenceSession:
         return FakeResponse(item.payload, status=item.status, headers=item.headers)
 
 
+def _minimal_valid_payload(value: int = 2) -> dict[str, Any]:
+    """Return a minimal valid pollen payload for coordinator refresh tests."""
+
+    return {
+        "regionCode": "us_ca_san_francisco",
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 5, "day": 9},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": value,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
 class RegistryEntry(NamedTuple):
     """Entity registry entry stub."""
 
@@ -1074,6 +1098,143 @@ def test_coordinator_mixed_dailyinfo_items_keep_last_data() -> None:
         loop.close()
 
     assert second_data == first_data
+
+
+def test_coordinator_stale_cached_data_raises_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed dailyInfo raises once cached data is older than the TTL."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload()),
+            ResponseSpec(status=200, payload={}),
+        ]
+    )
+    client = client_mod.GooglePollenApiClient(session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=6,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        now = start + datetime.timedelta(hours=24, seconds=1)
+        with pytest.raises(client_mod.UpdateFailed, match="cached data expired"):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert coordinator.data == first_data
+
+
+def test_coordinator_stale_data_ttl_accounts_for_update_interval() -> None:
+    """Effective stale-data TTL uses the larger of 24h and twice the interval."""
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+
+    try:
+        six_hour = coordinator_mod.PollenDataUpdateCoordinator(
+            hass=hass,
+            api_key="test",
+            lat=1.0,
+            lon=2.0,
+            hours=6,
+            language=None,
+            entry_id="entry-6h",
+            forecast_days=1,
+            create_d1=False,
+            create_d2=False,
+            client=client,
+        )
+        twenty_four_hour = coordinator_mod.PollenDataUpdateCoordinator(
+            hass=hass,
+            api_key="test",
+            lat=1.0,
+            lon=2.0,
+            hours=24,
+            language=None,
+            entry_id="entry-24h",
+            forecast_days=1,
+            create_d1=False,
+            create_d2=False,
+            client=client,
+        )
+    finally:
+        loop.close()
+
+    assert six_hour._stale_data_ttl() == datetime.timedelta(hours=24)
+    assert twenty_four_hour._stale_data_ttl() == datetime.timedelta(hours=48)
+
+
+def test_coordinator_success_after_malformed_response_updates_last_updated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later successful refresh updates last_updated after malformed dailyInfo."""
+
+    first_refresh = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    malformed_refresh = first_refresh + datetime.timedelta(hours=1)
+    second_refresh = first_refresh + datetime.timedelta(hours=2)
+    now = first_refresh
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload(value=2)),
+            ResponseSpec(status=200, payload={}),
+            ResponseSpec(status=200, payload=_minimal_valid_payload(value=4)),
+        ]
+    )
+    client = client_mod.GooglePollenApiClient(session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=6,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        assert coordinator.last_updated == first_refresh
+
+        now = malformed_refresh
+        cached_data = loop.run_until_complete(coordinator._async_update_data())
+        assert cached_data == first_data
+        assert coordinator.last_updated == first_refresh
+
+        now = second_refresh
+        second_data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert second_data["type_grass"]["value"] == 4
+    assert coordinator.last_updated == second_refresh
 
 
 def test_coordinator_clamps_forecast_days_negative() -> None:


### PR DESCRIPTION
Motivation

- Prevent the integration from serving indefinitely stale pollen data when the Google API later returns missing or invalid "dailyInfo" after an earlier successful refresh.
- Preserve the existing short-term fallback for transient malformed payloads while limiting its duration with a safe internal TTL.
- Make the TTL respect the configured coordinator interval so longer intervals get proportionally larger tolerance without adding user-facing options.

Description

- Added internal "STALE_DATA_MIN_TTL = timedelta(hours=24)".
- Added "_stale_data_ttl()" to compute the effective stale-data TTL as "max(STALE_DATA_MIN_TTL, update_interval * 2)" with a defensive fallback.
- Added "_utcnow()" to make stale-data age checks deterministic in tests.
- Added "_has_fresh_cached_data()" to decide whether existing coordinator data can still be reused after malformed API payloads.
- Changed the missing/invalid "dailyInfo" fallback branch:
  - returns cached "self.data" while it is still within the effective TTL.
  - raises "UpdateFailed("API response missing or invalid dailyInfo; cached data expired")" when cached data exists but is stale.
  - keeps raising "UpdateFailed("API response missing or invalid dailyInfo")" on first refresh when no cached data exists.
- Preserved the existing one-time warning behavior for malformed "dailyInfo".
- Added a separate one-time warning when cached data has expired.
- Updated "self.last_updated" to use "_utcnow()".
- Added deterministic tests and a small "_minimal_valid_payload()" helper for coordinator stale-data scenarios.
- Updated the test "DataUpdateCoordinator" stub to expose "update_interval", matching the real coordinator attribute used by the TTL helper.

Behavior intentionally preserved

- Valid API payload processing is unchanged.
- Current-day type and plant sensor extraction is unchanged.
- Forecast attributes and D+1/D+2 sensor behavior are unchanged.
- Client retry/backoff behavior is unchanged.
- "ConfigEntryAuthFailed", "PollenQuotaExceededError", and normal client "UpdateFailed" handling are unchanged.
- No new user-facing options were added.
- No entity IDs, unique IDs, translation keys, public sensor keys, attribute names, diagnostics shape, Home Assistant minimum version, or Python requirement were changed.
- README, CHANGELOG, manifest, pyproject, translations, config flow, and options flow were not changed in this PR.

Stale-data policy

Effective TTL:

- "max(24h, 2 × update_interval)"

Examples:

- "update_interval 6h  -> TTL 24h"
- "update_interval 24h -> TTL 48h"

Resulting behavior:

- "No previous data + missing/invalid dailyInfo -> UpdateFailed"
- "Fresh cached data + missing/invalid dailyInfo -> reuse cached data"
- "Expired cached data + missing/invalid dailyInfo -> UpdateFailed"

Testing

- "ruff check --fix --select I ."
- "ruff check ."
- "black --check ."
- "pytest -q tests/test_sensor.py"
- "pytest -q tests/test_config_flow.py"
- "pytest -q"
- "python -m compileall -q custom_components tests"

CI result:

- Lint: success
- tests: success, "272 passed"
- Validate with hassfest: success
- Validate with HACS: success

Changed files:

- "custom_components/pollenlevels/coordinator.py"
- "tests/test_sensor.py"
- "tests/test_config_flow.py"

Release notes

- This PR intentionally does not update "CHANGELOG.md" or bump the version.
- The change will be accumulated for the planned "2.2.0-alpha2" pre-release.