### PR TITLE
Refactor options flow to modern Home Assistant pattern

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -2,8 +2,6 @@
 
 Notes:
 - Adds a top-level DEBUG log when the force_update service is invoked to aid debugging.
-- Registers an options update listener to reload the entry so interval/language changes
-  take effect immediately without reinstalling.
 """
 
 from __future__ import annotations
@@ -177,7 +175,7 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
 async def async_setup_entry(
     hass: HomeAssistant, entry: PollenLevelsConfigEntry
 ) -> bool:
-    """Forward config entry to sensor platform and register options listener."""
+    """Forward config entry to sensor platform."""
     _LOGGER.debug(
         "PollenLevels async_setup_entry for entry_id=%s title=%s",
         entry.entry_id,
@@ -280,9 +278,6 @@ async def async_setup_entry(
         _LOGGER.exception("Error forwarding entry setups: %s", err)
         raise ConfigEntryNotReady from err
 
-    # Ensure options updates (interval/language/forecast settings) trigger reload.
-    entry.async_on_unload(entry.add_update_listener(_update_listener))
-
     _LOGGER.info("PollenLevels integration loaded successfully")
     return True
 
@@ -296,13 +291,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unloaded:
         entry.runtime_data = None
     return unloaded
-
-
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle options update by reloading the entry.
-
-    Home Assistant calls this listener after the user saves Options.
-    Reloading recreates the coordinator with the new settings.
-    """
-    _LOGGER.debug("Reloading entry %s after options update", entry.entry_id)
-    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -621,7 +621,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
+class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
     """Handle options for an existing entry."""
 
     async def async_step_init(self, user_input=None):

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -314,7 +314,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(entry: config_entries.ConfigEntry):
         """Return the options flow handler."""
