### PR TITLE
Promote v2.3.0b1 to stable v2.3.0 and document per-location Update button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## [2.3.0] - 2026-05-26
+### Added
+- Added the per-location "Update now" button entity to the stable release,
+  promoted from v2.3.0b1 after validation in a real Home Assistant instance.
+
 ### Changed
-- Promoted the validated v2.3.0b1 beta to the stable v2.3.0 release.
+- Documented the two manual refresh options in README and FAQ: the
+  per-location "Update now" button and the global
+  `pollenlevels.force_update` service.
+- No additional runtime changes were made after v2.3.0b1.
 
 ## [2.3.0b1] - 2026-05-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.3.0] - 2026-05-26
+### Changed
+- Promoted the validated v2.3.0b1 beta to the stable v2.3.0 release.
+
 ## [2.3.0b1] - 2026-05-23
 ### Added
 - Added a Home Assistant button platform with an "Update now" button entity for

--- a/FAQ.md
+++ b/FAQ.md
@@ -19,8 +19,10 @@ No. By default the integration fetches every **6 hours** (~**4 requests/day**), 
 ---
 
 ## 3. Can I manually refresh the data?
-Yes. Call the `pollenlevels.force_update` service from **Developer Tools → Services** in Home Assistant.  
-This fetches new data immediately and resets the refresh timer.
+Yes. You can use either method:
+- Press the per-location **Update now** button entity created by the integration to refresh one configured location.
+- Call the `pollenlevels.force_update` service from **Developer Tools → Services** to refresh all configured locations.
+Both methods request an immediate coordinator refresh. The normal scheduled polling interval remains managed by Home Assistant's DataUpdateCoordinator.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
   - **Plants** (Oak, Pine, Birch, etc.)
   - **Pollen Info** (Region / Date metadata)  
 - **Configurable updates** — Change update interval, language, forecast days, and per-day sensors without reinstalling.  
-- **Manual refresh** — Call `pollenlevels.force_update` to trigger an immediate update and reset the timer.
+- **Manual refresh** — Use the per-location **Update now** button entity to refresh a single configured location, or call the global `pollenlevels.force_update` service to refresh all configured locations.
 - **Last Updated sensor** — Shows timestamp of last successful update.
 - **Rich attributes** — Includes `inSeason`, index `description`, health `advice`,
   `color_hex`, `color_rgb`, and plant details.

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "2.3.0b1"
+    "version": "2.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "2.3.0b1"
+version = "2.3.0"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
### Motivation
- Promote the validated beta `2.3.0b1` to the stable `2.3.0` release and synchronize package metadata. 
- Clarify and document the new per-location "Update now" button as an alternative to the global refresh service. 
- Keep release notes and packaging consistent with the published stable version.

### Description
- Added a `## [2.3.0] - 2026-05-26` section to `CHANGELOG.md` and noted the promotion of the validated beta to stable. 
- Bumped the integration version from `2.3.0b1` to `2.3.0` in `custom_components/pollenlevels/manifest.json` and `pyproject.toml`. 
- Updated `README.md` and `FAQ.md` to document the per-location **Update now** button and to explain both the per-location button and the global `pollenlevels.force_update` service as manual refresh options.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b55904c48324a0a74b5a6c762d2a)