### PR TITLE
Polish documentation callout formatting

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -82,7 +82,7 @@ Typical quota items you’ll see (names may vary slightly by locale):
 > **Safe setting:** You can set **HeatMap** quotas to **0** (or the minimum allowed) to block tile usage and avoid accidental billing.
 
 **Recommended hard caps (safe defaults):**
-> Caution: Quota caps are a useful safety guard, but Google notes they may not be enforced with absolute precision due to latency. Keep a buffer below the free cap instead of setting limits right at the monthly maximum.
+> **Caution:** Quota caps are a useful safety guard, but Google notes they may not be enforced with absolute precision due to latency. Keep a buffer below the free cap instead of setting limits right at the monthly maximum.
 
 - **Forecast Usage per day** → **150**  
   (≈ 4,500/month, comfortably under the 5,000 free cap; increase only if you have multiple locations or frequent manual refreshes)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ color: '[[[
 curl -X GET "https://pollen.googleapis.com/v1/forecast:lookup?key=YOUR_KEY&location.latitude=48.8566&location.longitude=2.3522&days=2&languageCode=es"
 ```
 
-> Note: Replace "YOUR_KEY" locally and never share full API URLs containing "key=..." publicly.
+> **Note:** Replace `YOUR_KEY` locally and never share full API URLs containing `key=...` publicly.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make README and FAQ callouts visually consistent and clearer ahead of the 2.2.0 RC while keeping the change minimal and docs-only.

### Description
- Bolds callout prefixes and adjusts inline code formatting in the docs: updated `README.md` (bolded `Note:` and formatted `YOUR_KEY` / `key=...` as inline code) and `FAQ.md` (bolded `Caution:`); no runtime code, config, translations, tests, or release metadata were modified.

### Testing
- Ran `ruff check .`, `black --check .`, `pytest -q`, and `python -m compileall -q custom_components tests`, and all checks/tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b817ecf14832496e9df1d1062f0f7)