### PR TITLE
Refactor coordinator forecast extraction

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -88,6 +88,8 @@ def _normalize_plant_code(code: Any) -> str:
 def _extract_api_date(day: dict[str, Any]) -> str | None:
     """Extract a YYYY-MM-DD date string from one API dailyInfo item."""
     date_obj = day.get("date") or {}
+    if not isinstance(date_obj, dict):
+        return None
     if not all(date_obj.get(k) is not None for k in ("year", "month", "day")):
         return None
     return f"{date_obj['year']:04d}-{date_obj['month']:02d}-{date_obj['day']:02d}"

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -88,7 +88,7 @@ def _normalize_plant_code(code: Any) -> str:
 def _extract_api_date(day: dict[str, Any]) -> str | None:
     """Extract a YYYY-MM-DD date string from one API dailyInfo item."""
     date_obj = day.get("date") or {}
-    if not all(k in date_obj for k in ("year", "month", "day")):
+    if not all(date_obj.get(k) is not None for k in ("year", "month", "day")):
         return None
     return f"{date_obj['year']:04d}-{date_obj['month']:02d}-{date_obj['day']:02d}"
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -100,8 +100,8 @@ def _build_forecast_entry(
 ) -> dict[str, Any]:
     """Build one behavior-preserving forecast entry from an API item."""
     idx_raw = item.get("indexInfo")
