### PR TITLE
chore: improve type annotations in flows, coordinator, and sensors

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -523,7 +523,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    ) -> config_entries.ConfigFlowResult:
         """Handle initial step."""
         errors: dict[str, str] = {}
         description_placeholders: dict[str, Any] = {
@@ -551,7 +551,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=description_placeholders,
         )
 
-    async def async_step_reauth(self, entry_data: dict[str, Any]) -> dict[str, Any]:
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> config_entries.ConfigFlowResult:
         """Handle re-authentication when credentials become invalid."""
         return await self.async_step_reauth_confirm()
 
@@ -563,7 +565,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         success_reason: str,
         user_input: dict[str, Any] | None,
         persist_normalized_data: bool = True,
-    ) -> dict[str, Any]:
+    ) -> config_entries.ConfigFlowResult:
         """Render/process an API-key confirmation step for an existing entry."""
         errors: dict[str, str] = {}
         placeholders = {
@@ -615,7 +617,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    ) -> config_entries.ConfigFlowResult:
         """Prompt for a refreshed API key and validate it."""
         entry = self._get_reauth_entry()
         if entry is None:
@@ -630,7 +632,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    ) -> config_entries.ConfigFlowResult:
         """Prompt for a refreshed API key from the reconfigure UI."""
         entry = self._get_reconfigure_entry()
         if entry is None:
@@ -649,7 +651,7 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    ) -> config_entries.ConfigFlowResult:
         """Display/process options form."""
         errors: dict[str, str] = {}
         placeholders = {"title": self.config_entry.title or DEFAULT_ENTRY_TITLE}

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -551,7 +551,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=description_placeholders,
         )
 
-    async def async_step_reauth(self, entry_data: dict[str, Any]):
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> dict[str, Any]:
         """Handle re-authentication when credentials become invalid."""
         return await self.async_step_reauth_confirm()
 

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -323,7 +323,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 3
 
     @staticmethod
-    def async_get_options_flow(entry: config_entries.ConfigEntry):
+    def async_get_options_flow(
+        entry: config_entries.ConfigEntry,
+    ) -> PollenLevelsOptionsFlow:
         """Return the options flow handler."""
         return PollenLevelsOptionsFlow()
 
@@ -519,7 +521,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return errors, None
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Handle initial step."""
         errors: dict[str, str] = {}
         description_placeholders: dict[str, Any] = {
@@ -559,7 +563,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         success_reason: str,
         user_input: dict[str, Any] | None,
         persist_normalized_data: bool = True,
-    ):
+    ) -> dict[str, Any]:
         """Render/process an API-key confirmation step for an existing entry."""
         errors: dict[str, str] = {}
         placeholders = {
@@ -609,7 +613,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=placeholders,
         )
 
-    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Prompt for a refreshed API key and validate it."""
         entry = self._get_reauth_entry()
         if entry is None:
@@ -622,7 +628,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             persist_normalized_data=False,
         )
 
-    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Prompt for a refreshed API key from the reconfigure UI."""
         entry = self._get_reconfigure_entry()
         if entry is None:
@@ -639,7 +647,9 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
     """Handle options for an existing entry."""
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Display/process options form."""
         errors: dict[str, str] = {}
         placeholders = {"title": self.config_entry.title or DEFAULT_ENTRY_TITLE}

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -153,7 +153,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         create_d2: bool,
         client: GooglePollenApiClient,
         entry_title: str = DEFAULT_ENTRY_TITLE,
-    ):
+    ) -> None:
         """Initialize coordinator with configuration and interval."""
         update_interval = timedelta(hours=hours)
         super().__init__(
@@ -186,8 +186,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self._missing_dailyinfo_warned = False
         self._stale_dailyinfo_warned = False
 
-        self.data: dict[str, dict] = {}
-        self.last_updated = None
+        self.data: dict[str, dict[str, Any]] = {}
+        self.last_updated: datetime | None = None
 
     def _utcnow(self) -> datetime:
         """Return the current UTC time."""
@@ -276,7 +276,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         )
         return base
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch pollen data and extract sensors for current day and forecast."""
         try:
             payload = await self._client.async_fetch_pollen_data(
@@ -296,7 +296,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Pollen API error: %s", msg)
             raise UpdateFailed(msg) from err
 
-        new_data: dict[str, dict] = {}
+        new_data: dict[str, dict[str, Any]] = {}
 
         # region
         if region := payload.get("regionCode"):

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -238,7 +238,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
     # Modern friendly name composition: Device name + Entity short name
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: PollenDataUpdateCoordinator, code: str):
+    def __init__(self, coordinator: PollenDataUpdateCoordinator, code: str) -> None:
         """Initialize pollen sensor."""
         super().__init__(coordinator)
         self.coordinator = coordinator
@@ -253,7 +253,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         return info.get("displayName", self.code)
 
     @property
-    def native_value(self):
+    def native_value(self) -> Any:
         """Return current pollen index value as the sensor's native value."""
         info = self.coordinator.data.get(self.code, {})
         return info.get("value")
