### PR TITLE
Align tests workflow with compile validation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ jobs:
         run: |
           python -m pip install .
 
+      - name: Compile Python sources
+        run: |
+          python -m compileall -q custom_components tests
+
       - name: Run tests
         run: |
           pytest -q


### PR DESCRIPTION
### Motivation
- Catch syntax/bytecode issues earlier in CI so pull requests fail fast on invalid Python before release candidates.

### Description
- Add a CI-only `Compile Python sources` step to `.github/workflows/tests.yml` that runs `python -m compileall -q custom_components tests` before the existing `Run tests` step, and make no changes to runtime code, tests, or release metadata.

### Testing
- Ran `ruff check .` (passed), `black --check .` (passed), `pytest -q` (283 passed), and `python -m compileall -q custom_components tests` (no errors); all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2378030c8324acb3d42037abdbb5)