-    idx = idx_raw if isinstance(idx_raw, dict) else None
-    has_index = isinstance(idx_raw, dict) and bool(idx_raw)
+    idx = idx_raw if isinstance(idx_raw, dict) else {}
+    has_index = bool(idx)
     rgb = _rgb_from_api(idx.get("color")) if has_index else None
     return {
         "offset": offset,

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -85,6 +85,51 @@ def _normalize_plant_code(code: Any) -> str:
     return str(code).strip().upper()
 
 
+def _extract_api_date(day: dict[str, Any]) -> str | None:
+    """Extract a YYYY-MM-DD date string from one API dailyInfo item."""
+    date_obj = day.get("date") or {}
+    if not all(k in date_obj for k in ("year", "month", "day")):
+        return None
+    return f"{date_obj['year']:04d}-{date_obj['month']:02d}-{date_obj['day']:02d}"
+
+
+def _build_forecast_entry(
+    offset: int, date: str | None, item: dict[str, Any]
+) -> dict[str, Any]:
+    """Build one behavior-preserving forecast entry from an API item."""
+    idx_raw = item.get("indexInfo")
+    idx = idx_raw if isinstance(idx_raw, dict) else None
+    has_index = isinstance(idx_raw, dict) and bool(idx_raw)
+    rgb = _rgb_from_api(idx.get("color")) if has_index else None
+    return {
+        "offset": offset,
+        "date": date,
+        "has_index": has_index,
+        "value": idx.get("value") if has_index else None,
+        "category": idx.get("category") if has_index else None,
+        "description": idx.get("indexDescription") if has_index else None,
+        "color_hex": _rgb_to_hex_triplet(rgb) if has_index else None,
+        "color_rgb": list(rgb) if (has_index and rgb is not None) else None,
+    }
+
+
+def _build_forecast_list(
+    daily: list[dict[str, Any]],
+    item_by_day_code: list[dict[str, dict[str, Any]]],
+    code: str,
+    forecast_days: int,
+) -> list[dict[str, Any]]:
+    """Build forecast entries for one pollen type or plant code."""
+    forecast_list: list[dict[str, Any]] = []
+    for offset, day in enumerate(daily[1:], start=1):
+        if offset >= forecast_days:
+            break
+        date_str = _extract_api_date(day)
+        item = item_by_day_code[offset].get(code) or {}
+        forecast_list.append(_build_forecast_entry(offset, date_str, item))
+    return forecast_list
+
+
 class PollenDataUpdateCoordinator(DataUpdateCoordinator):
     """Coordinate pollen data fetch with forecast support for TYPES and PLANTS."""
 
@@ -286,12 +331,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
 
         # date (today)
         first_day = daily[0]
-        date_obj = first_day.get("date", {}) or {}
-        if all(k in date_obj for k in ("year", "month", "day")):
-            new_data["date"] = {
-                "source": "meta",
-                "value": f"{date_obj['year']:04d}-{date_obj['month']:02d}-{date_obj['day']:02d}",
-            }
+        date_str = _extract_api_date(first_day)
+        if date_str is not None:
+            new_data["date"] = {"source": "meta", "value": date_str}
 
         type_codes: set[str] = set()
         type_by_day_code: list[dict[str, dict[str, Any]]] = []
@@ -372,12 +414,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             plant_keys.append(key)
 
         # Forecast for TYPES
-        def _extract_day_info(day: dict) -> tuple[str | None, dict | None]:
-            d = day.get("date") or {}
-            if not all(k in d for k in ("year", "month", "day")):
-                return None, None
-            return f"{d['year']:04d}-{d['month']:02d}-{d['day']:02d}", d
-
         for tcode in sorted(type_codes):
             type_key = f"type_{tcode.lower()}"
             existing = new_data.get(type_key)
@@ -409,32 +445,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                         base["inSeason"] = candidate.get("inSeason")
                         base["advice"] = candidate.get("healthRecommendations")
                         break
-            forecast_list: list[dict[str, Any]] = []
-            for offset, day in enumerate(daily[1:], start=1):
-                if offset >= self.forecast_days:
-                    break
-                date_str, _ = _extract_day_info(day)
-                item = type_by_day_code[offset].get(tcode) or {}
-                idx_raw = item.get("indexInfo")
-                idx = idx_raw if isinstance(idx_raw, dict) else None
-                has_index = isinstance(idx_raw, dict) and bool(idx_raw)
-                rgb = _rgb_from_api(idx.get("color")) if has_index else None
-                forecast_list.append(
-                    {
-                        "offset": offset,
-                        "date": date_str,
-                        "has_index": has_index,
-                        "value": idx.get("value") if has_index else None,
-                        "category": idx.get("category") if has_index else None,
-                        "description": (
-                            idx.get("indexDescription") if has_index else None
-                        ),
-                        "color_hex": _rgb_to_hex_triplet(rgb) if has_index else None,
-                        "color_rgb": (
-                            list(rgb) if (has_index and rgb is not None) else None
-                        ),
-                    }
-                )
+            forecast_list = _build_forecast_list(
+                daily, type_by_day_code, tcode, self.forecast_days
+            )
             # Attach common forecast attributes (convenience, trend, expected_peak)
             base = self._process_forecast_attributes(base, forecast_list)
             new_data[type_key] = base
@@ -496,32 +509,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                 # Safety: skip if for some reason code is missing
                 continue
 
-            forecast_list: list[dict[str, Any]] = []
-            for offset, day in enumerate(daily[1:], start=1):
-                if offset >= self.forecast_days:
-                    break
-                date_str, _ = _extract_day_info(day)
-                item = plant_by_day_code[offset].get(pcode) or {}
-                idx_raw = item.get("indexInfo")
-                idx = idx_raw if isinstance(idx_raw, dict) else None
-                has_index = isinstance(idx_raw, dict) and bool(idx_raw)
-                rgb = _rgb_from_api(idx.get("color")) if has_index else None
-                forecast_list.append(
-                    {
-                        "offset": offset,
-                        "date": date_str,
-                        "has_index": has_index,
-                        "value": idx.get("value") if has_index else None,
-                        "category": idx.get("category") if has_index else None,
-                        "description": (
-                            idx.get("indexDescription") if has_index else None
-                        ),
-                        "color_hex": _rgb_to_hex_triplet(rgb) if has_index else None,
-                        "color_rgb": (
-                            list(rgb) if (has_index and rgb is not None) else None
-                        ),
-                    }
-                )
+            forecast_list = _build_forecast_list(
+                daily, plant_by_day_code, pcode, self.forecast_days
+            )
 
             # Attach common forecast attributes (convenience, trend, expected_peak)
             base = self._process_forecast_attributes(base, forecast_list)

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -90,9 +90,13 @@ def _extract_api_date(day: dict[str, Any]) -> str | None:
     date_obj = day.get("date") or {}
     if not isinstance(date_obj, dict):
         return None
-    if not all(date_obj.get(k) is not None for k in ("year", "month", "day")):
+
+    year = safe_parse_int(date_obj.get("year"))
+    month = safe_parse_int(date_obj.get("month"))
+    day_num = safe_parse_int(date_obj.get("day"))
+    if year is None or month is None or day_num is None:
         return None
-    return f"{date_obj['year']:04d}-{date_obj['month']:02d}-{date_obj['day']:02d}"
+    return f"{year:04d}-{month:02d}-{day_num:02d}"
 
 
 def _build_forecast_entry(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1624,6 +1624,31 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
                     }
                 ],
             },
+            {
+                "date": "bad-date",
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": 4,
+                            "category": "MODERATE",
+                            "indexDescription": "Moderate",
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {
+                            "value": 3,
+                            "category": "MODERATE",
+                            "indexDescription": "Moderate",
+                        },
+                    }
+                ],
+            },
         ]
     }
 
@@ -1640,7 +1665,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=4,
+        forecast_days=5,
         create_d1=True,
         create_d2=True,
         client=client,
@@ -1666,6 +1691,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert type_entry["forecast"][1]["has_index"] is True
     assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
     assert type_entry["forecast"][2]["date"] is None
