### PR TITLE
chore: prepare v2.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2.2.2] - 2026-05-20
+
+### Changed
+
+- Aligned re-authentication and reconfiguration coordinate placeholders with
+  the existing two-decimal visible device-name formatting while preserving
+  full-precision stored and API coordinates.
+- Documented the repository translation policy, keeping
+  `translations/en.json` as the source of truth without `strings.json` or
+  `%key:` references.
+- Improved internal type annotations in config flow, coordinator, and sensor
+  modules without changing runtime behavior.
+
 ## [2.2.1] - 2026-05-20
 ### Changed
 - Modernized the options-flow reload path by using Home Assistant's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## [2.2.2] - 2026-05-20
-
 ### Changed
-
 - Aligned re-authentication and reconfiguration coordinate placeholders with
   the existing two-decimal visible device-name formatting while preserving
   full-precision stored and API coordinates.

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.1"
+    "version": "2.2.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.1"
+version = "2.2.2"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation

- Prepare the v2.2.2 maintenance release to align release metadata after recent privacy, documentation, and type-annotation hardening changes.
- Include the already-merged changes from #120, #121, and #122 while preserving runtime behavior.
- Keep local brand assets out of this release.

### Description

- Bumped `custom_components/pollenlevels/manifest.json` from `2.2.1` to `2.2.2`.
- Bumped `pyproject.toml` from `2.2.1` to `2.2.2`.
- Added the top `2.2.2` changelog entry.

### Included changes

- Aligned re-authentication and reconfiguration coordinate placeholders with the existing two-decimal visible device-name formatting while preserving full-precision stored and API coordinates.
- Documented the repository translation policy, keeping `translations/en.json` as the source of truth without `strings.json` or `%key:` references for this custom/HACS integration.
- Improved internal type annotations in config flow, coordinator, and sensor modules without changing runtime behavior.

### Testing

- `python -m compileall -q custom_components tests`
- `ruff check .`
- `black --check .`
- `pytest -q`
- GitHub Actions hassfest validation
- GitHub Actions HACS validation

### Notes

- No runtime behavior changes.
- No entity IDs, unique IDs, translation keys, diagnostics, config entry data/options, API calls, stored coordinate precision, or availability behavior changed.
- No local brand assets are included in this release.
- HACS release asset must remain `pollenlevels.zip`.