### PR TITLE
Prepare 2.2.0-rc1 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.2.0-rc1] - 2026-05-18
+### Changed
+- Audited and streamlined the test suite while preserving coverage for redaction,
+  validation helpers, stale-data TTL behavior, forecast extraction, config flow
+  validation, and Home Assistant setup flows.
+- Added repository guidance for future agent reviews to avoid overengineering
+  defensive parsing and tests for highly unlikely upstream payload shapes.
+- Aligned the regular tests workflow with release validation by compiling Python
+  sources before running pytest.
+- Polished pre-RC documentation notes around API key sharing, Google Maps
+  Platform pricing/quota verification, quota-cap latency, and Markdown callout
+  formatting.
+
 ## [2.2.0-beta1] - 2026-05-18
 ### Changed
 - Refactored coordinator forecast extraction to reuse shared private helpers for

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0-beta1"
+    "version": "2.2.0-rc1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0-beta1"
+version = "2.2.0-rc1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Prepare the first release candidate for the upcoming 2.2.0 line by bumping release metadata and recording post-beta1 CI/test/documentation updates in the changelog. 
- This release preparation assumes PR #113 (polish documentation callout formatting) is merged into the base history, which is present in the branch lineage used for this change.

### Description
- Updated `custom_components/pollenlevels/manifest.json` version from "2.2.0-beta1" to "2.2.0-rc1". 
- Updated `pyproject.toml` `version` to "2.2.0-rc1" and inserted a new top changelog entry `## [2.2.0-rc1] - 2026-05-18` with a `### Changed` section summarizing test-suite, CI, and documentation polish items. 
- No runtime code, tests, workflow, translation, or README changes were introduced.

### Testing
- Ran `ruff check .` and `black --check .` which completed successfully. 
- Ran `pytest -q` which completed successfully with `283 passed`. 
- Ran `python -m compileall -q custom_components tests` which completed successfully. 
- Ran `python -m pip install .` which failed in this environment due to restricted network/index access when resolving build dependencies (environmental issue, not a code problem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8325ee3883248dc65dcd0c2e64f6)