+    assert type_entry["forecast"][3]["date"] is None
 
     d1_entry = data["type_grass_d1"]
     assert d1_entry["value"] is None
@@ -1695,6 +1721,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert plant_entry["forecast"][1]["date"] is None
     assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
     assert plant_entry["forecast"][2]["date"] is None
+    assert plant_entry["forecast"][3]["date"] is None
 
 
 def test_plant_forecast_matches_codes_case_insensitively() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1521,6 +1521,155 @@ def test_plant_sensor_includes_forecast_attributes(
     assert entry["expected_peak"]["value"] == 4
 
 
+def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None:
+    """Forecast entries preserve missing index and missing API date output."""
+
+    payload = {
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 6, "day": 1},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "inSeason": True,
+                        "healthRecommendations": ["Today advice"],
+                        "indexInfo": {
+                            "value": 2,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {
+                            "value": 3,
+                            "category": "MODERATE",
+                            "indexDescription": "Moderate",
+                        },
+                    }
+                ],
+            },
+            {
+                "date": {"year": 2025, "month": 6, "day": 2},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "inSeason": False,
+                        "healthRecommendations": ["Tomorrow advice"],
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {},
+                    }
+                ],
+            },
+            {
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "inSeason": True,
+                        "healthRecommendations": ["D2 advice"],
+                        "indexInfo": {
+                            "value": 5,
+                            "category": "HIGH",
+                            "indexDescription": "High",
+                            "color": {"red": 255, "green": 100, "blue": 50},
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {
+                            "value": 1,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                            "color": {"red": 0, "green": 1, "blue": 0},
+                        },
+                    }
+                ],
+            },
+        ]
+    }
+
+    fake_session = FakeSession(payload)
+    client = client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        forecast_days=3,
+        create_d1=True,
+        create_d2=True,
+        client=client,
+    )
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    type_entry = data["type_grass"]
+    assert type_entry["forecast"][0] == {
+        "offset": 1,
+        "date": "2025-06-02",
+        "has_index": False,
+        "value": None,
+        "category": None,
+        "description": None,
+        "color_hex": None,
+        "color_rgb": None,
+    }
+    assert type_entry["forecast"][1]["date"] is None
+    assert type_entry["forecast"][1]["has_index"] is True
+    assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
+
+    d1_entry = data["type_grass_d1"]
+    assert d1_entry["value"] is None
+    assert d1_entry["category"] is None
+    assert d1_entry["description"] is None
+    assert d1_entry["date"] == "2025-06-02"
+    assert d1_entry["has_index"] is False
+    assert d1_entry["inSeason"] is False
+    assert d1_entry["advice"] == ["Tomorrow advice"]
+
+    d2_entry = data["type_grass_d2"]
+    assert d2_entry["value"] == 5
+    assert d2_entry["date"] is None
+    assert d2_entry["has_index"] is True
+
+    plant_entry = data["plants_oak"]
+    assert plant_entry["forecast"][0] == {
+        "offset": 1,
+        "date": "2025-06-02",
+        "has_index": False,
+        "value": None,
+        "category": None,
+        "description": None,
+        "color_hex": None,
+        "color_rgb": None,
+    }
+    assert plant_entry["forecast"][1]["date"] is None
+    assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
+
+
 def test_plant_forecast_matches_codes_case_insensitively() -> None:
     """Plant forecast should match even when code casing varies by day."""
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1521,6 +1521,29 @@ def test_plant_sensor_includes_forecast_attributes(
     assert entry["expected_peak"]["value"] == 4
 
 
+@pytest.mark.parametrize(
+    ("day", "expected"),
+    [
+        ({"date": {"year": 2025, "month": 6, "day": 1}}, "2025-06-01"),
+        ({"date": {"year": "2025", "month": "6", "day": "1"}}, "2025-06-01"),
+        ({}, None),
+        ({"date": None}, None),
+        ({"date": {"year": 2025, "month": 6}}, None),
+        ({"date": {"year": 2025, "month": None, "day": 1}}, None),
+        ({"date": "bad-date"}, None),
+        ({"date": {"year": "bad", "month": 6, "day": 1}}, None),
+        ({"date": {"year": 2025.5, "month": 6, "day": 1}}, None),
+        ({"date": {"year": True, "month": 6, "day": 1}}, None),
+    ],
+)
+def test_extract_api_date_parses_integer_like_values(
+    day: dict[str, Any], expected: str | None
+) -> None:
+    """API date extraction accepts integer-like values and rejects malformed ones."""
+
+    assert coordinator_mod._extract_api_date(day) == expected
+
+
 def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None:
     """Forecast entries preserve missing index and missing API date output."""
 
@@ -1630,11 +1653,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
                     {
                         "code": "GRASS",
                         "displayName": "Grass",
-                        "indexInfo": {
-                            "value": 4,
-                            "category": "MODERATE",
-                            "indexDescription": "Moderate",
-                        },
+                        "indexInfo": "bad-index",
                     }
                 ],
                 "plantInfo": [
@@ -1691,7 +1710,16 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert type_entry["forecast"][1]["has_index"] is True
     assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
     assert type_entry["forecast"][2]["date"] is None
-    assert type_entry["forecast"][3]["date"] is None
+    assert type_entry["forecast"][3] == {
+        "offset": 4,
+        "date": None,
+        "has_index": False,
+        "value": None,
+        "category": None,
+        "description": None,
+        "color_hex": None,
+        "color_rgb": None,
+    }
 
     d1_entry = data["type_grass_d1"]
     assert d1_entry["value"] is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1572,6 +1572,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
                 ],
             },
             {
+                "date": {"year": 2025, "month": None, "day": 3},
                 "pollenTypeInfo": [
                     {
                         "code": "GRASS",
@@ -1599,6 +1600,30 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
                     }
                 ],
             },
