### PR TITLE
Audit and streamline test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,19 @@
 - Do not rename entities, alter `unique_id` patterns, or modify translation keys unless explicitly requested.
 - Prefer minimal, focused diffs; avoid cosmetic refactors or large code moves.
 
+## Test and Defensive Coding Policy
+- Do not add defensive code or tests only because an arbitrary JSON shape could theoretically exist.
+- Add defensive handling or regression tests when they:
+  - protect public behavior or user-facing outputs,
+  - cover a real bug or previously observed failure,
+  - cover a new branch introduced by the change,
+  - prevent a likely exception from partially malformed upstream data,
+  - or document an intentional compatibility or migration behavior.
+- Prefer small, focused tests over large synthetic fixtures.
+- Avoid duplicating malformed-payload test cases when the same behavior is already covered by a smaller helper-level test.
+- Keep defensive parsing proportional to the upstream API contract; do not add broad schema validators unless the integration has observed real instability in that payload area.
+- When a review suggests hardening for a highly unlikely upstream shape, first decide whether the scenario is realistic enough to justify code and test complexity. If not, document the reasoning in the PR instead of expanding the code.
+
 ## Changelog / `CHANGELOG.md`
 - This section is the single source of truth for the changelog style. Ignore external style guides when they conflict with these rules.
 - Do NOT add any new boilerplate, intro text or `## [Unreleased]` section automatically. If such sections already exist, leave them and only edit their content when explicitly requested.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -672,6 +672,25 @@ def _base_user_input() -> dict:
     }
 
 