-        return PollenLevelsOptionsFlow(entry)
+        return PollenLevelsOptionsFlow()
 
     async def _async_validate_input(
         self,
@@ -624,32 +624,31 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
     """Handle options for an existing entry."""
 
-    def __init__(self, entry: config_entries.ConfigEntry) -> None:
-        self.entry = entry
-
     async def async_step_init(self, user_input=None):
         """Display/process options form."""
         errors: dict[str, str] = {}
-        placeholders = {"title": self.entry.title or DEFAULT_ENTRY_TITLE}
+        placeholders = {"title": self.config_entry.title or DEFAULT_ENTRY_TITLE}
 
-        current_interval_raw = self.entry.options.get(
+        current_interval_raw = self.config_entry.options.get(
             CONF_UPDATE_INTERVAL,
-            self.entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+            self.config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
         )
         current_interval = _sanitize_update_interval_for_default(current_interval_raw)
-        current_lang = self.entry.options.get(
+        current_lang = self.config_entry.options.get(
             CONF_LANGUAGE_CODE,
-            self.entry.data.get(CONF_LANGUAGE_CODE, self.hass.config.language),
+            self.config_entry.data.get(CONF_LANGUAGE_CODE, self.hass.config.language),
         )
-        current_days_raw = self.entry.options.get(
+        current_days_raw = self.config_entry.options.get(
             CONF_FORECAST_DAYS,
-            self.entry.data.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS),
+            self.config_entry.data.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS),
         )
         current_days_default = _sanitize_forecast_days_for_default(current_days_raw)
         current_days = int(current_days_default)
-        current_mode = self.entry.options.get(CONF_CREATE_FORECAST_SENSORS)
+        current_mode = self.config_entry.options.get(CONF_CREATE_FORECAST_SENSORS)
         if current_mode is None:
-            current_mode = self.entry.data.get(CONF_CREATE_FORECAST_SENSORS, "none")
+            current_mode = self.config_entry.data.get(
+                CONF_CREATE_FORECAST_SENSORS, "none"
+            )
         current_mode = _sanitize_forecast_mode_for_default(current_mode)
 
         options_schema = vol.Schema(
@@ -688,7 +687,10 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
         )
 
         if user_input is not None:
-            normalized_input: dict[str, Any] = {**self.entry.options, **user_input}
+            normalized_input: dict[str, Any] = {
+                **self.config_entry.options,
+                **user_input,
+            }
             interval_value, interval_error = _parse_update_interval(
                 normalized_input.get(CONF_UPDATE_INTERVAL, current_interval),
                 current_interval,
@@ -719,9 +721,9 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
             try:
                 raw_lang = normalized_input.get(
                     CONF_LANGUAGE_CODE,
-                    self.entry.options.get(
+                    self.config_entry.options.get(
                         CONF_LANGUAGE_CODE,
-                        self.entry.data.get(CONF_LANGUAGE_CODE, ""),
+                        self.config_entry.data.get(CONF_LANGUAGE_CODE, ""),
                     ),
                 )
                 lang = raw_lang.strip() if isinstance(raw_lang, str) else ""
@@ -751,7 +753,7 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlow):
             except Exception as err:  # defensive
                 _LOGGER.exception(
                     "Options validation error: %s",
-                    redact_api_key(err, self.entry.data.get(CONF_API_KEY)),
+                    redact_api_key(err, self.config_entry.data.get(CONF_API_KEY)),
                 )
                 errors["base"] = "unknown"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -94,6 +94,10 @@ class _StubOptionsFlow:
     pass
 
 
+class _StubOptionsFlowWithReload(_StubOptionsFlow):
+    pass
+
+
 class _StubConfigEntry:
     def __init__(self, data=None, options=None, entry_id="stub-entry"):
         self.data = data or {}
@@ -105,7 +109,7 @@ class _StubConfigEntry:
 
 config_entries_mod.ConfigFlow = _StubConfigFlow
 config_entries_mod.OptionsFlow = _StubOptionsFlow
-config_entries_mod.OptionsFlowWithReload = _StubOptionsFlow
+config_entries_mod.OptionsFlowWithReload = _StubOptionsFlowWithReload
 config_entries_mod.ConfigEntry = _StubConfigEntry
 _force_module("homeassistant.config_entries", config_entries_mod)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -105,6 +105,7 @@ class _StubConfigEntry:
 
 config_entries_mod.ConfigFlow = _StubConfigFlow
 config_entries_mod.OptionsFlow = _StubOptionsFlow
+config_entries_mod.OptionsFlowWithReload = _StubOptionsFlow
 config_entries_mod.ConfigEntry = _StubConfigEntry
 _force_module("homeassistant.config_entries", config_entries_mod)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -678,7 +678,8 @@ def _build_options_flow(data: dict | None = None) -> cf.PollenLevelsOptionsFlow:
     entry = cf.config_entries.ConfigEntry(
         data=data or {CONF_FORECAST_DAYS: 3, CONF_CREATE_FORECAST_SENSORS: "none"}
     )
-    flow = cf.PollenLevelsOptionsFlow(entry)
+    flow = cf.PollenLevelsOptionsFlow()
+    flow.config_entry = entry
     flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
     flow.async_show_form = lambda **kwargs: {  # type: ignore[method-assign]
         "type": "form",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -299,7 +299,6 @@ class _FakeEntry:
         self.entry_id = entry_id
         self.title = title
         self.domain = integration.DOMAIN
-        self._update_listener = None
         self.data = data or {
             integration.CONF_API_KEY: "key",
             integration.CONF_LATITUDE: 1.0,
@@ -308,15 +307,6 @@ class _FakeEntry:
         self.options = options or {}
         self.version = version
         self.runtime_data = None
-
-    def add_update_listener(self, listener):
-        self._update_listener = listener
-        return listener
-
-    def async_on_unload(self, callback):
-        # Store callbacks to mirror Home Assistant behavior during tests.
-        self._on_unload = callback  # pragma: no cover - stored for completeness
-        return callback
 
 
 class _FakeHass:
@@ -587,7 +577,7 @@ def test_setup_entry_wraps_generic_error() -> None:
 def test_setup_entry_success_and_unload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Happy path should forward setup, register listener, and unload cleanly."""
+    """Happy path should forward setup and unload cleanly."""
 
     hass = _FakeHass()
     entry = _FakeEntry()
@@ -626,14 +616,9 @@ def test_setup_entry_success_and_unload(
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
     assert hass.config_entries.forward_calls == [(entry, ["sensor"])]
-    assert entry._update_listener is integration._update_listener  # noqa: SLF001
-    assert entry._on_unload is entry._update_listener  # noqa: SLF001
 
     assert entry.runtime_data is not None
     assert entry.runtime_data.coordinator.entry_id == entry.entry_id
-
-    asyncio.run(entry._update_listener(hass, entry))  # noqa: SLF001
-    assert hass.config_entries.reload_calls == [entry.entry_id]
 
     assert asyncio.run(integration.async_unload_entry(hass, entry)) is True
     assert hass.config_entries.unload_calls == [(entry, ["sensor"])]

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -42,11 +42,20 @@ def _flow(entry_data: dict | None = None, options: dict | None = None):
         },
         options=options,
     )
-    flow = PollenLevelsOptionsFlow(entry)
+    flow = PollenLevelsOptionsFlow()
+    flow.config_entry = entry
     flow.hass = SimpleNamespace(config=SimpleNamespace(language="en"))
     flow.async_show_form = lambda **kwargs: kwargs
     flow.async_create_entry = lambda *, title, data: {"title": title, "data": data}
     return flow
+
+
+def test_options_flow_uses_modern_reload_base_class() -> None:
+    """Options flow should inherit OptionsFlowWithReload."""
+
+    assert issubclass(
+        PollenLevelsOptionsFlow, base.cf.config_entries.OptionsFlowWithReload
+    )
 
 
 def test_options_flow_invalid_language_sets_error() -> None:


### PR DESCRIPTION
### Motivation

- Move the integration to the recommended Home Assistant options-flow lifecycle.
- Keep options changes applying immediately without relying on a manually registered config entry update listener.
- Avoid the deprecated listener + reload pattern ahead of Home Assistant 2026.6/2026.12 compatibility requirements.
- Simplify runtime wiring by removing the legacy `add_update_listener` usage and `_update_listener` helper.

### Description

- Removed the manual `entry.add_update_listener(_update_listener)` registration from `custom_components/pollenlevels/__init__.py`.
- Removed the `_update_listener` helper because options reloads are now handled by the options flow itself.
- Updated `PollenLevelsConfigFlow.async_get_options_flow` to return `PollenLevelsOptionsFlow()` without passing the config entry.
- Changed `PollenLevelsOptionsFlow` to inherit from `config_entries.OptionsFlowWithReload`.
- Updated `PollenLevelsOptionsFlow` to use `self.config_entry` instead of storing the entry in a custom `__init__`.
- Updated tests to construct options flows with `PollenLevelsOptionsFlow()` and assign `flow.config_entry`.
- Added regression coverage to ensure the options flow uses the modern reload-capable base class.
- Removed tests that asserted the old manual update-listener registration.

### Notes

- This PR intentionally does **not** restore `entry.add_update_listener` or `_update_listener`.
- Options changes still trigger reload behavior through `OptionsFlowWithReload`.
- The open Gemini/Codex review comments about restoring the listener refer to an earlier intermediate state of the PR and are superseded by the `OptionsFlowWithReload` change.

### Testing

- `python -m compileall -q custom_components tests`
- `ruff check .`
- `black --check .`
- `pytest -q`
- GitHub Actions:
  - Lint: passing
  - tests: passing
  - hassfest: passing
  - HACS validation: passing