### PR TITLE
chore: prepare v2.3.0b1 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [2.3.0b1] - 2026-05-23
+### Added
+- Added a Home Assistant button platform with an "Update now" button entity for
+  each configured Pollen Levels location.
+- Added the button platform to integration setup so update buttons are loaded
+  alongside sensor entities.
+
+### Changed
+- Isolated button platform tests with pytest fixtures and monkeypatch-based
+  Home Assistant stubs.
+- Centralized shared lightweight Home Assistant test stubs to reduce
+  import-order coupling across platform and setup tests.
+- Added deterministic integration module cleanup in tests so suites re-import
+  Pollen Levels modules with their own local stubs.
+
 ## [2.2.2] - 2026-05-20
 ### Changed
 - Aligned re-authentication and reconfiguration coordinate placeholders with

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.2.2"
+    "version": "2.3.0b1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.2.2"
+version = "2.3.0b1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Prepare the repository metadata and changelog for the v2.3.0b1 beta release following the merged button platform and test-stub isolation/centralization work. 
- Ensure packaging metadata and release notes reflect the new beta while keeping runtime, tests, translations, and workflows unchanged.

### Description
- Bumped the integration version in `custom_components/pollenlevels/manifest.json` from `2.2.2` to `2.3.0b1`.
- Bumped the project version in `pyproject.toml` from `2.2.2` to `2.3.0b1`.
- Prepended a new top `CHANGELOG.md` entry `## [2.3.0b1] - 2026-05-23` with the requested `Added` and `Changed` notes describing the button platform and test isolation work.

### Testing
- Ran `ruff check --fix --select I .` and `ruff check .`, both completed successfully.
- Ran `black --check .` and Python compile checks via `python -m compileall -q custom_components tests`, both passed.
- Ran `pytest -q`, which passed (299 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a00ba8908324949e9685f3e9982f)