### PR TITLE
Add manual update Button platform and translations; wire into integration and tests

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -51,6 +51,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 3
+PLATFORMS = ["sensor", "button"]
 
 # ---- Service -------------------------------------------------------------
 
@@ -269,7 +270,7 @@ async def async_setup_entry(
     entry.runtime_data = PollenLevelsRuntimeData(coordinator=coordinator, client=client)
 
     try:
-        await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except ConfigEntryAuthFailed, ConfigEntryNotReady:
         entry.runtime_data = None
         raise
@@ -287,7 +288,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug(
         "PollenLevels async_unload_entry called for entry_id=%s", entry.entry_id
     )
-    unloaded = await hass.config_entries.async_unload_platforms(entry, ["sensor"])
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unloaded:
         entry.runtime_data = None
     return unloaded

--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -1,0 +1,97 @@
+"""Button platform for per-entry manual updates."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .runtime import PollenLevelsConfigEntry
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import PollenDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    config_entry: PollenLevelsConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Pollen Levels update button for one config entry."""
+    runtime = config_entry.runtime_data
+    if runtime is None:
+        raise ConfigEntryNotReady("Runtime data not ready")
+
+    async_add_entities([PollenLevelsUpdateButton(runtime.coordinator)])
+
+
+class PollenLevelsUpdateButton(CoordinatorEntity, ButtonEntity):
+    """Button entity to manually refresh a single location."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "update_now"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
+        """Initialize update button entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.entry_id}_update_now"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, f"{coordinator.entry_id}_meta")},
+            "manufacturer": "Google",
+            "model": "Pollen API",
+            "translation_key": "info",
+            "translation_placeholders": {
+                "title": coordinator.entry_title,
+                "latitude": f"{coordinator.lat:.2f}",
+                "longitude": f"{coordinator.lon:.2f}",
+            },
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return whether the button is available."""
+        return True
+
+    async def async_press(self) -> None:
+        """Refresh this config entry's coordinator."""
+        try:
+            await self.coordinator.async_request_refresh()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Manual update button refresh failed for entry %s (%s)",
+                self.coordinator.entry_id,
+                type(err).__name__,
+            )
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="refresh_failed",
+            ) from err
+
+        if self.coordinator.last_update_success:
+            return
+
+        last_exception = getattr(self.coordinator, "last_exception", None)
+        error_type = type(last_exception).__name__ if last_exception else "UnknownError"
+        _LOGGER.warning(
+            "Manual update button refresh failed for entry %s (%s)",
+            self.coordinator.entry_id,
+            error_type,
+        )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="refresh_failed",
+        )

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Tipus de pol·len principals avui"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Actualitza ara"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "No s'han pogut actualitzar les dades de pol·len"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Hlavní typy pylu dnes"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Aktualizovat nyní"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Nepodařilo se aktualizovat data o pylu"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Vigtigste pollentyper i dag"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Opdater nu"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Kunne ikke opdatere pollendata"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Wichtigste Pollenarten heute"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Jetzt aktualisieren"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Pollendaten konnten nicht aktualisiert werden"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Top pollen types today"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Update now"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Failed to refresh pollen data"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Tipos de polen principales hoy"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Actualizar ahora"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "No se pudieron actualizar los datos de polen"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Tärkeimmät siitepölytyypit tänään"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Päivitä nyt"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Siitepölytietoja ei voitu päivittää"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Principaux types de pollen aujourd’hui"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Mettre à jour maintenant"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Impossible de mettre à jour les données polliniques"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Mai fő pollentípusok"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Frissítés most"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Nem sikerült frissíteni a pollenadatokat"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Tipi di polline principali oggi"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Aggiorna ora"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Impossibile aggiornare i dati sui pollini"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Viktigste pollentyper i dag"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Oppdater nå"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Kunne ikke oppdatere pollendata"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Belangrijkste pollentypen vandaag"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Nu bijwerken"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Kan pollengegevens niet bijwerken"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Główne typy pyłków dzisiaj"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Aktualizuj teraz"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Nie udało się zaktualizować danych o pyłkach"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Principais tipos de pólen hoje"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Atualizar agora"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Não foi possível atualizar os dados de pólen"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Principais tipos de pólen hoje"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Atualizar agora"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Não foi possível atualizar os dados de pólen"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Principalele tipuri de polen astăzi"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Actualizează acum"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Nu s-au putut actualiza datele despre polen"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Основные типы пыльцы сегодня"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Обновить сейчас"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Не удалось обновить данные о пыльце"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Viktigaste pollentyperna idag"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Uppdatera nu"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Kunde inte uppdatera pollendata"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "Основні типи пилку сьогодні"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "Оновити зараз"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "Не вдалося оновити дані про пилок"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "今日主要花粉类型"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "立即更新"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "无法更新花粉数据"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -108,6 +108,16 @@
       "top_pollen_types_today": {
         "name": "今日主要花粉類型"
       }
