### PR TITLE
Round visible reauth/reconfigure coordinate placeholders to 2 decimals

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -114,6 +114,17 @@ def _safe_coord(value: Any, *, lat: bool) -> float | None:
     return validate_longitude(value)
 
 
+def _format_visible_coordinate(value: Any, *, lat: bool) -> str:
+    """Format coordinates for UI placeholders with 2 decimals.
+
+    Returns an empty string when value is missing or invalid.
+    """
+    parsed = _safe_coord(value, lat=lat)
+    if parsed is None:
+        return ""
+    return f"{parsed:.2f}"
+
+
 def _required_forecast_days_for_mode(mode: str) -> int:
     """Return the minimum forecast days required for a sensor mode."""
     return _FORECAST_MODE_MIN_DAYS.get(mode, MIN_FORECAST_DAYS)
@@ -552,8 +563,12 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Render/process an API-key confirmation step for an existing entry."""
         errors: dict[str, str] = {}
         placeholders = {
-            "latitude": f"{entry.data.get(CONF_LATITUDE)}",
-            "longitude": f"{entry.data.get(CONF_LONGITUDE)}",
+            "latitude": _format_visible_coordinate(
+                entry.data.get(CONF_LATITUDE), lat=True
+            ),
+            "longitude": _format_visible_coordinate(
+                entry.data.get(CONF_LONGITUDE), lat=False
+            ),
             "api_key_url": POLLEN_API_KEY_URL,
             "restricting_api_keys_url": RESTRICTING_API_KEYS_URL,
         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1865,8 +1865,17 @@ def test_reauth_confirm_updates_existing_entry_and_reloads() -> None:
     assert recorder.reloaded == "entry-id"
 
 
-def test_reauth_confirm_description_placeholders_round_coordinates() -> None:
-    """Reauth placeholders should expose visible coordinates rounded to 2 decimals."""
+@pytest.mark.parametrize(
+    ("step_method_name", "entry_getter"),
+    [
+        ("async_step_reauth_confirm", "_get_reauth_entry"),
+        ("async_step_reconfigure", "_get_reconfigure_entry"),
+    ],
+)
+def test_api_key_confirm_description_placeholders_round_coordinates(
+    step_method_name: str, entry_getter: str
+) -> None:
+    """Reauth/reconfigure placeholders should round visible coordinates."""
 
     entry = cf.config_entries.ConfigEntry(
         data={
@@ -1878,19 +1887,15 @@ def test_reauth_confirm_description_placeholders_round_coordinates() -> None:
         entry_id="entry-id",
     )
 
-    class _Recorder:
-        def async_get_entry(self, entry_id: str):
-            return entry if entry_id == entry.entry_id else None
-
-        def async_update_entry(self, entry_to_update, *, data):
-            return None
-
-        def async_reload(self, entry_id: str):
-            return None
-
     flow = PollenLevelsConfigFlow()
-    flow.hass = SimpleNamespace(config_entries=_Recorder())
+    flow.hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_update_entry=lambda *args, **kwargs: None,
+            async_reload=lambda *args, **kwargs: None,
+        )
+    )
     flow.context = {"entry_id": "entry-id"}
+    setattr(flow, entry_getter, lambda: entry)
 
     captured: dict[str, object] = {}
     normalized = {**entry.data, CONF_API_KEY: "new-key"}
@@ -1904,7 +1909,8 @@ def test_reauth_confirm_description_placeholders_round_coordinates() -> None:
 
     flow._async_validate_input = fake_validate  # type: ignore[assignment]
 
-    asyncio.run(flow.async_step_reauth_confirm({CONF_API_KEY: "new-key"}))
+    step_method = getattr(flow, step_method_name)
+    asyncio.run(step_method({CONF_API_KEY: "new-key"}))
 
     placeholders = captured["description_placeholders"]
     assert placeholders is not None
@@ -2119,57 +2125,6 @@ def test_reconfigure_does_not_reintroduce_option_fields_in_data() -> None:
     assert updated_data[CONF_API_KEY] == "new-key"
     assert CONF_CREATE_FORECAST_SENSORS not in updated_data
     assert created["called"] is False
-
-
-def test_reconfigure_description_placeholders_round_coordinates() -> None:
-    """Reconfigure placeholders should expose visible coordinates rounded to 2 decimals."""
-
-    entry = cf.config_entries.ConfigEntry(
-        data={
-            CONF_API_KEY: "old-key",
-            CONF_LATITUDE: 39.123456,
-            CONF_LONGITUDE: -0.123456,
-            CONF_LANGUAGE_CODE: "en",
-        },
-        entry_id="entry-id",
-    )
-
-    class _Recorder:
-        def async_get_entry(self, entry_id: str):
-            return entry if entry_id == entry.entry_id else None
-
-        def async_update_entry(self, entry_to_update, *, data):
-            return None
-
-        def async_reload(self, entry_id: str):
-            return None
-
-    flow = PollenLevelsConfigFlow()
-    flow.hass = SimpleNamespace(config_entries=_Recorder())
-    flow.context = {"entry_id": "entry-id"}
-
-    captured: dict[str, object] = {}
-    normalized = {**entry.data, CONF_API_KEY: "new-key"}
-
-    async def fake_validate(
-        user_input, *, check_unique_id, description_placeholders=None
-    ):
-        captured["description_placeholders"] = description_placeholders
-        captured["user_input"] = dict(user_input)
-        return {}, normalized
-
-    flow._async_validate_input = fake_validate  # type: ignore[assignment]
-
-    asyncio.run(flow.async_step_reconfigure({CONF_API_KEY: "new-key"}))
-
-    placeholders = captured["description_placeholders"]
-    assert placeholders is not None
-    assert placeholders["latitude"] == "39.12"
-    assert placeholders["longitude"] == "-0.12"
-
-    combined_input = captured["user_input"]
-    assert combined_input[CONF_LATITUDE] == 39.123456
-    assert combined_input[CONF_LONGITUDE] == -0.123456
 
 
 def test_async_step_user_uses_custom_entry_name() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2117,6 +2117,8 @@ def test_reconfigure_does_not_reintroduce_option_fields_in_data() -> None:
     updated_entry, updated_data = recorder.updated
     assert updated_entry is entry
     assert updated_data[CONF_API_KEY] == "new-key"
+    assert CONF_CREATE_FORECAST_SENSORS not in updated_data
+    assert created["called"] is False
 
 
 def test_reconfigure_description_placeholders_round_coordinates() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1865,6 +1865,57 @@ def test_reauth_confirm_updates_existing_entry_and_reloads() -> None:
     assert recorder.reloaded == "entry-id"
 
 
+def test_reauth_confirm_description_placeholders_round_coordinates() -> None:
+    """Reauth placeholders should expose visible coordinates rounded to 2 decimals."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 39.123456,
+            CONF_LONGITUDE: -0.123456,
+            CONF_LANGUAGE_CODE: "en",
+        },
+        entry_id="entry-id",
+    )
+
+    class _Recorder:
+        def async_get_entry(self, entry_id: str):
+            return entry if entry_id == entry.entry_id else None
+
+        def async_update_entry(self, entry_to_update, *, data):
+            return None
+
+        def async_reload(self, entry_id: str):
+            return None
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=_Recorder())
+    flow.context = {"entry_id": "entry-id"}
+
+    captured: dict[str, object] = {}
+    normalized = {**entry.data, CONF_API_KEY: "new-key"}
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        captured["description_placeholders"] = description_placeholders
+        captured["user_input"] = dict(user_input)
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    asyncio.run(flow.async_step_reauth_confirm({CONF_API_KEY: "new-key"}))
+
+    placeholders = captured["description_placeholders"]
+    assert placeholders is not None
+    assert placeholders["latitude"] == "39.12"
+    assert placeholders["longitude"] == "-0.12"
+
+    combined_input = captured["user_input"]
+    assert combined_input[CONF_LATITUDE] == 39.123456
+    assert combined_input[CONF_LONGITUDE] == -0.123456
+
+
 def test_reauth_confirm_does_not_reintroduce_option_fields_in_data() -> None:
     """Reauth should only update API key in data, preserving option boundaries."""
 