+def _build_options_flow(data: dict | None = None) -> cf.PollenLevelsOptionsFlow:
+    """Build an options flow with simple form/create-entry callbacks."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data=data or {CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
+    )
+    flow = cf.PollenLevelsOptionsFlow(entry)
+    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
+    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "form",
+        **kwargs,
+    }
+    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
+        "type": "create_entry",
+        **kwargs,
+    }
+    return flow
+
+
 @pytest.mark.parametrize(
     ("raw_value", "expected"),
     [
@@ -1299,19 +1318,7 @@ def test_options_flow_invalid_forecast_mode_combinations(
 ) -> None:
     """Options flow should reject forecast modes requiring more forecast days."""
 
-    entry = cf.config_entries.ConfigEntry(
-        data={CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
-    )
-    flow = cf.PollenLevelsOptionsFlow(entry)
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "form",
-        **kwargs,
-    }
-    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "create_entry",
-        **kwargs,
-    }
+    flow = _build_options_flow()
 
     result = asyncio.run(
         flow.async_step_init(
@@ -1336,19 +1343,7 @@ def test_options_flow_valid_forecast_mode_combinations_are_accepted(
 ) -> None:
     """Options flow should accept forecast mode combinations with enough days."""
 
-    entry = cf.config_entries.ConfigEntry(
-        data={CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
-    )
-    flow = cf.PollenLevelsOptionsFlow(entry)
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "form",
-        **kwargs,
-    }
-    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "create_entry",
-        **kwargs,
-    }
+    flow = _build_options_flow()
 
     result = asyncio.run(
         flow.async_step_init(
@@ -1367,17 +1362,7 @@ def test_options_flow_valid_forecast_mode_combinations_are_accepted(
 def test_options_flow_invalid_forecast_days_returns_error() -> None:
     """Options flow should keep the dedicated invalid forecast days field error."""
 
-    entry = cf.config_entries.ConfigEntry(data={CONF_FORECAST_DAYS: 3})
-    flow = cf.PollenLevelsOptionsFlow(entry)
-    flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
-    flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "form",
-        **kwargs,
-    }
-    flow.async_create_entry = lambda **kwargs: {  # type: ignore[method-assign]
-        "type": "create_entry",
-        **kwargs,
-    }
+    flow = _build_options_flow({CONF_FORECAST_DAYS: 3})
 
     result = asyncio.run(flow.async_step_init({CONF_FORECAST_DAYS: "not-a-number"}))
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -406,6 +406,32 @@ def _minimal_valid_payload(value: int = 2) -> dict[str, Any]:
     }
 
 
+def _make_coordinator(
+    loop: asyncio.AbstractEventLoop,
+    client: client_mod.GooglePollenApiClient,
+    *,
+    hours: int = 12,
+    forecast_days: int = 1,
+    create_d1: bool = False,
+    create_d2: bool = False,
+) -> coordinator_mod.PollenDataUpdateCoordinator:
+    """Build a coordinator with stable defaults for refresh tests."""
+
+    return coordinator_mod.PollenDataUpdateCoordinator(
+        hass=DummyHass(loop),
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=hours,
+        language=None,
+        entry_id="entry",
+        forecast_days=forecast_days,
+        create_d1=create_d1,
+        create_d2=create_d2,
+        client=client,
+    )
+
+
 class RegistryEntry(NamedTuple):
     """Entity registry entry stub."""
 
@@ -806,20 +832,7 @@ def test_type_sensor_preserves_source_with_single_day(
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -868,20 +881,7 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing() -> None:
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -929,20 +929,7 @@ def test_coordinator_first_refresh_missing_dailyinfo_raises() -> None:
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="dailyInfo"):
@@ -960,20 +947,7 @@ def test_coordinator_first_refresh_invalid_dailyinfo_type_raises() -> None:
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="dailyInfo"):
@@ -1010,20 +984,7 @@ def test_coordinator_invalid_dailyinfo_items_keep_last_data() -> None:
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1075,20 +1036,7 @@ def test_coordinator_mixed_dailyinfo_items_keep_last_data() -> None:
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=2,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client, forecast_days=2)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1116,20 +1064,7 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=6,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client, hours=6)
     monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
 
     try:
@@ -1203,20 +1138,7 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=6,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client, hours=6)
     monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
 
     try:
@@ -1623,51 +1545,6 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
                     }
                 ],
             },
-            {
-                "pollenTypeInfo": [
-                    {
-                        "code": "GRASS",
-                        "displayName": "Grass",
-                        "indexInfo": {
-                            "value": 1,
-                            "category": "LOW",
-                            "indexDescription": "Low",
-                        },
-                    }
-                ],
-                "plantInfo": [
-                    {
-                        "code": "oak",
-                        "displayName": "Oak",
-                        "indexInfo": {
-                            "value": 2,
-                            "category": "LOW",
-                            "indexDescription": "Low",
-                        },
-                    }
-                ],
-            },
-            {
-                "date": "bad-date",
-                "pollenTypeInfo": [
-                    {
-                        "code": "GRASS",
-                        "displayName": "Grass",
-                        "indexInfo": "bad-index",
-                    }
-                ],
-                "plantInfo": [
-                    {
-                        "code": "oak",
-                        "displayName": "Oak",
-                        "indexInfo": {
-                            "value": 3,
-                            "category": "MODERATE",
-                            "indexDescription": "Moderate",
-                        },
-                    }
-                ],
-            },
         ]
     }
 
@@ -1675,19 +1552,8 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=5,
-        create_d1=True,
-        create_d2=True,
-        client=client,
+    coordinator = _make_coordinator(
+        loop, client, forecast_days=3, create_d1=True, create_d2=True
     )
 
     try:
@@ -1709,18 +1575,6 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert type_entry["forecast"][1]["date"] is None
     assert type_entry["forecast"][1]["has_index"] is True
     assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
-    assert type_entry["forecast"][2]["date"] is None
-    assert type_entry["forecast"][3] == {
-        "offset": 4,
-        "date": None,
-        "has_index": False,
-        "value": None,
-        "category": None,
-        "description": None,
-        "color_hex": None,
-        "color_rgb": None,
-    }
-
     d1_entry = data["type_grass_d1"]
     assert d1_entry["value"] is None
     assert d1_entry["category"] is None
@@ -1748,8 +1602,6 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     }
     assert plant_entry["forecast"][1]["date"] is None
     assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
-    assert plant_entry["forecast"][2]["date"] is None
-    assert plant_entry["forecast"][3]["date"] is None
 
 
 def test_plant_forecast_matches_codes_case_insensitively() -> None:
@@ -1836,20 +1688,7 @@ def test_coordinator_accepts_numeric_string_color_channels() -> None:
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1886,20 +1725,7 @@ def test_coordinator_ignores_invalid_string_color_channels() -> None:
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1936,20 +1762,7 @@ def test_coordinator_ignores_nonfinite_color_channels() -> None:
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1987,20 +1800,7 @@ def test_coordinator_type_keys_are_deterministic_sorted() -> None:
     client = client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -2241,20 +2041,7 @@ def test_coordinator_retries_then_raises_on_rate_limit(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
@@ -2300,20 +2087,7 @@ def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> N
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
@@ -2375,20 +2149,7 @@ def test_coordinator_retry_after_invalid_values_use_safe_default(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
@@ -2419,20 +2180,7 @@ def test_coordinator_retries_then_raises_on_server_errors(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="HTTP 502"):
@@ -2461,20 +2209,7 @@ def test_coordinator_retries_then_wraps_timeout(
     client = client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
-        hass=hass,
-        api_key="test",
-        lat=1.0,
-        lon=2.0,
-        hours=12,
-        language=None,
-        entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
-        client=client,
-    )
+    coordinator = _make_coordinator(loop, client)
 
     try:
         with pytest.raises(client_mod.UpdateFailed, match="Timeout"):


### PR DESCRIPTION
Motivation

- Reduce noise and duplicated boilerplate in the test suite while preserving the behavioral and regression coverage important for release candidate validation.
- Keep tests focused on public behavior, config flow boundaries, coordinator stale-data rules, forecast shaping, redaction/validation helpers, and Home Assistant integration boundaries.
- Add repository-level guidance to avoid overengineering defensive parsing/tests for highly unlikely arbitrary JSON shapes in future Codex/Gemini reviews.

Description

- Added a shared coordinator factory "_make_coordinator(...)" in "tests/test_sensor.py" to consolidate repeated "PollenDataUpdateCoordinator" construction and make per-test overrides concise.
- Added a shared options-flow builder "_build_options_flow(...)" in "tests/test_config_flow.py" to remove repeated options-flow stubbing while keeping parametrized compatibility checks explicit.
- Trimmed and simplified a large forecast extraction fixture by removing malformed-date rows/assertions that duplicated the direct "_extract_api_date(...)" parametrized tests.
- Preserved the key forecast assertions that document:
  - missing-index handling,
  - D+1/D+2 entity behavior,
  - plant forecast attributes,
  - type forecast attributes,
  - malformed API date handling through focused helper-level coverage.
- Added a new "AGENTS.md" section, "Test and Defensive Coding Policy", to guide future agent reviews and test-writing decisions.
- Changed only test files plus repository agent guidance: "tests/test_sensor.py", "tests/test_config_flow.py", and "AGENTS.md"; no production/runtime code or release metadata were modified.

Behavior intentionally preserved

- No runtime integration code was changed.
- No public sensor states or attributes were changed.
- No entity IDs or unique IDs were changed.
- No translation keys were changed.
- No config entry data/options shape was changed.
- No diagnostics shape was changed.
- No config flow or options flow behavior was changed.
- No stale-data TTL behavior was changed.
- No HTTP client retry/backoff behavior was changed.
- No README, CHANGELOG, manifest, pyproject, translation, workflow, or version changes were made.

Coverage intentionally preserved

- Coordinate and API-key redaction coverage remains in place.
- Config-flow forecast days and forecast sensor mode compatibility coverage remains in place.
- Runtime setup and invalid stored-coordinate behavior coverage remains in place.
- Coordinator stale-data TTL coverage remains in place.
- Forecast extraction coverage remains in place for:
  - missing "indexInfo",
  - empty "indexInfo",
  - missing or malformed API dates via direct "_extract_api_date(...)" tests,
  - D+1/D+2 type sensor shaping,
  - plant forecast attributes,
  - type forecast attributes,
  - color conversion behavior.
- The removed forecast fixture rows duplicated helper-level malformed-date coverage and did not protect additional public output paths.

Testing

- "ruff check --fix --select I ."
- "ruff check ."
- "black --check ."
- "pytest -q"
- "python -m compileall -q custom_components tests"

CI result:

- Lint: success
- tests: success, "283 passed"
- Validate with hassfest: success
- Validate with HACS: success

Changed files:

- "AGENTS.md"
- "tests/test_config_flow.py"
- "tests/test_sensor.py"

Release notes

- This PR intentionally does not update "CHANGELOG.md" or bump the version.
- This PR is test-suite and repository-guidance cleanup only.
- If beta1 testing does not surface regressions, this cleanup can be included before the planned "2.2.0-rc1" pre-release.