### PR TITLE
test: isolate button platform tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,13 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+        signature = inspect.signature(pyfuncitem.obj)
+        declared_funcargs = {
+            name: pyfuncitem.funcargs[name]
+            for name in signature.parameters
+            if name in pyfuncitem.funcargs
+        }
+        loop.run_until_complete(pyfuncitem.obj(**declared_funcargs))
     finally:
         # Ensure all tasks and async generators are properly cleaned up
         try:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -6,6 +6,7 @@ import importlib
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -13,102 +14,104 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-custom_components_pkg = types.ModuleType("custom_components")
-custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-sys.modules.setdefault("custom_components", custom_components_pkg)
 
-pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
-pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
-sys.modules.setdefault("custom_components.pollenlevels", pollenlevels_pkg)
+@pytest.fixture
+def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+    monkeypatch.setitem(sys.modules, "custom_components", custom_components_pkg)
 
-button_mod = types.ModuleType("homeassistant.components.button")
+    pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
+    pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
+    monkeypatch.setitem(sys.modules, "custom_components.pollenlevels", pollenlevels_pkg)
 
+    button_mod = types.ModuleType("homeassistant.components.button")
 
-class _StubButtonEntity:
-    pass
+    class _StubButtonEntity:
+        pass
 
+    button_mod.ButtonEntity = _StubButtonEntity
+    monkeypatch.setitem(sys.modules, "homeassistant.components.button", button_mod)
 
-button_mod.ButtonEntity = _StubButtonEntity
-sys.modules.setdefault("homeassistant.components.button", button_mod)
+    entity_mod = types.ModuleType("homeassistant.helpers.entity")
 
-entity_mod = sys.modules.get("homeassistant.helpers.entity") or types.ModuleType(
-    "homeassistant.helpers.entity"
-)
+    class _StubEntityCategory:
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
 
+    entity_mod.EntityCategory = _StubEntityCategory
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity_mod)
 
-class _StubEntityCategory:
-    CONFIG = "config"
-    DIAGNOSTIC = "diagnostic"
+    update_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
 
+    class _StubCoordinatorEntity:
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
 
-entity_mod.EntityCategory = _StubEntityCategory
-sys.modules["homeassistant.helpers.entity"] = entity_mod
+    update_mod.CoordinatorEntity = _StubCoordinatorEntity
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.update_coordinator", update_mod
+    )
 
-update_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+    core_mod = types.ModuleType("homeassistant.core")
 
+    class _StubHomeAssistant:
+        pass
 
-class _StubCoordinatorEntity:
-    def __init__(self, coordinator):
-        self.coordinator = coordinator
+    core_mod.HomeAssistant = _StubHomeAssistant
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core_mod)
 
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
 
-update_mod.CoordinatorEntity = _StubCoordinatorEntity
-sys.modules.setdefault("homeassistant.helpers.update_coordinator", update_mod)
+    class _StubHomeAssistantError(Exception):
+        def __init__(
+            self,
+            *args,
+            translation_domain=None,
+            translation_key=None,
+            translation_placeholders=None,
+        ):
+            super().__init__(*args)
+            self.translation_domain = translation_domain
+            self.translation_key = translation_key
+            self.translation_placeholders = translation_placeholders
 
-core_mod = sys.modules.get("homeassistant.core") or types.ModuleType(
-    "homeassistant.core"
-)
+    class _StubConfigEntryNotReady(Exception):
+        pass
 
+    exceptions_mod.HomeAssistantError = _StubHomeAssistantError
+    exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
+    monkeypatch.setitem(sys.modules, "homeassistant.exceptions", exceptions_mod)
 
-class _StubHomeAssistant:
-    pass
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
 
+    class _StubConfigEntry:
+        @classmethod
+        def __class_getitem__(cls, _item):
+            return cls
 
-core_mod.HomeAssistant = _StubHomeAssistant
-sys.modules["homeassistant.core"] = core_mod
+    config_entries_mod.ConfigEntry = _StubConfigEntry
+    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries_mod)
 
