### PR TITLE
Stop forcing update_before_add when adding pollen sensors

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -226,7 +226,7 @@ async def async_setup_entry(
             preview,
             suffix,
         )
-    async_add_entities(sensors, True)
+    async_add_entities(sensors)
 
 
 class PollenSensor(CoordinatorEntity, SensorEntity):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2356,6 +2356,68 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update() -> (
+    None
+):
+    """Setup uses first-refresh coordinator data and does not force entity update."""
+
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={
+            sensor.CONF_API_KEY: "key",
+            sensor.CONF_LATITUDE: 1.0,
+            sensor.CONF_LONGITUDE: 2.0,
+            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+        },
+        entry_id="entry",
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "date": {"source": "meta", "value": "2026-05-08"},
+            "region": {"source": "meta", "value": "us_ca_san_francisco"},
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+            },
+        },
+        entry_id="entry",
+        entry_title="Home",
+        lat=1.0,
+        lon=2.0,
+        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        create_d1=False,
+        create_d2=False,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+        coordinator=coordinator, client=object()
+    )
+
+    captured: list[Any] = []
+    update_before_add_value: bool | None = None
+
+    def _capture_entities(entities, _update_before_add=False):
+        nonlocal update_before_add_value
+        captured.extend(entities)
+        update_before_add_value = _update_before_add
+
+    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    assert update_before_add_value is False
+
+    grass_sensor = next(
+        entity
+        for entity in captured
+        if getattr(entity, "unique_id", "") == "entry_type_grass"
+    )
+    assert grass_sensor.native_value == 3
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
     """Setup creates the three daily summary sensors."""
 


### PR DESCRIPTION
### Motivation
- Avoid forcing an immediate entity update on add so entity creation uses the data already refreshed by the coordinator first refresh and prevents an extra refresh cycle.
- Ensure initial entity state is sourced from `coordinator.async_config_entry_first_refresh()` rather than from a forced `update_before_add` update.
- Update tests to reflect the new `update_before_add=False` behavior and to assert that initial sensor state is correct.

### Description
- Replace `async_add_entities(sensors, True)` with `async_add_entities(sensors)` in `custom_components/pollenlevels/sensor.py` to stop forcing `update_before_add`.
- Add `test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update` in `tests/test_sensor.py` which captures the `update_before_add` flag and asserts it is `False` and that a grass sensor reports the expected `native_value` from coordinator data.
- Adjusted test formatting (one test file was reformatted by `black`) and updated test helpers that capture the `update_before_add` argument.

### Testing
- Ran `black custom_components/pollenlevels/sensor.py tests/test_sensor.py` which reformatted the test file and succeeded.
- Ran `ruff check --fix --select I custom_components/pollenlevels/sensor.py tests/test_sensor.py` and `ruff check custom_components/pollenlevels/sensor.py tests/test_sensor.py`, both completed without errors.
- Ran `pytest -q tests/test_sensor.py` and all tests passed (`65 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc8c0685883249841d02dcec21482)