### PR TITLE
docs: clarify translation source-of-truth and forbid strings.json/%key usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@
 ## Style and Documentation
 - All code comments, README entries, and changelog notes **must be written in English**.
 - Keep imports tidy—remove unused symbols and respect the Ruff isort grouping so the Home Assistant package stays first-party under `custom_components/pollenlevels`.
-- Translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep all other locale files in sync with it and do not add or rely on a `strings.json` file.
+- Translation source of truth is `custom_components/pollenlevels/translations/en.json`.
+- Keep all other locale files synchronized with that keyset.
+- Do not add or rely on a `strings.json` file, and do not introduce `%key:` translation references in this custom repository.
 
 
 ## Integration Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,10 @@
 ## Style and Documentation
 - All code comments, README entries, and changelog notes **must be written in English**.
 - Keep imports tidy—remove unused symbols and respect the Ruff isort grouping so the Home Assistant package stays first-party under `custom_components/pollenlevels`.
-- Translation source of truth is `custom_components/pollenlevels/translations/en.json`.
+- The translation source of truth is `custom_components/pollenlevels/translations/en.json`.
 - Keep all other locale files synchronized with that keyset.
-- Do not add or rely on a `strings.json` file, and do not introduce `%key:` translation references in this custom repository.
+- Do not add or rely on a `strings.json` file.
+- Do not introduce `%key:` translation references in this custom repository.
 
 
 ## Integration Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,4 +7,5 @@
 - The translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep every other locale file in
   sync with it.
 - Do not add or rely on a `strings.json` file; translation updates should flow from `en.json` to the other language files.
+- Do not introduce `%key:` translation references in this custom repository.
 - Preserve the existing coordinator-driven architecture and avoid introducing blocking I/O in the event loop.


### PR DESCRIPTION
### Motivation
- Make the repository translation policy explicit so reviewers and contributors know the single source of truth for locale keys. 
- Prevent introduction of alternative translation artifacts or reference patterns that are incompatible with the integration's localization workflow.

### Description
- Add a short note in `AGENTS.md` stating `custom_components/pollenlevels/translations/en.json` is the translation source of truth. 
- Add guidance to keep all other locale files synchronized with that keyset and to not add or rely on a `strings.json` file or `%key:` translation references. 
- Mirror the `%key:` prohibition in `CONTRIBUTING.md` to surface the rule to contributors.

### Testing
- Ran `ruff check --fix --select I .` and it passed. 
- Ran `ruff check .` and it passed. 
- Ran `black --check .` and it passed; a targeted `black --check AGENTS.md CONTRIBUTING.md` invocation failed because Black does not parse Markdown, but the repository-level check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0deae6f35c8324a5869f421af338c6)