-exceptions_mod = sys.modules.get("homeassistant.exceptions") or types.ModuleType(
-    "homeassistant.exceptions"
-)
-
-
-class _StubHomeAssistantError(Exception):
-    def __init__(
-        self,
-        *args,
-        translation_domain=None,
-        translation_key=None,
-        translation_placeholders=None,
-    ):
-        super().__init__(*args)
-        self.translation_domain = translation_domain
-        self.translation_key = translation_key
-        self.translation_placeholders = translation_placeholders
-
-
-class _StubConfigEntryNotReady(Exception):
-    pass
-
-
-exceptions_mod.HomeAssistantError = _StubHomeAssistantError
-exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
-sys.modules["homeassistant.exceptions"] = exceptions_mod
-
-config_entries_mod = sys.modules.get(
-    "homeassistant.config_entries"
-) or types.ModuleType("homeassistant.config_entries")
-
-
-class _StubConfigEntry:
-    @classmethod
-    def __class_getitem__(cls, _item):
-        return cls
+    return SimpleNamespace(
+        exceptions=exceptions_mod,
+        hass_class=_StubHomeAssistant,
+    )
 
 
-config_entries_mod.ConfigEntry = _StubConfigEntry
-sys.modules["homeassistant.config_entries"] = config_entries_mod
-
-button = importlib.import_module("custom_components.pollenlevels.button")
+@pytest.fixture
+def button_platform(
+    monkeypatch: pytest.MonkeyPatch, stub_ha_modules: SimpleNamespace
+) -> SimpleNamespace:
+    monkeypatch.delitem(
+        sys.modules, "custom_components.pollenlevels.button", raising=False
+    )
+    module = importlib.import_module("custom_components.pollenlevels.button")
+    return SimpleNamespace(
+        module=module,
+        exceptions=stub_ha_modules.exceptions,
+        hass_class=stub_ha_modules.hass_class,
+    )
 
 
 class _FakeCoordinator:
@@ -122,9 +125,9 @@ class _FakeCoordinator:
         self.last_exception = None
 
 
-def test_button_attributes() -> None:
+def test_button_attributes(button_platform: SimpleNamespace) -> None:
     coordinator = _FakeCoordinator()
-    entity = button.PollenLevelsUpdateButton(coordinator)
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
 
     assert entity._attr_unique_id == "entry-123_update_now"
     assert entity._attr_translation_key == "update_now"
@@ -135,19 +138,25 @@ def test_button_attributes() -> None:
     assert entity._attr_device_info["translation_key"] == "info"
 
 
-def test_button_available_when_last_update_failed() -> None:
+def test_button_available_when_last_update_failed(
+    button_platform: SimpleNamespace,
+) -> None:
     coordinator = _FakeCoordinator()
     coordinator.last_update_success = False
 
-    entity = button.PollenLevelsUpdateButton(coordinator)
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
 
     assert entity.available is True
 
 
 @pytest.mark.asyncio
-async def test_button_press_awaits_async_request_refresh() -> None:
+async def test_button_press_awaits_async_request_refresh(
+    button_platform: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_ha_modules: SimpleNamespace,
+) -> None:
     coordinator = _FakeCoordinator()
-    entity = button.PollenLevelsUpdateButton(coordinator)
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
 
     await entity.async_press()
 
@@ -155,12 +164,16 @@ async def test_button_press_awaits_async_request_refresh() -> None:
 
 
 @pytest.mark.asyncio
-async def test_button_press_raises_homeassistant_error_on_refresh_failure() -> None:
+async def test_button_press_raises_homeassistant_error_on_refresh_failure(
+    button_platform: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_ha_modules: SimpleNamespace,
+) -> None:
     coordinator = _FakeCoordinator()
     coordinator.async_request_refresh.side_effect = RuntimeError("boom")
-    entity = button.PollenLevelsUpdateButton(coordinator)
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
 
-    with pytest.raises(exceptions_mod.HomeAssistantError) as err:
+    with pytest.raises(button_platform.exceptions.HomeAssistantError) as err:
         await entity.async_press()
 
     assert err.value.translation_domain == "pollenlevels"
@@ -168,7 +181,11 @@ async def test_button_press_raises_homeassistant_error_on_refresh_failure() -> N
 
 
 @pytest.mark.asyncio
-async def test_button_press_raises_when_refresh_reports_failure() -> None:
+async def test_button_press_raises_when_refresh_reports_failure(
+    button_platform: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_ha_modules: SimpleNamespace,
+) -> None:
     coordinator = _FakeCoordinator()
 
     async def _refresh_without_raise() -> None:
@@ -176,9 +193,9 @@ async def test_button_press_raises_when_refresh_reports_failure() -> None:
         coordinator.last_exception = RuntimeError("boom")
 
     coordinator.async_request_refresh.side_effect = _refresh_without_raise
-    entity = button.PollenLevelsUpdateButton(coordinator)
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
 
