### PR TITLE
Prepare v2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [2.2.1] - 2026-05-20
+### Changed
+- Modernized the options-flow reload path by using Home Assistant's
+  `OptionsFlowWithReload` pattern instead of a manually registered config-entry
+  update listener.
+- Reduced visible coordinate precision in translated device-name placeholders to
+  two decimal places while preserving full-precision coordinates for API
+  requests and configuration.
+
+### Fixed
+- Avoided a possible duplicate coordinator refresh when adding sensor entities
+  during setup, relying on the existing first coordinator refresh performed
+  before platform setup.
+- Preserved immediate reload behavior after options changes without reintroducing
+  the legacy update-listener pattern.
+
 ## [2.2.0] - 2026-05-18
 ### Added
 - Added stale-data expiration for malformed Google Pollen API payloads: cached

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.0"
+    "version": "2.2.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.0"
+version = "2.2.1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Prepare a patch release (v2.2.1) to record and publish the small behavior and privacy improvements merged in recent PRs.
- Keep changes minimal and non-functional: only update release metadata and the changelog while preserving integration API and entity stability.
- Ensure the repository still passes the required static checks and test suite before opening the release PR.

### Description
- Bumped the integration manifest version from `2.2.0` to `2.2.1` in `custom_components/pollenlevels/manifest.json` and the package version from `2.2.0` to `2.2.1` in `pyproject.toml`.
- Added a new top changelog entry `## [2.2.1] - 2026-05-20` describing the modernized options-flow reload migration, reduced visible coordinate precision in device-name placeholders, avoidance of duplicate coordinator refreshes at startup, and preservation of immediate reload behavior after options changes.
- No functional code changes were made beyond metadata and changelog, and this release does not change API request coordinates, unique IDs, entity IDs, translation keys, or stored config entry data.

### Testing
- Ran `python -m compileall -q custom_components tests` and compilation checks completed successfully.
- Ran `ruff check --fix --select I .` and `ruff check .` and both lint steps completed successfully with import-order fixes applied where needed.
- Ran `black --check .` and `pytest -q` and all checks passed with the full test suite succeeding (`288 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d8fcec7e48324ae2fb75a8f6ec98a)