@@ -273,7 +273,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         return PLANT_TYPE_ICONS.get(ptype, DEFAULT_ICON)
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra attributes for sensor."""
         info = self.coordinator.data.get(self.code, {}) or {}
         attrs = {
@@ -359,7 +359,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         return attrs
 
     @property
-    def device_info(self):
+    def device_info(self) -> dict[str, Any]:
         """Return device info with translation support for the group."""
         info = self.coordinator.data.get(self.code, {}) or {}
         group = info.get("source")
@@ -517,7 +517,7 @@ class TopPollenTypesTodaySensor(_BaseSummarySensor):
 class _BaseMetaSensor(CoordinatorEntity, SensorEntity):
     """Provide base for metadata sensors."""
 
-    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize metadata sensor.
 
         Static attributes are precomputed as `_attr_*` to avoid repeated property calls.
@@ -555,14 +555,14 @@ class RegionSensor(_BaseMetaSensor):
     # Metadata; classify as diagnostic for better UI grouping.
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize region sensor with static attributes."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{self.coordinator.entry_id}_region"
         self._attr_icon = "mdi:earth"
 
     @property
-    def native_value(self):
+    def native_value(self) -> str | None:
         """Return region code."""
         return self.coordinator.data.get("region", {}).get("value")
 
@@ -577,7 +577,7 @@ class DateSensor(_BaseMetaSensor):
     # Use DATE so the frontend applies date semantics/formatting.
     _attr_device_class = SensorDeviceClass.DATE
 
-    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize date sensor with static attributes."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{self.coordinator.entry_id}_date"
@@ -609,14 +609,14 @@ class LastUpdatedSensor(_BaseMetaSensor):
     # Use TIMESTAMP so the frontend formats the datetime automatically
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
-    def __init__(self, coordinator: PollenDataUpdateCoordinator):
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize last updated sensor with static attributes."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{self.coordinator.entry_id}_last_updated"
         self._attr_icon = "mdi:clock-check"
 
     @property
-    def native_value(self):
+    def native_value(self) -> Any:
         """Return UTC datetime of last update; frontend will localize/format."""
         # Coordinator stores an aware UTC datetime; HA expects a datetime object
         # for TIMESTAMP sensors. The UI will render it as local time.

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable
-from datetime import date  # Added `date` for DATE device class native_value
+from datetime import date, datetime  # Added `date` for DATE device class native_value
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 
@@ -253,7 +253,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         return info.get("displayName", self.code)
 
     @property
-    def native_value(self) -> Any:
+    def native_value(self) -> float | int | None:
         """Return current pollen index value as the sensor's native value."""
         info = self.coordinator.data.get(self.code, {})
         return info.get("value")
@@ -616,7 +616,7 @@ class LastUpdatedSensor(_BaseMetaSensor):
         self._attr_icon = "mdi:clock-check"
 
     @property
-    def native_value(self) -> Any:
+    def native_value(self) -> datetime | None:
         """Return UTC datetime of last update; frontend will localize/format."""
         # Coordinator stores an aware UTC datetime; HA expects a datetime object
         # for TIMESTAMP sensors. The UI will render it as local time.

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable
-from datetime import date, datetime  # Added `date` for DATE device class native_value
+from datetime import date, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 


### PR DESCRIPTION
### Motivation

- Improve internal type clarity across config flow, coordinator, and sensor modules.
- Keep the changes annotation-only, with no runtime behavior changes.
- Prepare the codebase for future static-analysis hardening without introducing new tooling yet.

### Description

- Added explicit Home Assistant flow result annotations in `config_flow.py`.
- Added missing parameter and return annotations to user, reauth, reconfigure, and options-flow handlers.
- Annotated coordinator initialization, cached data, last-updated timestamp, and update-data return types.
- Added constructor return annotations for pollen, summary, and metadata sensors.
- Tightened selected sensor properties, including `native_value`, `extra_state_attributes`, and `device_info`.
- Kept Google Pollen API payload typing conservative with `dict[str, Any]` where the response shape remains flexible.

### Testing

- `python -m compileall -q custom_components tests`
- `ruff check .`
- `black --check .`
- `pytest -q`
- hassfest
- HACS validation

### Notes

- No runtime behavior changes.
- No entity IDs, unique IDs, device identifiers, translation keys, diagnostics, config entry data/options, API calls, coordinate precision, or availability behavior changed.
- No release metadata, README, CHANGELOG, translations, or brand assets changed.