+            {
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": 1,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {
+                            "value": 2,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                    }
+                ],
+            },
         ]
     }
 
@@ -1615,7 +1640,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=3,
+        forecast_days=4,
         create_d1=True,
         create_d2=True,
         client=client,
@@ -1640,6 +1665,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert type_entry["forecast"][1]["date"] is None
     assert type_entry["forecast"][1]["has_index"] is True
     assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
+    assert type_entry["forecast"][2]["date"] is None
 
     d1_entry = data["type_grass_d1"]
     assert d1_entry["value"] is None
@@ -1668,6 +1694,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     }
     assert plant_entry["forecast"][1]["date"] is None
     assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
+    assert plant_entry["forecast"][2]["date"] is None
 
 
 def test_plant_forecast_matches_codes_case_insensitively() -> None:


### PR DESCRIPTION
### Motivation

* Reduce duplication and complexity in the forecast extraction logic inside `custom_components/pollenlevels/coordinator.py`.
* Preserve all public behavior, attributes, and existing forecast shaping semantics while extracting small helpers for clarity.
* Make the coordinator forecast code easier to maintain after the stale-data TTL work.

### Description

* Added three module-level private helpers:

  * `_extract_api_date(day)`
  * `_build_forecast_entry(offset, date, item)`
  * `_build_forecast_list(daily, item_by_day_code, code, forecast_days)`
* Replaced inline date extraction for the current day with `_extract_api_date(...)` while preserving the emitted `date` meta shape.
* Replaced duplicated forecast-construction blocks for both TYPES and PLANTS with `_build_forecast_list(...)`.
* Preserved all forecast entry output keys:

  * `offset`
  * `date`
  * `has_index`
  * `value`
  * `category`
  * `description`
  * `color_hex`
  * `color_rgb`
* Preserved D+1/D+2 type sensor creation and output shaping.
* Hardened `_extract_api_date(...)` so malformed API date values return `None` instead of failing coordinator processing:

  * missing `date`
  * `date: null`
  * non-dict date values
  * missing `year`, `month`, or `day`
  * `year`, `month`, or `day` set to `null`
* Added a focused regression test `test_forecast_extraction_preserves_missing_index_and_date_behavior` in `tests/test_sensor.py`.

### Behavior intentionally preserved

* No public sensor keys were changed.
* No entity IDs or unique IDs were changed.
* No translation keys were changed.
* No config entry data/options shape was changed.
* No diagnostics shape was changed.
* No config flow or options flow behavior was changed.
* No stale-data TTL behavior was changed.
* No HTTP client retry/backoff behavior was changed.
* No user-facing options were added.
* README, CHANGELOG, manifest, pyproject, and translations were not changed.

### Regression coverage

The new regression test covers:

* Forecast entries with missing `indexInfo`.
* Forecast entries with empty `indexInfo`.
* Forecast entries with missing API dates.
* Forecast entries with API date fields set to `null`.
* Forecast entries with malformed non-dict API date values.
* Forecast color conversion.
* Forecast extraction for pollen types.
* Forecast extraction for plants.
* D+1/D+2 type sensor shaping.

### Testing

* `ruff check --fix --select I .`
* `ruff check .`
* `black --check .`
* `pytest -q tests/test_sensor.py`
* `pytest -q`
* `python -m compileall -q custom_components tests`

CI result:

* Lint: success
* tests: success, `273 passed`
* Validate with hassfest: success
* Validate with HACS: success

Changed files:

* `custom_components/pollenlevels/coordinator.py`
* `tests/test_sensor.py`

### Release notes

* This PR intentionally does not update `CHANGELOG.md` or bump the version.
* If alpha1/alpha2 testing does not surface regressions, this refactor can be accumulated for the next planned `2.2.0-beta1` pre-release.
