### PR TITLE
Prepare 2.2.0-alpha2 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [2.2.0-alpha2] - 2026-05-17
+### Changed
+- Added stale-data expiration for malformed Google Pollen API payloads: cached
+  coordinator data is now reused only while it remains within the effective TTL.
+- The stale-data TTL is calculated internally as the larger of 24 hours or twice
+  the configured update interval, so installations using a 24-hour update
+  interval can tolerate one missed malformed refresh before cached data expires.
+
+### Fixed
+- Prevented indefinitely stale pollen data from remaining available when the API
+  repeatedly returns missing or invalid `dailyInfo` after a previous successful
+  refresh.
+- Preserved the short-term fallback for transient malformed `dailyInfo` payloads
+  while allowing Home Assistant to mark entities unavailable once cached data has
+  expired.
+
 ## [2.2.0-alpha1] - 2026-05-17
 ### Added
 - Added the first alpha pre-release for the upcoming 2.2.0 cycle to validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [2.2.0-alpha2] - 2026-05-17
-### Changed
+### Added
 - Added stale-data expiration for malformed Google Pollen API payloads: cached
   coordinator data is now reused only while it remains within the effective TTL.
-- The stale-data TTL is calculated internally as the larger of 24 hours or twice
+- Added an internal stale-data TTL calculated as the larger of 24 hours or twice
   the configured update interval, so installations using a 24-hour update
   interval can tolerate one missed malformed refresh before cached data expires.
 

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0-alpha1"
+    "version": "2.2.0-alpha2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0-alpha1"
+version = "2.2.0-alpha2"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Prepare the second alpha pre-release for the upcoming 2.2.0 line and record the stale coordinator data expiration behavior introduced in the coordinator hardening change (PR #106). 
- Bump project and integration metadata to the next pre-release identifier without changing runtime behavior. 

### Description
- Updated `custom_components/pollenlevels/manifest.json` to set `version` to `2.2.0-alpha2`. 
- Updated `pyproject.toml` to set `project.version` to `2.2.0-alpha2`. 
- Inserted a new top-level changelog entry `## [2.2.0-alpha2] - 2026-05-17` containing only `### Added` and `### Fixed` bullets that document the stale-data expiration behavior from the coordinator changes in PR #106. 
- No runtime code, tests, translations, README, or workflow files were modified. 

### Testing
- Ran `ruff check --fix --select I .` and `ruff check .` successfully with no remaining import-order issues. 
- Ran `black --check .` successfully. 
- Ran `pytest -q` with `272 passed`. 
- Ran `python -m compileall -q custom_components tests` successfully. 
- Attempted `python -m pip install .` but it failed due to an environment network limitation when fetching build dependencies from PyPI (`Tunnel connection failed: 403 Forbidden`), which is an external infrastructure issue and not related to repository changes. 
- Verified `custom_components/pollenlevels/manifest.json` and `pyproject.toml` both contain exactly `2.2.0-alpha2` and that `CHANGELOG.md` top heading is exactly `## [2.2.0-alpha2] - 2026-05-17`, and that no `### Notes` section was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2d3646148324868e8631ead78711)