### PR TITLE
test: centralize Home Assistant stubs

### DIFF
--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -20,6 +20,9 @@ def force_module(name: str, module: ModuleType) -> ModuleType:
 def _set_module(
     name: str, module: ModuleType, *, monkeypatch: Any | None = None
 ) -> ModuleType:
+    # Intentionally replace target modules to keep stubs deterministic and avoid
+    # import-order coupling across suites. Fixtures can pass monkeypatch so
+    # teardown restores previous state automatically.
     if monkeypatch is not None:
         monkeypatch.setitem(sys.modules, name, module)
         return module

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -1,0 +1,59 @@
+"""Shared lightweight Home Assistant stubs for tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def force_module(name: str, module: ModuleType) -> ModuleType:
+    """Force a module into ``sys.modules`` and return it."""
+
+    sys.modules[name] = module
+    return module
+
+
+def stub_custom_components_packages(*, root: Path | None = None) -> None:
+    """Stub custom_components packages for local integration imports."""
+
+    base = root or ROOT
+    custom_components_pkg = ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(base / "custom_components")]
+    force_module("custom_components", custom_components_pkg)
+
+    pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
+    pollenlevels_pkg.__path__ = [str(base / "custom_components" / "pollenlevels")]
+    force_module("custom_components.pollenlevels", pollenlevels_pkg)
+
+
+def stub_config_entry_class(cls: type[Any]) -> ModuleType:
+    module = ModuleType("homeassistant.config_entries")
+    module.ConfigEntry = cls
+    force_module("homeassistant.config_entries", module)
+    return module
+
+
+def stub_exceptions(**exception_types: type[Exception]) -> ModuleType:
+    module = ModuleType("homeassistant.exceptions")
+    for name, exc in exception_types.items():
+        setattr(module, name, exc)
+    force_module("homeassistant.exceptions", module)
+    return module
+
+
+def stub_update_coordinator_module(
+    *,
+    update_failed: type[Exception],
+    data_update_coordinator: type[Any],
+    coordinator_entity: type[Any],
+) -> ModuleType:
+    module = ModuleType("homeassistant.helpers.update_coordinator")
+    module.UpdateFailed = update_failed
+    module.DataUpdateCoordinator = data_update_coordinator
+    module.CoordinatorEntity = coordinator_entity
+    force_module("homeassistant.helpers.update_coordinator", module)
+    return module

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -17,31 +17,50 @@ def force_module(name: str, module: ModuleType) -> ModuleType:
     return module
 
 
-def stub_custom_components_packages(*, root: Path | None = None) -> None:
+def _set_module(
+    name: str, module: ModuleType, *, monkeypatch: Any | None = None
+) -> ModuleType:
+    if monkeypatch is not None:
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+    return force_module(name, module)
+
+
+def stub_custom_components_packages(
+    *, root: Path | None = None, monkeypatch: Any | None = None
+) -> None:
     """Stub custom_components packages for local integration imports."""
 
     base = root or ROOT
     custom_components_pkg = ModuleType("custom_components")
     custom_components_pkg.__path__ = [str(base / "custom_components")]
-    force_module("custom_components", custom_components_pkg)
+    _set_module("custom_components", custom_components_pkg, monkeypatch=monkeypatch)
 
     pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
     pollenlevels_pkg.__path__ = [str(base / "custom_components" / "pollenlevels")]
-    force_module("custom_components.pollenlevels", pollenlevels_pkg)
+    _set_module(
+        "custom_components.pollenlevels",
+        pollenlevels_pkg,
+        monkeypatch=monkeypatch,
+    )
 
 
-def stub_config_entry_class(cls: type[Any]) -> ModuleType:
+def stub_config_entry_class(
+    cls: type[Any], *, monkeypatch: Any | None = None
+) -> ModuleType:
     module = ModuleType("homeassistant.config_entries")
     module.ConfigEntry = cls
-    force_module("homeassistant.config_entries", module)
+    _set_module("homeassistant.config_entries", module, monkeypatch=monkeypatch)
     return module
 
 
-def stub_exceptions(**exception_types: type[Exception]) -> ModuleType:
+def stub_exceptions(
+    *, monkeypatch: Any | None = None, **exception_types: type[Exception]
+) -> ModuleType:
     module = ModuleType("homeassistant.exceptions")
     for name, exc in exception_types.items():
         setattr(module, name, exc)
-    force_module("homeassistant.exceptions", module)
+    _set_module("homeassistant.exceptions", module, monkeypatch=monkeypatch)
     return module
 
 
@@ -50,10 +69,13 @@ def stub_update_coordinator_module(
     update_failed: type[Exception],
     data_update_coordinator: type[Any],
     coordinator_entity: type[Any],
+    monkeypatch: Any | None = None,
 ) -> ModuleType:
     module = ModuleType("homeassistant.helpers.update_coordinator")
     module.UpdateFailed = update_failed
     module.DataUpdateCoordinator = data_update_coordinator
     module.CoordinatorEntity = coordinator_entity
-    force_module("homeassistant.helpers.update_coordinator", module)
+    _set_module(
+        "homeassistant.helpers.update_coordinator", module, monkeypatch=monkeypatch
+    )
     return module

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -18,7 +19,7 @@ def force_module(name: str, module: ModuleType) -> ModuleType:
 
 
 def _set_module(
-    name: str, module: ModuleType, *, monkeypatch: Any | None = None
+    name: str, module: ModuleType, *, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> ModuleType:
     # Intentionally replace target modules to keep stubs deterministic and avoid
     # import-order coupling across suites. Fixtures can pass monkeypatch so
@@ -30,7 +31,7 @@ def _set_module(
 
 
 def stub_custom_components_packages(
-    *, root: Path | None = None, monkeypatch: Any | None = None
+    *, root: Path | None = None, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> None:
     """Stub custom_components packages for local integration imports."""
 
@@ -49,7 +50,7 @@ def stub_custom_components_packages(
 
 
 def stub_config_entry_class(
-    cls: type[Any], *, monkeypatch: Any | None = None
+    cls: type[object], *, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> ModuleType:
     module = ModuleType("homeassistant.config_entries")
     module.ConfigEntry = cls
@@ -58,7 +59,9 @@ def stub_config_entry_class(
 
 
 def stub_exceptions(
-    *, monkeypatch: Any | None = None, **exception_types: type[Exception]
+    *,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    **exception_types: type[Exception],
 ) -> ModuleType:
     module = ModuleType("homeassistant.exceptions")
     for name, exc in exception_types.items():
@@ -70,9 +73,9 @@ def stub_exceptions(
 def stub_update_coordinator_module(
     *,
     update_failed: type[Exception],
-    data_update_coordinator: type[Any],
-    coordinator_entity: type[Any],
-    monkeypatch: Any | None = None,
+    data_update_coordinator: type[object],
+    coordinator_entity: type[object],
+    monkeypatch: pytest.MonkeyPatch | None = None,
 ) -> ModuleType:
     module = ModuleType("homeassistant.helpers.update_coordinator")
     module.UpdateFailed = update_failed
@@ -82,3 +85,22 @@ def stub_update_coordinator_module(
         "homeassistant.helpers.update_coordinator", module, monkeypatch=monkeypatch
     )
     return module
+
+
+def clear_integration_modules(
+    package_name: str = "custom_components.pollenlevels",
+    *,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> None:
+    """Remove cached integration modules so tests import them with local stubs."""
+
+    module_names = [
+        name
+        for name in sys.modules
+        if name == package_name or name.startswith(f"{package_name}.")
+    ]
+    for name in module_names:
+        if monkeypatch is not None:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        else:
+            sys.modules.pop(name, None)

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -30,6 +30,20 @@ def _set_module(
     return force_module(name, module)
 
 
+def stub_homeassistant_package(
+    *,
+    as_package: bool = True,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> ModuleType:
+    """Install a fresh ``homeassistant`` base module for local stubs."""
+
+    module = ModuleType("homeassistant")
+    if as_package:
+        module.__path__ = []
+    _set_module("homeassistant", module, monkeypatch=monkeypatch)
+    return module
+
+
 def stub_custom_components_packages(
     *, root: Path | None = None, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> None:
@@ -96,7 +110,7 @@ def clear_integration_modules(
 
     module_names = [
         name
-        for name in sys.modules
+        for name in list(sys.modules)
         if name == package_name or name.startswith(f"{package_name}.")
     ]
     for name in module_names:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -11,19 +11,20 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from tests._ha_stubs import (
+    stub_config_entry_class,
+    stub_custom_components_packages,
+    stub_exceptions,
+    stub_update_coordinator_module,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 
 @pytest.fixture
 def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
-    custom_components_pkg = types.ModuleType("custom_components")
-    custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-    monkeypatch.setitem(sys.modules, "custom_components", custom_components_pkg)
-
-    pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
-    pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
-    monkeypatch.setitem(sys.modules, "custom_components.pollenlevels", pollenlevels_pkg)
+    stub_custom_components_packages(root=ROOT)
 
     button_mod = types.ModuleType("homeassistant.components.button")
 
@@ -42,15 +43,14 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     entity_mod.EntityCategory = _StubEntityCategory
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity_mod)
 
-    update_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
-
     class _StubCoordinatorEntity:
         def __init__(self, coordinator):
             self.coordinator = coordinator
 
-    update_mod.CoordinatorEntity = _StubCoordinatorEntity
-    monkeypatch.setitem(
-        sys.modules, "homeassistant.helpers.update_coordinator", update_mod
+    stub_update_coordinator_module(
+        update_failed=RuntimeError,
+        data_update_coordinator=object,
+        coordinator_entity=_StubCoordinatorEntity,
     )
 
     core_mod = types.ModuleType("homeassistant.core")
@@ -60,8 +60,6 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
     core_mod.HomeAssistant = _StubHomeAssistant
     monkeypatch.setitem(sys.modules, "homeassistant.core", core_mod)
-
-    exceptions_mod = types.ModuleType("homeassistant.exceptions")
 
     class _StubHomeAssistantError(Exception):
         def __init__(
@@ -79,19 +77,17 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     class _StubConfigEntryNotReady(Exception):
         pass
 
-    exceptions_mod.HomeAssistantError = _StubHomeAssistantError
-    exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
-    monkeypatch.setitem(sys.modules, "homeassistant.exceptions", exceptions_mod)
-
-    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+    exceptions_mod = stub_exceptions(
+        HomeAssistantError=_StubHomeAssistantError,
+        ConfigEntryNotReady=_StubConfigEntryNotReady,
+    )
 
     class _StubConfigEntry:
         @classmethod
         def __class_getitem__(cls, _item):
             return cls
 
-    config_entries_mod.ConfigEntry = _StubConfigEntry
-    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries_mod)
+    stub_config_entry_class(_StubConfigEntry)
 
     return SimpleNamespace(
         exceptions=exceptions_mod,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -103,9 +103,6 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 def button_platform(
     monkeypatch: pytest.MonkeyPatch, stub_ha_modules: SimpleNamespace
 ) -> SimpleNamespace:
-    monkeypatch.delitem(
-        sys.modules, "custom_components.pollenlevels.button", raising=False
-    )
     module = importlib.import_module("custom_components.pollenlevels.button")
     return SimpleNamespace(
         module=module,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -16,6 +16,7 @@ from tests._ha_stubs import (
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
+    stub_homeassistant_package,
     stub_update_coordinator_module,
 )
 
@@ -27,6 +28,7 @@ sys.path.insert(0, str(ROOT))
 def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     clear_integration_modules(monkeypatch=monkeypatch)
     stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
+    stub_homeassistant_package(monkeypatch=monkeypatch)
 
     button_mod = types.ModuleType("homeassistant.components.button")
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(ROOT))
 
 @pytest.fixture
 def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
-    stub_custom_components_packages(root=ROOT)
+    stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
 
     button_mod = types.ModuleType("homeassistant.components.button")
 
@@ -51,6 +51,7 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         update_failed=RuntimeError,
         data_update_coordinator=object,
         coordinator_entity=_StubCoordinatorEntity,
+        monkeypatch=monkeypatch,
     )
 
     core_mod = types.ModuleType("homeassistant.core")
@@ -78,6 +79,7 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         pass
 
     exceptions_mod = stub_exceptions(
+        monkeypatch=monkeypatch,
         HomeAssistantError=_StubHomeAssistantError,
         ConfigEntryNotReady=_StubConfigEntryNotReady,
     )
@@ -87,7 +89,7 @@ def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
         def __class_getitem__(cls, _item):
             return cls
 
-    stub_config_entry_class(_StubConfigEntry)
+    stub_config_entry_class(_StubConfigEntry, monkeypatch=monkeypatch)
 
     return SimpleNamespace(
         exceptions=exceptions_mod,

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from tests._ha_stubs import (
+    clear_integration_modules,
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
@@ -24,6 +25,7 @@ sys.path.insert(0, str(ROOT))
 
 @pytest.fixture
 def stub_ha_modules(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    clear_integration_modules(monkeypatch=monkeypatch)
     stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
 
     button_mod = types.ModuleType("homeassistant.components.button")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -15,6 +15,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 from tests._ha_stubs import (
+    clear_integration_modules,
     force_module,
     stub_custom_components_packages,
     stub_exceptions,
@@ -28,6 +29,7 @@ sys.path.insert(0, str(ROOT))
 # ---------------------------------------------------------------------------
 # Minimal package and dependency stubs so the config flow can be imported.
 # ---------------------------------------------------------------------------
+clear_integration_modules()
 stub_custom_components_packages(root=ROOT)
 
 ha_mod = ModuleType("homeassistant")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -19,6 +19,7 @@ from tests._ha_stubs import (
     force_module,
     stub_custom_components_packages,
     stub_exceptions,
+    stub_homeassistant_package,
     stub_update_coordinator_module,
 )
 
@@ -32,8 +33,7 @@ sys.path.insert(0, str(ROOT))
 clear_integration_modules()
 stub_custom_components_packages(root=ROOT)
 
-ha_mod = ModuleType("homeassistant")
-force_module("homeassistant", ha_mod)
+ha_mod = stub_homeassistant_package()
 
 config_entries_mod = ModuleType("homeassistant.config_entries")
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,37 +14,24 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from tests._ha_stubs import (
+    force_module,
+    stub_custom_components_packages,
+    stub_exceptions,
+    stub_update_coordinator_module,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
-
-
-def _force_module(name: str, module: ModuleType) -> None:
-    """Force a module into sys.modules.
-
-    Tests in this repository are designed to run without Home Assistant installed.
-    In some developer environments, other pytest plugins or pre-imports may have
-    already inserted modules like `custom_components` or `homeassistant`.
-
-    Using `setdefault()` can then silently keep the pre-existing module, which
-    may not match the lightweight stubs expected by these tests.
-    """
-
-    sys.modules[name] = module
 
 
 # ---------------------------------------------------------------------------
 # Minimal package and dependency stubs so the config flow can be imported.
 # ---------------------------------------------------------------------------
-custom_components_pkg = ModuleType("custom_components")
-custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-_force_module("custom_components", custom_components_pkg)
-
-pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
-pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
-_force_module("custom_components.pollenlevels", pollenlevels_pkg)
+stub_custom_components_packages(root=ROOT)
 
 ha_mod = ModuleType("homeassistant")
-_force_module("homeassistant", ha_mod)
+force_module("homeassistant", ha_mod)
 
 config_entries_mod = ModuleType("homeassistant.config_entries")
 
@@ -111,27 +98,24 @@ config_entries_mod.ConfigFlow = _StubConfigFlow
 config_entries_mod.OptionsFlow = _StubOptionsFlow
 config_entries_mod.OptionsFlowWithReload = _StubOptionsFlowWithReload
 config_entries_mod.ConfigEntry = _StubConfigEntry
-_force_module("homeassistant.config_entries", config_entries_mod)
-
-exceptions_mod = ModuleType("homeassistant.exceptions")
+force_module("homeassistant.config_entries", config_entries_mod)
 
 
 class _StubConfigEntryAuthFailed(Exception):
     pass
 
 
-exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
-_force_module("homeassistant.exceptions", exceptions_mod)
+stub_exceptions(ConfigEntryAuthFailed=_StubConfigEntryAuthFailed)
 
 const_mod = ModuleType("homeassistant.const")
 const_mod.CONF_LATITUDE = "latitude"
 const_mod.CONF_LOCATION = "location"
 const_mod.CONF_LONGITUDE = "longitude"
 const_mod.CONF_NAME = "name"
-_force_module("homeassistant.const", const_mod)
+force_module("homeassistant.const", const_mod)
 
 helpers_mod = ModuleType("homeassistant.helpers")
-_force_module("homeassistant.helpers", helpers_mod)
+force_module("homeassistant.helpers", helpers_mod)
 
 config_validation_mod = ModuleType("homeassistant.helpers.config_validation")
 
@@ -163,7 +147,7 @@ def _longitude(value=None):
 config_validation_mod.latitude = _latitude
 config_validation_mod.longitude = _longitude
 config_validation_mod.string = lambda value=None: value
-_force_module("homeassistant.helpers.config_validation", config_validation_mod)
+force_module("homeassistant.helpers.config_validation", config_validation_mod)
 
 aiohttp_client_mod = ModuleType("homeassistant.helpers.aiohttp_client")
 
@@ -205,9 +189,7 @@ class _StubSession:
 
 
 aiohttp_client_mod.async_get_clientsession = lambda hass: _StubSession()
-_force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
-
-update_coordinator_mod = ModuleType("homeassistant.helpers.update_coordinator")
+force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
 
 
 class _StubUpdateFailed(Exception):
@@ -235,10 +217,11 @@ class _StubCoordinatorEntity:
         self.coordinator = coordinator
 
 
-update_coordinator_mod.UpdateFailed = _StubUpdateFailed
-update_coordinator_mod.DataUpdateCoordinator = _StubDataUpdateCoordinator
-update_coordinator_mod.CoordinatorEntity = _StubCoordinatorEntity
-_force_module("homeassistant.helpers.update_coordinator", update_coordinator_mod)
+stub_update_coordinator_module(
+    update_failed=_StubUpdateFailed,
+    data_update_coordinator=_StubDataUpdateCoordinator,
+    coordinator_entity=_StubCoordinatorEntity,
+)
 
 util_mod = ModuleType("homeassistant.util")
 dt_mod = ModuleType("homeassistant.util.dt")
@@ -254,8 +237,8 @@ def _parse_http_date(value: str):
 dt_mod.parse_http_date = _parse_http_date
 dt_mod.utcnow = lambda: datetime.now(UTC)
 util_mod.dt = dt_mod
-_force_module("homeassistant.util", util_mod)
-_force_module("homeassistant.util.dt", dt_mod)
+force_module("homeassistant.util", util_mod)
+force_module("homeassistant.util.dt", dt_mod)
 
 selector_mod = ModuleType("homeassistant.helpers.selector")
 
@@ -338,7 +321,7 @@ selector_mod.SelectSelector = _SelectSelector
 selector_mod.SelectSelectorConfig = _SelectSelectorConfig
 selector_mod.SelectSelectorMode = _SelectSelectorMode
 selector_mod.section = lambda key: key
-_force_module("homeassistant.helpers.selector", selector_mod)
+force_module("homeassistant.helpers.selector", selector_mod)
 
 ha_mod.helpers = helpers_mod
 ha_mod.config_entries = config_entries_mod
@@ -363,7 +346,7 @@ aiohttp_mod.ClientError = _StubClientError
 aiohttp_mod.ClientTimeout = _StubClientTimeout
 aiohttp_mod.ClientSession = _StubClientSession
 aiohttp_mod.ContentTypeError = ValueError
-_force_module("aiohttp", aiohttp_mod)
+force_module("aiohttp", aiohttp_mod)
 
 vol_mod = ModuleType("voluptuous")
 
@@ -387,7 +370,7 @@ vol_mod.All = lambda *args, **kwargs: None
 vol_mod.Coerce = lambda *args, **kwargs: None
 vol_mod.Range = lambda *args, **kwargs: None
 vol_mod.In = lambda *args, **kwargs: None
-_force_module("voluptuous", vol_mod)
+force_module("voluptuous", vol_mod)
 
 from homeassistant.const import (
     CONF_LATITUDE,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from tests._ha_stubs import (
+    clear_integration_modules,
     force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
@@ -68,6 +69,7 @@ class _HomeAssistant:
 core_mod.HomeAssistant = _HomeAssistant
 force_module("homeassistant.core", core_mod)
 
+clear_integration_modules()
 stub_custom_components_packages(root=Path(__file__).resolve().parents[1])
 
 from custom_components.pollenlevels import diagnostics as diag  # noqa: E402

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import datetime as dt
-import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
 
 import pytest
 
-
-def _force_module(name: str, module: ModuleType) -> None:
-    sys.modules[name] = module
-
+from tests._ha_stubs import (
+    force_module,
+    stub_config_entry_class,
+    stub_custom_components_packages,
+)
 
 components_mod = ModuleType("homeassistant.components")
 diagnostics_mod = ModuleType("homeassistant.components.diagnostics")
@@ -34,8 +34,8 @@ def _async_redact_data(data: dict[str, Any], _redact: set[str]) -> dict[str, Any
 
 
 diagnostics_mod.async_redact_data = _async_redact_data
-_force_module("homeassistant.components", components_mod)
-_force_module("homeassistant.components.diagnostics", diagnostics_mod)
+force_module("homeassistant.components", components_mod)
+force_module("homeassistant.components.diagnostics", diagnostics_mod)
 
 config_entries_mod = ModuleType("homeassistant.config_entries")
 
@@ -56,8 +56,7 @@ class _ConfigEntry:
         self.runtime_data = None
 
 
-config_entries_mod.ConfigEntry = _ConfigEntry
-_force_module("homeassistant.config_entries", config_entries_mod)
+stub_config_entry_class(_ConfigEntry)
 
 core_mod = ModuleType("homeassistant.core")
 
@@ -67,19 +66,9 @@ class _HomeAssistant:
 
 
 core_mod.HomeAssistant = _HomeAssistant
-_force_module("homeassistant.core", core_mod)
+force_module("homeassistant.core", core_mod)
 
-custom_components_pkg = ModuleType("custom_components")
-custom_components_pkg.__path__ = [
-    str(Path(__file__).resolve().parents[1] / "custom_components")
-]
-_force_module("custom_components", custom_components_pkg)
-
-pollenlevels_pkg = ModuleType("custom_components.pollenlevels")
-pollenlevels_pkg.__path__ = [
-    str(Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels")
-]
-_force_module("custom_components.pollenlevels", pollenlevels_pkg)
+stub_custom_components_packages(root=Path(__file__).resolve().parents[1])
 
 from custom_components.pollenlevels import diagnostics as diag  # noqa: E402
 from custom_components.pollenlevels.const import (  # noqa: E402

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -38,8 +38,6 @@ diagnostics_mod.async_redact_data = _async_redact_data
 force_module("homeassistant.components", components_mod)
 force_module("homeassistant.components.diagnostics", diagnostics_mod)
 
-config_entries_mod = ModuleType("homeassistant.config_entries")
-
 
 class _ConfigEntry:
     def __init__(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,7 +24,21 @@ sys.path.insert(0, str(ROOT))
 stub_custom_components_packages(root=ROOT)
 
 # Provide the additional stubs required by __init__.
-force_module("homeassistant", types.ModuleType("homeassistant"))
+homeassistant_mod = types.ModuleType("homeassistant")
+homeassistant_mod.__path__ = []
+force_module("homeassistant", homeassistant_mod)
+
+config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+
+class _StubConfigEntry:
+    @classmethod
+    def __class_getitem__(cls, _item):
+        return cls
+
+
+config_entries_mod.ConfigEntry = _StubConfigEntry
+force_module("homeassistant.config_entries", config_entries_mod)
 
 core_mod = sys.modules.get("homeassistant.core") or types.ModuleType(
     "homeassistant.core"
@@ -115,7 +129,8 @@ cv_mod = types.ModuleType("homeassistant.helpers.config_validation")
 cv_mod.config_entry_only_config_schema = lambda _domain: lambda config: config
 force_module("homeassistant.helpers.config_validation", cv_mod)
 
-vol_mod = sys.modules["voluptuous"]
+vol_mod = sys.modules.get("voluptuous") or types.ModuleType("voluptuous")
+force_module("voluptuous", vol_mod)
 if not hasattr(vol_mod, "Schema"):
     vol_mod.Schema = lambda *args, **kwargs: None
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -244,9 +244,7 @@ stub_update_coordinator_module(
     data_update_coordinator=_StubDataUpdateCoordinator,
     coordinator_entity=_StubCoordinatorEntity,
 )
-_BaseDataUpdateCoordinator = sys.modules[
-    "homeassistant.helpers.update_coordinator"
-].DataUpdateCoordinator
+_BaseDataUpdateCoordinator = _StubDataUpdateCoordinator
 
 integration = importlib.import_module(
     "custom_components.pollenlevels.__init__"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -239,11 +239,14 @@ stub_exceptions(
     ConfigEntryNotReady=_StubConfigEntryNotReady,
     ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
 )
-update_coordinator_mod = stub_update_coordinator_module(
+stub_update_coordinator_module(
     update_failed=_StubUpdateFailed,
     data_update_coordinator=_StubDataUpdateCoordinator,
     coordinator_entity=_StubCoordinatorEntity,
 )
+_BaseDataUpdateCoordinator = sys.modules[
+    "homeassistant.helpers.update_coordinator"
+].DataUpdateCoordinator
 
 integration = importlib.import_module(
     "custom_components.pollenlevels.__init__"
@@ -552,7 +555,7 @@ def test_setup_entry_decimal_numeric_options_fallback_to_defaults(
 
     seen: dict[str, int] = {}
 
-    class _StubCoordinator(update_coordinator_mod.DataUpdateCoordinator):
+    class _StubCoordinator(_BaseDataUpdateCoordinator):
         def __init__(self, *args, **kwargs):
             seen["hours"] = kwargs["hours"]
             seen["forecast_days"] = kwargs["forecast_days"]
@@ -597,7 +600,7 @@ def test_setup_entry_success_and_unload(
         async def async_fetch_pollen_data(self, **_kwargs):
             return {"region": {"source": "meta"}, "dailyInfo": []}
 
-    class _StubCoordinator(update_coordinator_mod.DataUpdateCoordinator):
+    class _StubCoordinator(_BaseDataUpdateCoordinator):
         def __init__(self, *args, **kwargs):
             self.api_key = kwargs["api_key"]
             self.lat = kwargs["lat"]
@@ -648,7 +651,7 @@ def test_setup_entry_normalizes_forecast_sensor_mode(
         async def async_fetch_pollen_data(self, **_kwargs):
             return {"region": {"source": "meta"}, "dailyInfo": []}
 
-    class _StubCoordinator(update_coordinator_mod.DataUpdateCoordinator):
+    class _StubCoordinator(_BaseDataUpdateCoordinator):
         def __init__(self, *args, **kwargs):
             self.create_d1 = kwargs["create_d1"]
             self.create_d2 = kwargs["create_d2"]
@@ -692,7 +695,7 @@ def test_setup_entry_disables_d1_when_forecast_days_is_one(
         async def async_fetch_pollen_data(self, **_kwargs):
             return {"region": {"source": "meta"}, "dailyInfo": []}
 
-    class _StubCoordinator(update_coordinator_mod.DataUpdateCoordinator):
+    class _StubCoordinator(_BaseDataUpdateCoordinator):
         def __init__(self, *args, **kwargs):
             self.create_d1 = kwargs["create_d1"]
             self.create_d2 = kwargs["create_d2"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,14 +11,20 @@ from typing import Any
 
 import pytest
 
+from tests._ha_stubs import (
+    force_module,
+    stub_custom_components_packages,
+    stub_exceptions,
+    stub_update_coordinator_module,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-# Import config_flow test module to reuse its Home Assistant stubs.
-import tests.test_config_flow  # noqa: E402,F401  # pylint: disable=unused-import
+stub_custom_components_packages(root=ROOT)
 
 # Provide the additional stubs required by __init__.
-sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+force_module("homeassistant", types.ModuleType("homeassistant"))
 
 core_mod = sys.modules.get("homeassistant.core") or types.ModuleType(
     "homeassistant.core"
@@ -71,7 +77,7 @@ class _StubSensorStateClass:  # pragma: no cover - structure only
 sensor_mod.SensorEntity = _StubSensorEntity
 sensor_mod.SensorDeviceClass = _StubSensorDeviceClass
 sensor_mod.SensorStateClass = _StubSensorStateClass
-sys.modules.setdefault("homeassistant.components.sensor", sensor_mod)
+force_module("homeassistant.components.sensor", sensor_mod)
 
 const_mod = sys.modules.get("homeassistant.const") or types.ModuleType(
     "homeassistant.const"
@@ -81,7 +87,7 @@ sys.modules["homeassistant.const"] = const_mod
 
 aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
 aiohttp_client_mod.async_get_clientsession = lambda _hass: None
-sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
+force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
 
 aiohttp_mod = sys.modules.get("aiohttp") or types.ModuleType("aiohttp")
 
@@ -105,8 +111,9 @@ aiohttp_mod.ClientTimeout = _StubClientTimeout
 aiohttp_mod.ContentTypeError = ValueError
 sys.modules["aiohttp"] = aiohttp_mod
 
-cv_mod = sys.modules["homeassistant.helpers.config_validation"]
+cv_mod = types.ModuleType("homeassistant.helpers.config_validation")
 cv_mod.config_entry_only_config_schema = lambda _domain: lambda config: config
+force_module("homeassistant.helpers.config_validation", cv_mod)
 
 vol_mod = sys.modules["voluptuous"]
 if not hasattr(vol_mod, "Schema"):
@@ -131,7 +138,7 @@ def _stub_async_get(_hass):  # pragma: no cover - structure only
 
 entity_registry_mod.async_get = _stub_async_get
 entity_registry_mod.async_entries_for_config_entry = lambda *args, **kwargs: []
-sys.modules.setdefault("homeassistant.helpers.entity_registry", entity_registry_mod)
+force_module("homeassistant.helpers.entity_registry", entity_registry_mod)
 
 entity_mod = types.ModuleType("homeassistant.helpers.entity")
 
@@ -141,7 +148,7 @@ class _StubEntityCategory:
 
 
 entity_mod.EntityCategory = _StubEntityCategory
-sys.modules.setdefault("homeassistant.helpers.entity", entity_mod)
+force_module("homeassistant.helpers.entity", entity_mod)
 
 dt_mod = types.ModuleType("homeassistant.util.dt")
 
@@ -177,29 +184,19 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
 
 dt_mod.parse_http_date = _stub_parse_http_date
-sys.modules.setdefault("homeassistant.util.dt", dt_mod)
+force_module("homeassistant.util.dt", dt_mod)
 
 util_mod = types.ModuleType("homeassistant.util")
 util_mod.dt = dt_mod
-sys.modules.setdefault("homeassistant.util", util_mod)
+force_module("homeassistant.util", util_mod)
 
-exceptions_mod = sys.modules.setdefault(
-    "homeassistant.exceptions", types.ModuleType("homeassistant.exceptions")
-)
-if not hasattr(exceptions_mod, "ConfigEntryNotReady"):
 
-    class _StubConfigEntryNotReady(Exception):
-        pass
+class _StubConfigEntryNotReady(Exception):
+    pass
 
-    exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
-if not hasattr(exceptions_mod, "ConfigEntryAuthFailed"):
 
-    class _StubConfigEntryAuthFailed(Exception):
-        pass
-
-    exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
-
-update_coordinator_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
+class _StubConfigEntryAuthFailed(Exception):
+    pass
 
 
 class _StubUpdateFailed(Exception):
@@ -231,11 +228,14 @@ class _StubDataUpdateCoordinator:
         return asyncio.create_task(self.async_refresh())
 
 
-update_coordinator_mod.DataUpdateCoordinator = _StubDataUpdateCoordinator
-update_coordinator_mod.UpdateFailed = _StubUpdateFailed
-update_coordinator_mod.CoordinatorEntity = _StubCoordinatorEntity
-sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator", update_coordinator_mod
+stub_exceptions(
+    ConfigEntryNotReady=_StubConfigEntryNotReady,
+    ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+)
+update_coordinator_mod = stub_update_coordinator_module(
+    update_failed=_StubUpdateFailed,
+    data_update_coordinator=_StubDataUpdateCoordinator,
+    coordinator_entity=_StubCoordinatorEntity,
 )
 
 integration = importlib.import_module(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ from tests._ha_stubs import (
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
+    stub_homeassistant_package,
     stub_update_coordinator_module,
 )
 
@@ -27,9 +28,7 @@ clear_integration_modules()
 stub_custom_components_packages(root=ROOT)
 
 # Provide the additional stubs required by __init__.
-homeassistant_mod = types.ModuleType("homeassistant")
-homeassistant_mod.__path__ = []
-force_module("homeassistant", homeassistant_mod)
+homeassistant_mod = stub_homeassistant_package()
 
 
 class _StubConfigEntry:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,9 +38,7 @@ class _StubConfigEntry:
 
 stub_config_entry_class(_StubConfigEntry)
 
-core_mod = sys.modules.get("homeassistant.core") or types.ModuleType(
-    "homeassistant.core"
-)
+core_mod = types.ModuleType("homeassistant.core")
 
 
 class _StubHomeAssistant:  # pragma: no cover - structure only
@@ -53,12 +51,10 @@ class _StubServiceCall:  # pragma: no cover - structure only
 
 core_mod.HomeAssistant = _StubHomeAssistant
 core_mod.ServiceCall = _StubServiceCall
-sys.modules["homeassistant.core"] = core_mod
+force_module("homeassistant.core", core_mod)
 
-ha_components_mod = sys.modules.get("homeassistant.components") or types.ModuleType(
-    "homeassistant.components"
-)
-sys.modules["homeassistant.components"] = ha_components_mod
+ha_components_mod = types.ModuleType("homeassistant.components")
+force_module("homeassistant.components", ha_components_mod)
 
 sensor_mod = types.ModuleType("homeassistant.components.sensor")
 
@@ -91,17 +87,15 @@ sensor_mod.SensorDeviceClass = _StubSensorDeviceClass
 sensor_mod.SensorStateClass = _StubSensorStateClass
 force_module("homeassistant.components.sensor", sensor_mod)
 
-const_mod = sys.modules.get("homeassistant.const") or types.ModuleType(
-    "homeassistant.const"
-)
+const_mod = types.ModuleType("homeassistant.const")
 const_mod.ATTR_ATTRIBUTION = "Attribution"
-sys.modules["homeassistant.const"] = const_mod
+force_module("homeassistant.const", const_mod)
 
 aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
 aiohttp_client_mod.async_get_clientsession = lambda _hass: None
 force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
 
-aiohttp_mod = sys.modules.get("aiohttp") or types.ModuleType("aiohttp")
+aiohttp_mod = types.ModuleType("aiohttp")
 
 
 class _StubClientError(Exception):
@@ -121,21 +115,19 @@ aiohttp_mod.ClientError = _StubClientError
 aiohttp_mod.ClientSession = _StubClientSession
 aiohttp_mod.ClientTimeout = _StubClientTimeout
 aiohttp_mod.ContentTypeError = ValueError
-sys.modules["aiohttp"] = aiohttp_mod
+force_module("aiohttp", aiohttp_mod)
 
 cv_mod = types.ModuleType("homeassistant.helpers.config_validation")
 cv_mod.config_entry_only_config_schema = lambda _domain: lambda config: config
 force_module("homeassistant.helpers.config_validation", cv_mod)
 
-vol_mod = sys.modules.get("voluptuous") or types.ModuleType("voluptuous")
+vol_mod = types.ModuleType("voluptuous")
 force_module("voluptuous", vol_mod)
 if not hasattr(vol_mod, "Schema"):
     vol_mod.Schema = lambda *args, **kwargs: None
 
-helpers_mod = sys.modules.get("homeassistant.helpers") or types.ModuleType(
-    "homeassistant.helpers"
-)
-sys.modules["homeassistant.helpers"] = helpers_mod
+helpers_mod = types.ModuleType("homeassistant.helpers")
+force_module("homeassistant.helpers", helpers_mod)
 
 entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,7 @@ import pytest
 
 from tests._ha_stubs import (
     force_module,
+    stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
     stub_update_coordinator_module,
@@ -28,8 +29,6 @@ homeassistant_mod = types.ModuleType("homeassistant")
 homeassistant_mod.__path__ = []
 force_module("homeassistant", homeassistant_mod)
 
-config_entries_mod = types.ModuleType("homeassistant.config_entries")
-
 
 class _StubConfigEntry:
     @classmethod
@@ -37,8 +36,7 @@ class _StubConfigEntry:
         return cls
 
 
-config_entries_mod.ConfigEntry = _StubConfigEntry
-force_module("homeassistant.config_entries", config_entries_mod)
+stub_config_entry_class(_StubConfigEntry)
 
 core_mod = sys.modules.get("homeassistant.core") or types.ModuleType(
     "homeassistant.core"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 
 from tests._ha_stubs import (
+    clear_integration_modules,
     force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
@@ -22,6 +23,7 @@ from tests._ha_stubs import (
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+clear_integration_modules()
 stub_custom_components_packages(root=ROOT)
 
 # Provide the additional stubs required by __init__.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,17 +12,18 @@ from typing import Any, NamedTuple
 
 import pytest
 
+from tests._ha_stubs import (
+    stub_config_entry_class,
+    stub_custom_components_packages,
+    stub_exceptions,
+    stub_update_coordinator_module,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 # Ensure the custom_components namespace exists for relative imports.
-custom_components_pkg = types.ModuleType("custom_components")
-custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-sys.modules.setdefault("custom_components", custom_components_pkg)
-
-pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
-pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
-sys.modules.setdefault("custom_components.pollenlevels", pollenlevels_pkg)
+stub_custom_components_packages(root=ROOT)
 
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs to import the integration module under test.
@@ -75,8 +76,6 @@ const_mod.CONF_LOCATION = "location"
 const_mod.CONF_LATITUDE = "latitude"
 const_mod.CONF_LONGITUDE = "longitude"
 
-exceptions_mod = types.ModuleType("homeassistant.exceptions")
-
 
 class _StubConfigEntryNotReady(Exception):
     pass
@@ -86,11 +85,10 @@ class _StubConfigEntryAuthFailed(Exception):
     pass
 
 
-exceptions_mod.ConfigEntryNotReady = _StubConfigEntryNotReady
-exceptions_mod.ConfigEntryAuthFailed = _StubConfigEntryAuthFailed
-sys.modules.setdefault("homeassistant.exceptions", exceptions_mod)
-
-config_entries_mod = types.ModuleType("homeassistant.config_entries")
+stub_exceptions(
+    ConfigEntryNotReady=_StubConfigEntryNotReady,
+    ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+)
 
 
 class _StubConfigEntry:
@@ -99,8 +97,7 @@ class _StubConfigEntry:
         return cls
 
 
-config_entries_mod.ConfigEntry = _StubConfigEntry
-sys.modules.setdefault("homeassistant.config_entries", config_entries_mod)
+stub_config_entry_class(_StubConfigEntry)
 
 helpers_mod = types.ModuleType("homeassistant.helpers")
 sys.modules.setdefault("homeassistant.helpers", helpers_mod)
@@ -144,8 +141,6 @@ def _add_entities_callback_stub(entities, update_before_add: bool = False) -> No
 
 entity_platform_mod.AddEntitiesCallback = _add_entities_callback_stub  # type: ignore[assignment]
 sys.modules.setdefault("homeassistant.helpers.entity_platform", entity_platform_mod)
-
-update_coordinator_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
 
 
 class _StubUpdateFailed(Exception):
@@ -191,12 +186,12 @@ class _StubCoordinatorEntity:
         return self._attr_device_info
 
 
-update_coordinator_mod.DataUpdateCoordinator = _StubDataUpdateCoordinator
-update_coordinator_mod.UpdateFailed = _StubUpdateFailed
-update_coordinator_mod.CoordinatorEntity = _StubCoordinatorEntity
-sys.modules.setdefault(
-    "homeassistant.helpers.update_coordinator", update_coordinator_mod
-)
+if "homeassistant.helpers.update_coordinator" not in sys.modules:
+    stub_update_coordinator_module(
+        update_failed=_StubUpdateFailed,
+        data_update_coordinator=_StubDataUpdateCoordinator,
+        coordinator_entity=_StubCoordinatorEntity,
+    )
 
 dt_mod = types.ModuleType("homeassistant.util.dt")
 
@@ -278,12 +273,19 @@ def _load_module(module_name: str, relative_path: str):
     return module
 
 
+for _mod in (
+    "custom_components.pollenlevels.client",
+    "custom_components.pollenlevels.coordinator",
+    "custom_components.pollenlevels.sensor",
+):
+    sys.modules.pop(_mod, None)
+
 const = _load_module("custom_components.pollenlevels.const", "const.py")
 coordinator_mod = _load_module(
     "custom_components.pollenlevels.coordinator", "coordinator.py"
 )
 sensor = _load_module("custom_components.pollenlevels.sensor", "sensor.py")
-client_mod = importlib.import_module("custom_components.pollenlevels.client")
+client_mod = _load_module("custom_components.pollenlevels.client", "client.py")
 
 
 class DummyHass:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -18,6 +18,7 @@ from tests._ha_stubs import (
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
+    stub_homeassistant_package,
     stub_update_coordinator_module,
 )
 
@@ -31,8 +32,7 @@ stub_custom_components_packages(root=ROOT)
 # ---------------------------------------------------------------------------
 # Minimal Home Assistant stubs to import the integration module under test.
 # ---------------------------------------------------------------------------
-ha = types.ModuleType("homeassistant")
-force_module("homeassistant", ha)
+ha = stub_homeassistant_package()
 
 ha.components = types.ModuleType("homeassistant.components")
 force_module("homeassistant.components", ha.components)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from typing import Any, NamedTuple
 import pytest
 
 from tests._ha_stubs import (
+    force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
@@ -29,10 +30,10 @@ stub_custom_components_packages(root=ROOT)
 # Minimal Home Assistant stubs to import the integration module under test.
 # ---------------------------------------------------------------------------
 ha = types.ModuleType("homeassistant")
-sys.modules.setdefault("homeassistant", ha)
+force_module("homeassistant", ha)
 
 ha.components = types.ModuleType("homeassistant.components")
-sys.modules.setdefault("homeassistant.components", ha.components)
+force_module("homeassistant.components", ha.components)
 
 sensor_mod = types.ModuleType("homeassistant.components.sensor")
 
@@ -63,7 +64,7 @@ class _StubSensorStateClass:
 sensor_mod.SensorDeviceClass = _StubSensorDeviceClass
 sensor_mod.SensorEntity = _StubSensorEntity
 sensor_mod.SensorStateClass = _StubSensorStateClass
-sys.modules.setdefault("homeassistant.components.sensor", sensor_mod)
+force_module("homeassistant.components.sensor", sensor_mod)
 
 const_mod = sys.modules.get("homeassistant.const")
 if const_mod is None:
@@ -100,7 +101,7 @@ class _StubConfigEntry:
 stub_config_entry_class(_StubConfigEntry)
 
 helpers_mod = types.ModuleType("homeassistant.helpers")
-sys.modules.setdefault("homeassistant.helpers", helpers_mod)
+force_module("homeassistant.helpers", helpers_mod)
 
 entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
 
@@ -116,11 +117,11 @@ def _stub_async_get(_hass):  # pragma: no cover - not exercised in tests
 
 entity_registry_mod.async_get = _stub_async_get
 entity_registry_mod.async_entries_for_config_entry = lambda *args, **kwargs: []
-sys.modules.setdefault("homeassistant.helpers.entity_registry", entity_registry_mod)
+force_module("homeassistant.helpers.entity_registry", entity_registry_mod)
 
 aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
 aiohttp_client_mod.async_get_clientsession = lambda hass: None
-sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
+force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
 
 entity_mod = types.ModuleType("homeassistant.helpers.entity")
 
@@ -130,7 +131,7 @@ class _StubEntityCategory:
 
 
 entity_mod.EntityCategory = _StubEntityCategory
-sys.modules.setdefault("homeassistant.helpers.entity", entity_mod)
+force_module("homeassistant.helpers.entity", entity_mod)
 
 entity_platform_mod = types.ModuleType("homeassistant.helpers.entity_platform")
 
@@ -140,7 +141,7 @@ def _add_entities_callback_stub(entities, update_before_add: bool = False) -> No
 
 
 entity_platform_mod.AddEntitiesCallback = _add_entities_callback_stub  # type: ignore[assignment]
-sys.modules.setdefault("homeassistant.helpers.entity_platform", entity_platform_mod)
+force_module("homeassistant.helpers.entity_platform", entity_platform_mod)
 
 
 class _StubUpdateFailed(Exception):
@@ -186,12 +187,11 @@ class _StubCoordinatorEntity:
         return self._attr_device_info
 
 
-if "homeassistant.helpers.update_coordinator" not in sys.modules:
-    stub_update_coordinator_module(
-        update_failed=_StubUpdateFailed,
-        data_update_coordinator=_StubDataUpdateCoordinator,
-        coordinator_entity=_StubCoordinatorEntity,
-    )
+stub_update_coordinator_module(
+    update_failed=_StubUpdateFailed,
+    data_update_coordinator=_StubDataUpdateCoordinator,
+    coordinator_entity=_StubCoordinatorEntity,
+)
 
 dt_mod = types.ModuleType("homeassistant.util.dt")
 
@@ -229,11 +229,11 @@ def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
 
 
 dt_mod.parse_http_date = _stub_parse_http_date
-sys.modules.setdefault("homeassistant.util.dt", dt_mod)
+force_module("homeassistant.util.dt", dt_mod)
 
 util_mod = types.ModuleType("homeassistant.util")
 util_mod.dt = dt_mod
-sys.modules.setdefault("homeassistant.util", util_mod)
+force_module("homeassistant.util", util_mod)
 
 aiohttp_existing = sys.modules.get("aiohttp")
 aiohttp_mod = aiohttp_existing or types.ModuleType("aiohttp")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from typing import Any, NamedTuple
 import pytest
 
 from tests._ha_stubs import (
+    clear_integration_modules,
     force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
@@ -24,6 +25,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 # Ensure the custom_components namespace exists for relative imports.
+clear_integration_modules()
 stub_custom_components_packages(root=ROOT)
 
 # ---------------------------------------------------------------------------
@@ -266,14 +268,6 @@ def _load_module(module_name: str, relative_path: str):
     sys.modules[module_name] = module
     return module
 
-
-for _mod in (
-    "custom_components.pollenlevels.const",
-    "custom_components.pollenlevels.client",
-    "custom_components.pollenlevels.coordinator",
-    "custom_components.pollenlevels.sensor",
-):
-    sys.modules.pop(_mod, None)
 
 const = _load_module("custom_components.pollenlevels.const", "const.py")
 client_mod = _load_module("custom_components.pollenlevels.client", "client.py")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -66,10 +66,8 @@ sensor_mod.SensorEntity = _StubSensorEntity
 sensor_mod.SensorStateClass = _StubSensorStateClass
 force_module("homeassistant.components.sensor", sensor_mod)
 
-const_mod = sys.modules.get("homeassistant.const")
-if const_mod is None:
-    const_mod = types.ModuleType("homeassistant.const")
-    sys.modules["homeassistant.const"] = const_mod
+const_mod = types.ModuleType("homeassistant.const")
+force_module("homeassistant.const", const_mod)
 
 const_mod.ATTR_ATTRIBUTION = "Attribution"
 const_mod.CONF_NAME = "name"
@@ -235,8 +233,7 @@ util_mod = types.ModuleType("homeassistant.util")
 util_mod.dt = dt_mod
 force_module("homeassistant.util", util_mod)
 
-aiohttp_existing = sys.modules.get("aiohttp")
-aiohttp_mod = aiohttp_existing or types.ModuleType("aiohttp")
+aiohttp_mod = types.ModuleType("aiohttp")
 
 
 class _StubClientError(Exception):
@@ -252,14 +249,11 @@ class _StubClientTimeout:
         self.total = total
 
 
-if not hasattr(aiohttp_mod, "ClientError"):
-    aiohttp_mod.ClientError = _StubClientError
-if not hasattr(aiohttp_mod, "ClientSession"):
-    aiohttp_mod.ClientSession = _StubClientSession
-if not hasattr(aiohttp_mod, "ClientTimeout"):
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
-if aiohttp_existing is None:
-    sys.modules["aiohttp"] = aiohttp_mod
+aiohttp_mod.ClientError = _StubClientError
+aiohttp_mod.ClientSession = _StubClientSession
+aiohttp_mod.ClientTimeout = _StubClientTimeout
+aiohttp_mod.ContentTypeError = ValueError
+force_module("aiohttp", aiohttp_mod)
 
 
 def _load_module(module_name: str, relative_path: str):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -274,6 +274,7 @@ def _load_module(module_name: str, relative_path: str):
 
 
 for _mod in (
+    "custom_components.pollenlevels.const",
     "custom_components.pollenlevels.client",
     "custom_components.pollenlevels.coordinator",
     "custom_components.pollenlevels.sensor",
@@ -281,11 +282,11 @@ for _mod in (
     sys.modules.pop(_mod, None)
 
 const = _load_module("custom_components.pollenlevels.const", "const.py")
+client_mod = _load_module("custom_components.pollenlevels.client", "client.py")
 coordinator_mod = _load_module(
     "custom_components.pollenlevels.coordinator", "coordinator.py"
 )
 sensor = _load_module("custom_components.pollenlevels.sensor", "sensor.py")
-client_mod = _load_module("custom_components.pollenlevels.client", "client.py")
 
 
 class DummyHass:


### PR DESCRIPTION
### Motivation

- Reduce duplicated lightweight Home Assistant and `custom_components` stubbing across the test suite.
- Avoid import-order coupling while preserving per-suite isolation and the existing async test style.
- Keep tests lightweight and independent of a real Home Assistant installation by consolidating repeated stub helpers.

### Description

- Added `tests/_ha_stubs.py` with shared helpers for lightweight test stubbing:
  - `force_module`
  - `stub_custom_components_packages`
  - `stub_config_entry_class`
  - `stub_exceptions`
  - `stub_update_coordinator_module`
  - `clear_integration_modules`
- Added `clear_integration_modules()` to remove cached `custom_components.pollenlevels` modules before suite-specific stubs are installed and integration modules are re-imported.
- Refactored `tests/test_button.py`, `tests/test_sensor.py`, `tests/test_config_flow.py`, `tests/test_init.py`, and `tests/test_diagnostics.py` to use the shared helpers where appropriate.
- Kept per-file composition of only the stubs needed by each suite.
- Preserved deterministic stub replacement instead of additive stubbing to avoid cross-suite leakage from previous `sys.modules` state.
- Removed the cross-test import dependency where `tests/test_init.py` previously imported `tests.test_config_flow` solely to reuse its stubs.
- Kept runtime code unchanged.

### Out of scope

- Runtime changes.
- Sensor, button, config flow, init, diagnostics, coordinator, or client behavior changes.
- Test assertion changes unrelated to stub setup.
- Full migration of all module-level test stubs to fixtures.
- README, CHANGELOG, manifest, pyproject version, or release changes.

### Testing

- [x] `python -m compileall -q custom_components tests`
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest -q`
- [x] `pytest -q tests/test_button.py`
- [x] `pytest -q tests/test_sensor.py`
- [x] `pytest -q tests/test_config_flow.py`
- [x] `pytest -q tests/test_init.py`
- [x] `pytest -q tests/test_diagnostics.py`
- [x] GitHub Actions: Lint
- [x] GitHub Actions: tests
- [x] GitHub Actions: hassfest
- [x] GitHub Actions: HACS validation