-    with pytest.raises(exceptions_mod.HomeAssistantError) as err:
+    with pytest.raises(button_platform.exceptions.HomeAssistantError) as err:
         await entity.async_press()
 
     assert err.value.translation_domain == "pollenlevels"
@@ -186,17 +203,25 @@ async def test_button_press_raises_when_refresh_reports_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_setup_entry_raises_if_runtime_data_missing() -> None:
+async def test_setup_entry_raises_if_runtime_data_missing(
+    button_platform: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_ha_modules: SimpleNamespace,
+) -> None:
     entry = types.SimpleNamespace(runtime_data=None)
 
-    with pytest.raises(exceptions_mod.ConfigEntryNotReady):
-        await button.async_setup_entry(
-            _StubHomeAssistant(), entry, lambda entities: None
+    with pytest.raises(button_platform.exceptions.ConfigEntryNotReady):
+        await button_platform.module.async_setup_entry(
+            button_platform.hass_class(), entry, lambda entities: None
         )
 
 
 @pytest.mark.asyncio
-async def test_setup_entry_adds_one_button_entity() -> None:
+async def test_setup_entry_adds_one_button_entity(
+    button_platform: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_ha_modules: SimpleNamespace,
+) -> None:
     coordinator = _FakeCoordinator()
     runtime = types.SimpleNamespace(coordinator=coordinator)
     entry = types.SimpleNamespace(runtime_data=runtime)
@@ -205,6 +230,8 @@ async def test_setup_entry_adds_one_button_entity() -> None:
     def _add_entities(entities):
         added.extend(entities)
 
-    await button.async_setup_entry(_StubHomeAssistant(), entry, _add_entities)
+    await button_platform.module.async_setup_entry(
+        button_platform.hass_class(), entry, _add_entities
+    )
     assert len(added) == 1
-    assert isinstance(added[0], button.PollenLevelsUpdateButton)
+    assert isinstance(added[0], button_platform.module.PollenLevelsUpdateButton)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -100,9 +100,9 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
 
 @pytest.fixture
-def button_platform(
-    monkeypatch: pytest.MonkeyPatch, stub_ha_modules: SimpleNamespace
-) -> SimpleNamespace:
+def button_platform(request: pytest.FixtureRequest) -> SimpleNamespace:
+    monkeypatch = request.getfixturevalue("monkeypatch")
+    stub_ha_modules = request.getfixturevalue("stub_ha_modules")
     monkeypatch.delitem(
         sys.modules, "custom_components.pollenlevels.button", raising=False
     )
@@ -151,9 +151,7 @@ def test_button_available_when_last_update_failed(
 
 @pytest.mark.asyncio
 async def test_button_press_awaits_async_request_refresh(
-    button_platform: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_ha_modules: SimpleNamespace,
+    button_platform: SimpleNamespace, **_kwargs
 ) -> None:
     coordinator = _FakeCoordinator()
     entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
@@ -165,9 +163,7 @@ async def test_button_press_awaits_async_request_refresh(
 
 @pytest.mark.asyncio
 async def test_button_press_raises_homeassistant_error_on_refresh_failure(
-    button_platform: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_ha_modules: SimpleNamespace,
+    button_platform: SimpleNamespace, **_kwargs
 ) -> None:
     coordinator = _FakeCoordinator()
     coordinator.async_request_refresh.side_effect = RuntimeError("boom")
@@ -182,9 +178,7 @@ async def test_button_press_raises_homeassistant_error_on_refresh_failure(
 
 @pytest.mark.asyncio
 async def test_button_press_raises_when_refresh_reports_failure(
-    button_platform: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_ha_modules: SimpleNamespace,
+    button_platform: SimpleNamespace, **_kwargs
 ) -> None:
     coordinator = _FakeCoordinator()
 
@@ -204,9 +198,7 @@ async def test_button_press_raises_when_refresh_reports_failure(
 
 @pytest.mark.asyncio
 async def test_setup_entry_raises_if_runtime_data_missing(
-    button_platform: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_ha_modules: SimpleNamespace,
+    button_platform: SimpleNamespace, **_kwargs
 ) -> None:
     entry = types.SimpleNamespace(runtime_data=None)
 
@@ -218,9 +210,7 @@ async def test_setup_entry_raises_if_runtime_data_missing(
 
 @pytest.mark.asyncio
 async def test_setup_entry_adds_one_button_entity(
-    button_platform: SimpleNamespace,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_ha_modules: SimpleNamespace,
+    button_platform: SimpleNamespace, **_kwargs
 ) -> None:
     coordinator = _FakeCoordinator()
     runtime = types.SimpleNamespace(coordinator=coordinator)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -100,9 +100,9 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
 
 @pytest.fixture
-def button_platform(request: pytest.FixtureRequest) -> SimpleNamespace:
-    monkeypatch = request.getfixturevalue("monkeypatch")
-    stub_ha_modules = request.getfixturevalue("stub_ha_modules")
+def button_platform(
+    monkeypatch: pytest.MonkeyPatch, stub_ha_modules: SimpleNamespace
+) -> SimpleNamespace:
     monkeypatch.delitem(
         sys.modules, "custom_components.pollenlevels.button", raising=False
     )
@@ -151,7 +151,7 @@ def test_button_available_when_last_update_failed(
 
 @pytest.mark.asyncio
 async def test_button_press_awaits_async_request_refresh(
-    button_platform: SimpleNamespace, **_kwargs
+    button_platform: SimpleNamespace,
 ) -> None:
     coordinator = _FakeCoordinator()
     entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
@@ -163,7 +163,7 @@ async def test_button_press_awaits_async_request_refresh(
 
 @pytest.mark.asyncio
 async def test_button_press_raises_homeassistant_error_on_refresh_failure(
-    button_platform: SimpleNamespace, **_kwargs
+    button_platform: SimpleNamespace,
 ) -> None:
     coordinator = _FakeCoordinator()
     coordinator.async_request_refresh.side_effect = RuntimeError("boom")
@@ -178,7 +178,7 @@ async def test_button_press_raises_homeassistant_error_on_refresh_failure(
 
 @pytest.mark.asyncio
 async def test_button_press_raises_when_refresh_reports_failure(
-    button_platform: SimpleNamespace, **_kwargs
+    button_platform: SimpleNamespace,
 ) -> None:
     coordinator = _FakeCoordinator()
 
@@ -198,7 +198,7 @@ async def test_button_press_raises_when_refresh_reports_failure(
 
 @pytest.mark.asyncio
 async def test_setup_entry_raises_if_runtime_data_missing(
-    button_platform: SimpleNamespace, **_kwargs
+    button_platform: SimpleNamespace,
 ) -> None:
     entry = types.SimpleNamespace(runtime_data=None)
 
@@ -210,7 +210,7 @@ async def test_setup_entry_raises_if_runtime_data_missing(
 
 @pytest.mark.asyncio
 async def test_setup_entry_adds_one_button_entity(
-    button_platform: SimpleNamespace, **_kwargs
+    button_platform: SimpleNamespace,
 ) -> None:
     coordinator = _FakeCoordinator()
     runtime = types.SimpleNamespace(coordinator=coordinator)


### PR DESCRIPTION
### Motivation

- Reduce import-order side effects by removing module-level `sys.modules` stubs in `tests/test_button.py`.
- Make the button platform tests deterministic by injecting Home Assistant test doubles through explicit pytest fixtures.
- Ensure `custom_components.pollenlevels.button` is imported only after the required Home Assistant stubs are in place.

### Description

- Removed module-level Home Assistant stub setup from `tests/test_button.py`.
- Added a `stub_ha_modules` fixture that injects required Home Assistant and package stubs using `monkeypatch.setitem(sys.modules, ...)`.
- Added a `button_platform` fixture that:
  - depends explicitly on `stub_ha_modules` and `monkeypatch`;
  - removes any cached `custom_components.pollenlevels.button` module with `monkeypatch.delitem(..., raising=False)`;
  - imports `custom_components.pollenlevels.button` only after the stubs are injected;
  - returns a `types.SimpleNamespace` with the imported module, exceptions module, and Home Assistant stub class.
- Updated all button platform tests to use the explicit `button_platform` fixture instead of module-level imports or globals.
- Kept the existing async test style with `@pytest.mark.asyncio`, `async def`, and `await`.
- Adjusted the lightweight async pytest hook in `tests/conftest.py` to pass only the fixture arguments declared by each async test function, avoiding leaked dependent fixtures when running coroutine tests without an external async plugin.

### Out of scope

- Runtime code changes.
- Sensor, config flow, init, diagnostics, or client test refactors.
- Shared Home Assistant stub centralization across the whole test suite.
- Release version bumps.
- README or CHANGELOG updates.

### Testing

- [x] `python -m compileall -q custom_components tests`
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest -q`
- [x] `pytest -q tests/test_button.py`
- [x] GitHub Actions: Lint
- [x] GitHub Actions: tests
- [x] GitHub Actions: hassfest
- [x] GitHub Actions: HACS validation