@@ -2066,8 +2117,57 @@ def test_reconfigure_does_not_reintroduce_option_fields_in_data() -> None:
     updated_entry, updated_data = recorder.updated
     assert updated_entry is entry
     assert updated_data[CONF_API_KEY] == "new-key"
-    assert CONF_CREATE_FORECAST_SENSORS not in updated_data
-    assert created["called"] is False
+
+
+def test_reconfigure_description_placeholders_round_coordinates() -> None:
+    """Reconfigure placeholders should expose visible coordinates rounded to 2 decimals."""
+
+    entry = cf.config_entries.ConfigEntry(
+        data={
+            CONF_API_KEY: "old-key",
+            CONF_LATITUDE: 39.123456,
+            CONF_LONGITUDE: -0.123456,
+            CONF_LANGUAGE_CODE: "en",
+        },
+        entry_id="entry-id",
+    )
+
+    class _Recorder:
+        def async_get_entry(self, entry_id: str):
+            return entry if entry_id == entry.entry_id else None
+
+        def async_update_entry(self, entry_to_update, *, data):
+            return None
+
+        def async_reload(self, entry_id: str):
+            return None
+
+    flow = PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace(config_entries=_Recorder())
+    flow.context = {"entry_id": "entry-id"}
+
+    captured: dict[str, object] = {}
+    normalized = {**entry.data, CONF_API_KEY: "new-key"}
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        captured["description_placeholders"] = description_placeholders
+        captured["user_input"] = dict(user_input)
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    asyncio.run(flow.async_step_reconfigure({CONF_API_KEY: "new-key"}))
+
+    placeholders = captured["description_placeholders"]
+    assert placeholders is not None
+    assert placeholders["latitude"] == "39.12"
+    assert placeholders["longitude"] == "-0.12"
+
+    combined_input = captured["user_input"]
+    assert combined_input[CONF_LATITUDE] == 39.123456
+    assert combined_input[CONF_LONGITUDE] == -0.123456
 
 
 def test_async_step_user_uses_custom_entry_name() -> None:


### PR DESCRIPTION
### Motivation
- Ensure coordinates shown in UI description placeholders are human-friendly (rounded to 2 decimals) while preserving full-precision stored/config/API values and translation placeholders.
- Keep visible formatting confined to UI scope (reauth/reconfigure placeholders and device names) without changing identifiers, storage, diagnostics, or API request precision.

### Description
- Added a small private helper ` _format_visible_coordinate()` in `custom_components/pollenlevels/config_flow.py` to format UI-visible coordinates to 2 decimals and return an empty string for missing/invalid values.
- Updated reauth/reconfigure confirmation `description_placeholders` in `config_flow.py` to use ` _format_visible_coordinate()` for `latitude` and `longitude` instead of raw entry values.
- Verified `custom_components/pollenlevels/sensor.py` continues to use `_device_translation_placeholders()` with `latitude`/`longitude` formatted to 2 decimals for device names and left those unchanged.
- Added focused tests in `tests/test_config_flow.py` to assert reauth and reconfigure placeholders show rounded strings (e.g. `39.12`, `-0.12`) while merged/normalized validation input still preserves full-precision coordinates (e.g. `39.123456`, `-0.123456`).

### Testing
- Ran `python -m compileall -q custom_components tests` which succeeded.
- Ran `ruff check --fix --select I .` and `ruff check .` which succeeded.
- Ran `black --check .` which succeeded.
- Ran `pytest -q` which passed: `290 passed`.
- Verified translation parity across locale files against `translations/en.json` with a custom check, confirming all 21 files have matching keys and placeholders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da93065b483248aab9612c0ed9771)