+    },
+    "button": {
+      "update_now": {
+        "name": "立即更新"
+      }
+    }
+  },
+  "exceptions": {
+    "refresh_failed": {
+      "message": "無法更新花粉資料"
     }
   }
 }

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,249 @@
+"""Unit tests for the Pollen Levels button platform."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+custom_components_pkg = types.ModuleType("custom_components")
+custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+sys.modules.setdefault("custom_components", custom_components_pkg)
+
+pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
+pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
+sys.modules.setdefault("custom_components.pollenlevels", pollenlevels_pkg)
+
+
+class _FakeCoordinator:
+    def __init__(self) -> None:
+        self.entry_id = "entry-123"
+        self.entry_title = "Test Location"
+        self.lat = 40.7128
+        self.lon = -74.0060
+        self.async_request_refresh = AsyncMock()
+        self.last_update_success = True
+        self.last_exception = None
+
+
+@pytest.fixture
+def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    """Provide Home Assistant stubs required by button.py."""
+
+    button_mod = types.ModuleType("homeassistant.components.button")
+
+    class _StubButtonEntity:
+        pass
+
+    button_mod.ButtonEntity = _StubButtonEntity
+    monkeypatch.setitem(sys.modules, "homeassistant.components.button", button_mod)
+
+    entity_mod = types.ModuleType("homeassistant.helpers.entity")
+
+    class _StubEntityCategory:
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
+
+    entity_mod.EntityCategory = _StubEntityCategory
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity_mod)
+
+    update_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+    class _StubCoordinatorEntity:
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+
+    update_mod.CoordinatorEntity = _StubCoordinatorEntity
+    monkeypatch.setitem(
+        sys.modules,
+        "homeassistant.helpers.update_coordinator",
+        update_mod,
+    )
+
+    core_mod = types.ModuleType("homeassistant.core")
+
+    class _StubHomeAssistant:
+        pass
+
+    core_mod.HomeAssistant = _StubHomeAssistant
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core_mod)
+
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+    class _StubHomeAssistantError(Exception):
+        def __init__(
+            self,
+            *args,
+            translation_domain=None,
+            translation_key=None,
+            translation_placeholders=None,
+        ):
+            super().__init__(*args)
+            self.translation_domain = translation_domain
+            self.translation_key = translation_key
+            self.translation_placeholders = translation_placeholders
+
+    class _StubConfigEntryNotReady(Exception):
+        pass
+
+    exceptions_mod.HomeAssistantError = _StubHomeAssistantError
+    exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
+    monkeypatch.setitem(sys.modules, "homeassistant.exceptions", exceptions_mod)
+
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+    class _StubConfigEntry:
+        @classmethod
+        def __class_getitem__(cls, _item):
+            return cls
+
+    config_entries_mod.ConfigEntry = _StubConfigEntry
+    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries_mod)
+
+    return types.SimpleNamespace(
+        exceptions=exceptions_mod,
+        hass_class=_StubHomeAssistant,
+    )
+
+
+@pytest.fixture
+def button_platform(
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> types.SimpleNamespace:
+    """Import button platform after stubbing Home Assistant modules."""
+
+    monkeypatch.delitem(
+        sys.modules,
+        "custom_components.pollenlevels.button",
+        raising=False,
+    )
+    module = importlib.import_module("custom_components.pollenlevels.button")
+    return types.SimpleNamespace(
+        module=module,
+        exceptions=stub_ha_modules.exceptions,
+        hass_class=stub_ha_modules.hass_class,
+    )
+
+
+def test_button_attributes(button_platform: types.SimpleNamespace) -> None:
+    coordinator = _FakeCoordinator()
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    assert entity._attr_unique_id == "entry-123_update_now"
+    assert entity._attr_translation_key == "update_now"
+    assert entity._attr_entity_category == "config"
+    assert entity._attr_device_info["identifiers"] == {
+        ("pollenlevels", "entry-123_meta")
+    }
+    assert entity._attr_device_info["translation_key"] == "info"
+
+
+def test_button_available_when_last_update_failed(
+    button_platform: types.SimpleNamespace,
+) -> None:
+    coordinator = _FakeCoordinator()
+    coordinator.last_update_success = False
+
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    assert entity.available is True
+
+
+@pytest.mark.asyncio
+async def test_button_press_awaits_async_request_refresh(
+    button_platform: types.SimpleNamespace,
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _FakeCoordinator()
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    await entity.async_press()
+
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_button_press_raises_homeassistant_error_on_refresh_failure(
+    button_platform: types.SimpleNamespace,
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _FakeCoordinator()
+    coordinator.async_request_refresh.side_effect = RuntimeError("boom")
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    with pytest.raises(button_platform.exceptions.HomeAssistantError) as err:
+        await entity.async_press()
+
+    assert err.value.translation_domain == "pollenlevels"
+    assert err.value.translation_key == "refresh_failed"
+
+
+@pytest.mark.asyncio
+async def test_button_press_raises_when_refresh_reports_failure(
+    button_platform: types.SimpleNamespace,
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _FakeCoordinator()
+
+    async def _refresh_without_raise() -> None:
+        coordinator.last_update_success = False
+        coordinator.last_exception = RuntimeError("boom")
+
+    coordinator.async_request_refresh.side_effect = _refresh_without_raise
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    with pytest.raises(button_platform.exceptions.HomeAssistantError) as err:
+        await entity.async_press()
+
+    assert err.value.translation_domain == "pollenlevels"
+    assert err.value.translation_key == "refresh_failed"
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_raises_if_runtime_data_missing(
+    button_platform: types.SimpleNamespace,
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = types.SimpleNamespace(runtime_data=None)
+
+    with pytest.raises(button_platform.exceptions.ConfigEntryNotReady):
+        await button_platform.module.async_setup_entry(
+            button_platform.hass_class(),
+            entry,
+            lambda entities: None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_adds_one_button_entity(
+    button_platform: types.SimpleNamespace,
+    stub_ha_modules: types.SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _FakeCoordinator()
+    runtime = types.SimpleNamespace(coordinator=coordinator)
+    entry = types.SimpleNamespace(runtime_data=runtime)
+    added = []
+
+    def _add_entities(entities):
+        added.extend(entities)
+
+    await button_platform.module.async_setup_entry(
+        button_platform.hass_class(),
+        entry,
+        _add_entities,
+    )
+    assert len(added) == 1
+    assert isinstance(added[0], button_platform.module.PollenLevelsUpdateButton)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -615,13 +615,13 @@ def test_setup_entry_success_and_unload(
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
-    assert hass.config_entries.forward_calls == [(entry, ["sensor"])]
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
 
     assert entry.runtime_data is not None
     assert entry.runtime_data.coordinator.entry_id == entry.entry_id
 
     assert asyncio.run(integration.async_unload_entry(hass, entry)) is True
-    assert hass.config_entries.unload_calls == [(entry, ["sensor"])]
+    assert hass.config_entries.unload_calls == [(entry, ["sensor", "button"])]
     assert entry.runtime_data is None
 
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -4,6 +4,7 @@ These tests ensure:
 - All locale files have the exact same keyset as en.json (en.json is the source of truth).
 - Translation keys referenced by config_flow.py (config + options flows) exist in en.json.
 - Translation keys referenced by sensor.py via entity/device translation_key exist in en.json.
+- Translation keys referenced by button.py via entity translation_key exist in en.json.
 - Translation keys for sections (step.*.sections.*) are present if schema uses ``section(...)``.
 - Translation keys for services declared in services.yaml exist in en.json.
 
@@ -30,6 +31,7 @@ TRANSLATIONS_DIR = COMPONENT_DIR / "translations"
 CONFIG_FLOW_PATH = COMPONENT_DIR / "config_flow.py"
 CONST_PATH = COMPONENT_DIR / "const.py"
 SENSOR_PATH = COMPONENT_DIR / "sensor.py"
+BUTTON_PATH = COMPONENT_DIR / "button.py"
 SERVICES_YAML_PATH = COMPONENT_DIR / "services.yaml"
 
 
@@ -37,8 +39,8 @@ def _fail_unexpected_ast(context: str) -> None:
     """Fail with a consistent, actionable message for unsupported AST shapes."""
 
     pytest.fail(
-        "Unexpected AST layout while extracting translation keys from "
-        f"config_flow.py ({context}); please update the helper in test_translations.py",
+        "Unexpected AST layout while extracting translation keys "
+        f"({context}); please update the helper in test_translations.py",
     )
 
 
@@ -210,6 +212,89 @@ def _extract_sensor_translation_key_usage() -> tuple[set[str], set[str]]:
     return entity_keys, device_keys
 
 
+def _extract_button_translation_key_usage() -> set[str]:
+    """Extract translation keys referenced by button entities.
+
+    Entity keys:
+      - _attr_translation_key = "<key>"  -> entity.button.<key>.name
+
+    This stays intentionally narrow; unsupported AST changes should fail loudly.
+    """
+
+    if not BUTTON_PATH.is_file():
+        raise AssertionError(f"Missing button.py at {BUTTON_PATH}")
+
+    tree = ast.parse(BUTTON_PATH.read_text(encoding="utf-8"))
+
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+
+        if isinstance(node, ast.Assign):
+            if len(node.targets) != 1:
+                _fail_unexpected_ast(
+                    "button.py _attr_translation_key assignment has multiple targets"
+                )
+            target = node.targets[0]
+            value = node.value
+        else:
+            target = node.target
+            value = node.value
+
+        if isinstance(target, ast.Name) and target.id == "_attr_translation_key":
+            if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+                _fail_unexpected_ast(
+                    "button.py _attr_translation_key value is not a string literal"
+                )
+            keys.add(value.value)
+
+    return keys
+
+
+def _extract_button_exception_translation_keys() -> set[str]:
+    """Extract HomeAssistantError translation keys referenced by button.py."""
+
+    if not BUTTON_PATH.is_file():
+        raise AssertionError(f"Missing button.py at {BUTTON_PATH}")
+
+    tree = ast.parse(BUTTON_PATH.read_text(encoding="utf-8"))
+
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Name) and node.func.id == "HomeAssistantError"
+        ):
+            continue
+
+        domain = None
+        key = None
+        for kw in node.keywords:
+            if kw.arg == "translation_domain":
+                if isinstance(kw.value, ast.Name) and kw.value.id == "DOMAIN":
+                    domain = "DOMAIN"
+                else:
+                    _fail_unexpected_ast(
+                        "button.py HomeAssistantError translation_domain is unsupported"
+                    )
+            if kw.arg == "translation_key":
+                if isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    key = kw.value.value
+                else:
+                    _fail_unexpected_ast(
+                        "button.py HomeAssistantError translation_key is not string literal"
+                    )
+
+        if domain == "DOMAIN" and key is not None:
+            keys.add(key)
+
+    return keys
+
+
 def test_translations_match_english_keyset() -> None:
     """Verify all locale files mirror the English translation keyset."""
 
@@ -248,6 +333,38 @@ def test_config_flow_extractor_includes_helper_error_keys() -> None:
     assert "options.error.invalid_update_interval" in keys
     assert "config.error.invalid_forecast_days" in keys
     assert "options.error.invalid_forecast_days" in keys
+
+
+def test_button_translation_keys_present() -> None:
+    """Ensure translation keys referenced by button.py exist in en.json."""
+
+    english = _flatten_keys(_load_translation(TRANSLATIONS_DIR / "en.json"))
+    button_keys = _extract_button_translation_key_usage()
+
+    assert button_keys, "No _attr_translation_key values found in button.py"
+
+    missing = {
+        f"entity.button.{key}.name"
+        for key in button_keys
+        if f"entity.button.{key}.name" not in english
+    }
+    assert not missing, f"Missing button translation keys: {sorted(missing)}"
+
+
+def test_button_exception_translation_keys_present() -> None:
+    """Ensure HomeAssistantError translation keys in button.py exist in en.json."""
+
+    english = _flatten_keys(_load_translation(TRANSLATIONS_DIR / "en.json"))
+    error_keys = _extract_button_exception_translation_keys()
+
+    assert error_keys, "No HomeAssistantError translation_key values found in button.py"
+
+    missing = {
+        f"exceptions.{key}.message"
+        for key in error_keys
+        if f"exceptions.{key}.message" not in english
+    }
+    assert not missing, f"Missing button exception translation keys: {sorted(missing)}"
 
 
 def test_sensor_translation_keys_present() -> None:


### PR DESCRIPTION
### Motivation
- Provide a per-entry manual refresh control so users can trigger an immediate data refresh for a specific configured location. 
- Expose translation keys for the new button and surface failures via localized exception messages. 
- Ensure automated tests cover the new button behavior and that translations include the new keys.

### Description
- Add a new `button` platform at `custom_components/pollenlevels/button.py` implementing `PollenLevelsUpdateButton` that calls the coordinator's `async_request_refresh` and raises localized `HomeAssistantError` on failure. 
- Introduce `PLATFORMS = ["sensor", "button"]` in `__init__.py` and forward/unload entry setups using `PLATFORMS` so the button platform is loaded/unloaded with the integration. 
- Add localized translation entries for `entity.button.update_now.name` and `exceptions.refresh_failed.message` across all locale JSON files under `translations/`. 
- Add comprehensive unit tests in `tests/test_button.py` to validate button attributes, availability, refresh behavior, and `async_setup_entry` handling. 
- Update `tests/test_init.py` to expect the integration to forward/unload both `sensor` and `button` platforms. 
- Extend `tests/test_translations.py` to extract/verify translation keys referenced in `button.py`, including entity `translation_key` values and `HomeAssistantError` translation keys.

### Testing
- Ran the new unit tests for the button platform: `tests/test_button.py` and they passed. 
- Ran updated integration tests in `tests/test_init.py` which now verify forwarding/unloading include `button`, and they passed. 
- Ran translation coverage tests in `tests/test_translations.py` which now validate button-related translation keys and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef4ccb5288324b86c901863c608d0)