### PR TITLE
Prepare 2.2.0-beta1 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [2.2.0-beta1] - 2026-05-18
+### Changed
+- Refactored coordinator forecast extraction to reuse shared private helpers for
+  API date extraction, forecast entry construction, and forecast list
+  construction.
+- Reused the shared forecast extraction path for both pollen type and plant
+  forecast attributes while preserving existing public sensor states and
+  attributes.
+- Hardened coordinator API date extraction so malformed API date payloads return
+  `None` instead of failing coordinator processing.
+- Hardened forecast `indexInfo` handling so missing, empty, or malformed
+  forecast index payloads keep the existing `has_index: false` behavior.
+
+### Fixed
+- Prevented malformed forecast date payloads from interrupting otherwise usable
+  coordinator updates.
+- Preserved D+1/D+2 type sensor shaping when forecast days contain missing
+  indexes, malformed dates, or malformed forecast index payloads.
+
 ## [2.2.0-alpha2] - 2026-05-17
 ### Added
 - Added stale-data expiration for malformed Google Pollen API payloads: cached

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0-alpha2"
+    "version": "2.2.0-beta1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0-alpha2"
+version = "2.2.0-beta1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Prepare the first beta pre-release for the upcoming 2.2.0 line by promoting the current alpha artifacts to `2.2.0-beta1` and documenting the coordinator forecast extraction refactor from PR #108.
- Keep the change surface minimal and limited to release metadata and `CHANGELOG.md` so no runtime behavior is altered.

### Description
- Bumped the integration manifest version in `custom_components/pollenlevels/manifest.json` from `2.2.0-alpha2` to `2.2.0-beta1`.
- Bumped the project package version in `pyproject.toml` from `2.2.0-alpha2` to `2.2.0-beta1`.
- Inserted a new top-level `CHANGELOG.md` entry `## [2.2.0-beta1] - 2026-05-18` describing the coordinator forecast extraction refactor and associated hardening/fixes from PR #108 while leaving the existing `2.2.0-alpha2` and `2.2.0-alpha1` entries unchanged.
- Limited the PR to only these metadata and changelog updates and did not change runtime code, tests, translations, workflows, or README.

### Testing
- Ran `ruff check --fix --select I` and `ruff check .`, both of which completed successfully.
- Ran `black --check .`, which completed successfully.
- Ran `pytest -q`, which completed successfully with `283 passed` tests.
- Ran `python -m compileall -q custom_components tests`, which completed successfully.
- Attempted `python -m pip install .` which failed to build/install due to an external package-index/tunnel `403 Forbidden` when fetching build dependencies (environment/network issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae47b1e4c8324a8fdc52c555abd58)