### PR TITLE
Prepare 2.2.0 final release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,47 @@
-## [2.2.0-rc1] - 2026-05-18
+## [2.2.0] - 2026-05-18
+
+### Added
+
+- Added stale-data expiration for malformed Google Pollen API payloads: cached
+  coordinator data is now reused only while it remains within the effective TTL.
+- Added repository guidance for future agent reviews to avoid overengineering
+  defensive parsing and tests for highly unlikely upstream payload shapes.
+
 ### Changed
+
+- Hardened HTTP and config-flow error redaction so API keys and precise
+  coordinates are redacted from client and validation error messages.
+- Centralized latitude and longitude validation across config flow and runtime
+  setup.
+- Centralized forecast sensor mode and forecast-days compatibility validation
+  across setup and options flow.
+- Cached daily summary sensor payloads per coordinator data object to avoid
+  redundant `daily_summary(...)` recomputation for the same sensor update.
+- Refactored coordinator forecast extraction to reuse shared private helpers for
+  API date extraction, forecast entry construction, and forecast list
+  construction.
+- Aligned package, release, and regular test validation by compiling Python
+  sources and running Ruff, Black, and pytest before release packaging.
 - Audited and streamlined the test suite while preserving coverage for redaction,
   validation helpers, stale-data TTL behavior, forecast extraction, config flow
   validation, and Home Assistant setup flows.
-- Added repository guidance for future agent reviews to avoid overengineering
-  defensive parsing and tests for highly unlikely upstream payload shapes.
-- Aligned the regular tests workflow with release validation by compiling Python
-  sources before running pytest.
-- Polished pre-RC documentation notes around API key sharing, Google Maps
-  Platform pricing/quota verification, quota-cap latency, and Markdown callout
+- Polished documentation around API key sharing, Google Maps Platform
+  pricing/quota verification, quota-cap latency, and Markdown callout
   formatting.
+
+### Fixed
+
+- Prevented indefinitely stale pollen data from remaining available when the API
+  repeatedly returns missing or invalid `dailyInfo` after a previous successful
+  refresh.
+- Prevented malformed forecast date payloads from interrupting otherwise usable
+  coordinator updates.
+- Preserved D+1/D+2 type sensor shaping when forecast days contain missing
+  indexes, malformed dates, or malformed forecast index payloads.
+- Ensured config-flow error placeholders use safe fallback messages when upstream
+  exception messages are empty.
+- Prevented precise invalid stored coordinates from being logged during runtime
+  setup failures.
 
 ## [2.2.0-beta1] - 2026-05-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,11 @@
 ## [2.2.0] - 2026-05-18
-
 ### Added
-
 - Added stale-data expiration for malformed Google Pollen API payloads: cached
   coordinator data is now reused only while it remains within the effective TTL.
 - Added repository guidance for future agent reviews to avoid overengineering
   defensive parsing and tests for highly unlikely upstream payload shapes.
 
 ### Changed
-
 - Hardened HTTP and config-flow error redaction so API keys and precise
   coordinates are redacted from client and validation error messages.
 - Centralized latitude and longitude validation across config flow and runtime
@@ -30,7 +27,6 @@
   formatting.
 
 ### Fixed
-
 - Prevented indefinitely stale pollen data from remaining available when the API
   repeatedly returns missing or invalid `dailyInfo` after a previous successful
   refresh.

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0-rc1"
+    "version": "2.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0-rc1"
+version = "2.2.0"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Promote the unpublished `2.2.0-rc1` artifacts to the final stable `2.2.0` release and consolidate the top-level changelog entry while avoiding any runtime behavior changes.
- Keep prior `2.2.0-beta1`/`2.2.0-alpha2`/`2.2.0-alpha1` history intact and maintain the existing repository constraints (no runtime, test, workflow, translation, or README changes). 

### Description
- Updated the integration manifest version to `2.2.0` in `custom_components/pollenlevels/manifest.json`.
- Updated the package version to `2.2.0` in `pyproject.toml`.
- Replaced the top changelog entry with the final `## [2.2.0] - 2026-05-18` entry containing the provided `Added`/`Changed`/`Fixed` text and left subsequent `2.2.0-beta1`, `2.2.0-alpha2`, and `2.2.0-alpha1` entries unchanged.
- No other files were modified (no runtime code, tests, workflows, translations, or README edits). 

### Testing
- Ran `ruff check .` which passed with no issues.
- Ran `black --check .` which passed with no required formatting changes.
- Ran `pytest -q` which succeeded with `283 passed` tests.
- Ran `python -m compileall -q custom_components tests` which completed successfully.
- Attempted `python -m pip install .` which failed due to the environment/network being unable to fetch build dependencies (index/TLS/403), and is an environment limitation rather than a code failure.

Verification: `manifest.json` and `pyproject.toml` contain exactly `2.2.0`, `CHANGELOG.md` top heading is exactly `## [2.2.0] - 2026-05-18`, there is no top-level `2.2.0-rc1` entry and no `### Notes` section, and no runtime/test/workflow/translation/README files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0f190ae48324a1d4bc75802a9bc6)