### PR TITLE
Add regression tests for `pollenlevels.force_update` and improve secret-safe logging

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -41,7 +41,7 @@ from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .sensor import ForecastSensorMode
 from .util import (
     normalize_sensor_mode,
-    redact_api_key,
+    redact_sensitive_values,
     safe_parse_int,
     validate_location_pair,
 )
@@ -158,7 +158,12 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
                 continue
             if isinstance(result, Exception):
                 api_key = (entry.data or {}).get(CONF_API_KEY)
-                safe_message = redact_api_key(result, api_key)
+                safe_message = redact_sensitive_values(
+                    result,
+                    api_key=api_key,
+                    latitude=(entry.data or {}).get(CONF_LATITUDE),
+                    longitude=(entry.data or {}).get(CONF_LONGITUDE),
+                )
                 _LOGGER.warning(
                     "Manual refresh failed for entry %s (%s): %s",
                     entry.entry_id,

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -57,7 +57,7 @@ _LOCATION_PARAM_RE = re.compile(
     r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
 )
 _URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)https?://\S+")
-_PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)(.+)$", re.DOTALL)
+_PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)([^\r\n]*)")
 
 
 def _stringify_for_redaction(value: object) -> str:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -52,11 +52,15 @@ async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
 
 
 _REDACTION_PLACEHOLDER = "***"
-_KEY_PARAM_RE = re.compile(r"(?i)(^|[?&\s])(key(?:=|%3d))([^&\s\"']+)")
+_KEY_PARAM_RE = re.compile(
+    r"(?i)(^|[?&\s])(key(?:=|%3d))(?:\"([^\"]*)\"|'([^']*)'|([^&\s\"']+))"
+)
 _LOCATION_PARAM_RE = re.compile(
     r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
 )
-_URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)([\"']?)https?://[^\s\"']+([\"']?)")
+_URL_ASSIGN_RE = re.compile(
+    r"(?i)(url\s*=\s*)(?:\"https?://([^\"]*)\"|'https?://([^']*)'|(https?://[^\s\"']+))"
+)
 _PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)([^\r\n]*)")
 
 
@@ -110,7 +114,15 @@ def redact_sensitive_values(
         s = s.replace(api_key, _REDACTION_PLACEHOLDER)
 
     s = _KEY_PARAM_RE.sub(
-        lambda match: (f"{match.group(1)}{match.group(2)}{_REDACTION_PLACEHOLDER}"),
+        lambda match: (
+            f'{match.group(1)}{match.group(2)}"{_REDACTION_PLACEHOLDER}"'
+            if match.group(3) is not None
+            else (
+                f"{match.group(1)}{match.group(2)}'{_REDACTION_PLACEHOLDER}'"
+                if match.group(4) is not None
+                else f"{match.group(1)}{match.group(2)}{_REDACTION_PLACEHOLDER}"
+            )
+        ),
         s,
     )
     s = _LOCATION_PARAM_RE.sub(
@@ -119,7 +131,16 @@ def redact_sensitive_values(
     )
 
     s = _URL_ASSIGN_RE.sub(
-        lambda match: f"{match.group(1)}{match.group(2)}***{match.group(3)}", s
+        lambda match: (
+            f'{match.group(1)}"{_REDACTION_PLACEHOLDER}"'
+            if match.group(2) is not None
+            else (
+                f"{match.group(1)}'{_REDACTION_PLACEHOLDER}'"
+                if match.group(3) is not None
+                else f"{match.group(1)}{_REDACTION_PLACEHOLDER}"
+            )
+        ),
+        s,
     )
     s = _PAYLOAD_RE.sub(r"\1***", s)
 

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -57,7 +57,7 @@ _LOCATION_PARAM_RE = re.compile(
     r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
 )
 _URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)https?://\S+")
-_PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)(.+)$")
+_PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)(.+)$", re.DOTALL)
 
 
 def _stringify_for_redaction(value: object) -> str:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -56,6 +56,8 @@ _KEY_PARAM_RE = re.compile(r"(?i)(^|[?&\s])(key(?:=|%3d))([^&\s]+)")
 _LOCATION_PARAM_RE = re.compile(
     r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
 )
+_URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)https?://\S+")
+_PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)(.+)$")
 
 
 def _stringify_for_redaction(value: object) -> str:
@@ -115,6 +117,9 @@ def redact_sensitive_values(
         lambda match: f"{match.group(1)}{_REDACTION_PLACEHOLDER}",
         s,
     )
+
+    s = _URL_ASSIGN_RE.sub(r"\1***", s)
+    s = _PAYLOAD_RE.sub(r"\1***", s)
 
     coordinates = sorted(
         _coordinate_values(latitude) | _coordinate_values(longitude),

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -52,11 +52,11 @@ async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
 
 
 _REDACTION_PLACEHOLDER = "***"
-_KEY_PARAM_RE = re.compile(r"(?i)(^|[?&\s])(key(?:=|%3d))([^&\s]+)")
+_KEY_PARAM_RE = re.compile(r"(?i)(^|[?&\s])(key(?:=|%3d))([^&\s\"']+)")
 _LOCATION_PARAM_RE = re.compile(
     r"(?i)(location\.(?:latitude|longitude)(?:=|%3d))(-?\d+(?:\.\d+)?)"
 )
-_URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)https?://\S+")
+_URL_ASSIGN_RE = re.compile(r"(?i)(url\s*=\s*)([\"']?)https?://[^\s\"']+([\"']?)")
 _PAYLOAD_RE = re.compile(r"(?i)(payload\s*=\s*)([^\r\n]*)")
 
 
@@ -118,7 +118,9 @@ def redact_sensitive_values(
         s,
     )
 
-    s = _URL_ASSIGN_RE.sub(r"\1***", s)
+    s = _URL_ASSIGN_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}***{match.group(3)}", s
+    )
     s = _PAYLOAD_RE.sub(r"\1***", s)
 
     coordinates = sorted(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -858,6 +858,10 @@ def test_force_update_logs_do_not_expose_secrets(caplog) -> None:
     assert "payload=line1" not in text
     assert "location.latitude=12.345678" not in text
     assert "location.longitude=-98.765432" not in text
+    assert "payload=***" in text
+    assert "token=***" in text
+    assert "location.latitude=***" in text
+    assert "location.longitude=***" in text
     assert "Manual refresh failed for entry entry-secrets (RuntimeError):" in text
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -723,12 +723,6 @@ def test_force_update_service_is_registered_with_empty_schema(
 ) -> None:
     """async_setup should register force_update with an empty schema."""
 
-    hass = _FakeHass()
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-
-    key = (integration.DOMAIN, "force_update")
-    assert key in hass.services.registered
     marker = object()
 
     def _schema(value):
@@ -740,6 +734,8 @@ def test_force_update_service_is_registered_with_empty_schema(
     hass = _FakeHass()
     assert asyncio.run(integration.async_setup(hass, {})) is True
 
+    key = (integration.DOMAIN, "force_update")
+    assert key in hass.services.registered
     assert hass.services.schemas[key] is marker
 
 
@@ -807,7 +803,7 @@ def test_force_update_continues_after_single_coordinator_failure() -> None:
     assert good_entry.runtime_data.coordinator.calls == 1
 
 
-def test_force_update_handles_cancelled_error() -> None:
+def test_force_update_handles_cancelled_error(caplog) -> None:
     """Cancellation results are handled gracefully and do not fail the service."""
 
     class _CancelledCoordinator:
@@ -820,7 +816,10 @@ def test_force_update_handles_cancelled_error() -> None:
     hass = _FakeHass(entries=[entry])
 
     assert asyncio.run(integration.async_setup(hass, {})) is True
-    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+    with caplog.at_level("DEBUG"):
+        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert "Manual refresh cancelled for entry entry-cancel" in caplog.text
 
 
 def test_force_update_logs_do_not_expose_secrets(caplog) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -333,9 +333,12 @@ class _FakeHass:
 class _ServiceRegistry:
     def __init__(self):
         self.registered: dict[tuple[str, str], Any] = {}
+        self.schemas: dict[tuple[str, str], Any] = {}
 
     def async_register(self, domain: str, service: str, handler, schema=None):
-        self.registered[(domain, service)] = handler
+        key = (domain, service)
+        self.registered[key] = handler
+        self.schemas[key] = schema
 
     async def async_call(self, domain: str, service: str):
         handler = self.registered[(domain, service)]
@@ -715,6 +718,32 @@ def test_setup_entry_disables_d1_when_forecast_days_is_one(
     assert entry.runtime_data.coordinator.create_d2 is False
 
 
+def test_force_update_service_is_registered_with_empty_schema() -> None:
+    """async_setup should register force_update with an empty schema."""
+
+    hass = _FakeHass()
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+
+    key = (integration.DOMAIN, "force_update")
+    assert key in hass.services.registered
+    original_schema = integration.vol.Schema
+    marker = object()
+
+    def _schema(value):
+        assert value == {}
+        return marker
+
+    integration.vol.Schema = _schema
+    try:
+        hass = _FakeHass()
+        assert asyncio.run(integration.async_setup(hass, {})) is True
+    finally:
+        integration.vol.Schema = original_schema
+
+    assert hass.services.schemas[key] is marker
+
+
 def test_force_update_requests_refresh_per_entry() -> None:
     """force_update should queue refresh via runtime_data coordinators and skip missing runtime data."""
 
@@ -748,6 +777,82 @@ def test_force_update_requests_refresh_per_entry() -> None:
     assert entry2.runtime_data.coordinator.calls == ["refresh"]
     assert entry1.runtime_data.coordinator.done.is_set()
     assert entry2.runtime_data.coordinator.done.is_set()
+
+
+def test_force_update_continues_after_single_coordinator_failure() -> None:
+    """One coordinator failure should not block refreshes for other entries."""
+
+    class _OkCoordinator:
+        def __init__(self):
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    class _FailCoordinator:
+        async def async_request_refresh(self):
+            raise RuntimeError("boom")
+
+    good_entry = _FakeEntry(entry_id="entry-good")
+    good_entry.runtime_data = types.SimpleNamespace(coordinator=_OkCoordinator())
+    bad_entry = _FakeEntry(entry_id="entry-bad")
+    bad_entry.runtime_data = types.SimpleNamespace(coordinator=_FailCoordinator())
+
+    hass = _FakeHass(entries=[bad_entry, good_entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert good_entry.runtime_data.coordinator.calls == 1
+
+
+def test_force_update_propagates_cancelled_error() -> None:
+    """Cancellation must propagate when refresh scheduling is cancelled."""
+
+    class _CancelledCoordinator:
+        async def async_request_refresh(self):
+            raise asyncio.CancelledError
+
+    entry = _FakeEntry(entry_id="entry-cancel")
+    entry.runtime_data = types.SimpleNamespace(coordinator=_CancelledCoordinator())
+
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+
+def test_force_update_logs_do_not_expose_secrets(caplog) -> None:
+    """Failure logs should avoid exposing key material and detailed location/payload data."""
+
+    class _FailCoordinator:
+        async def async_request_refresh(self):
+            raise RuntimeError(
+                "api_key=secret-123 lat=12.345678 lon=-98.765432 "
+                "url=https://example.test/pollen?token=secret-123 payload={'raw': 'x'}"
+            )
+
+    entry = _FakeEntry(
+        entry_id="entry-secrets",
+        data={
+            integration.CONF_API_KEY: "secret-123",
+            integration.CONF_LATITUDE: 12.345678,
+            integration.CONF_LONGITUDE: -98.765432,
+        },
+    )
+    entry.runtime_data = types.SimpleNamespace(coordinator=_FailCoordinator())
+
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    text = caplog.text
+    assert "secret-123" not in text
+    assert "12.345678" not in text
+    assert "-98.765432" not in text
+    assert "https://example.test/pollen?token=secret-123" not in text
+    assert "payload={'raw': 'x'}" not in text
 
 
 def test_migrate_entry_moves_mode_to_options() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -718,7 +718,9 @@ def test_setup_entry_disables_d1_when_forecast_days_is_one(
     assert entry.runtime_data.coordinator.create_d2 is False
 
 
-def test_force_update_service_is_registered_with_empty_schema() -> None:
+def test_force_update_service_is_registered_with_empty_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """async_setup should register force_update with an empty schema."""
 
     hass = _FakeHass()
@@ -727,19 +729,16 @@ def test_force_update_service_is_registered_with_empty_schema() -> None:
 
     key = (integration.DOMAIN, "force_update")
     assert key in hass.services.registered
-    original_schema = integration.vol.Schema
     marker = object()
 
     def _schema(value):
         assert value == {}
         return marker
 
-    integration.vol.Schema = _schema
-    try:
-        hass = _FakeHass()
-        assert asyncio.run(integration.async_setup(hass, {})) is True
-    finally:
-        integration.vol.Schema = original_schema
+    monkeypatch.setattr(integration.vol, "Schema", _schema)
+
+    hass = _FakeHass()
+    assert asyncio.run(integration.async_setup(hass, {})) is True
 
     assert hass.services.schemas[key] is marker
 
@@ -765,8 +764,10 @@ def test_force_update_requests_refresh_per_entry() -> None:
     entry2.runtime_data = types.SimpleNamespace(coordinator=_StubCoordinator())
     entry3 = _FakeEntry(entry_id="entry-3")
     entry3.runtime_data = None
+    entry4 = _FakeEntry(entry_id="entry-4")
+    entry4.runtime_data = types.SimpleNamespace()
 
-    hass = _FakeHass(entries=[entry1, entry2, entry3])
+    hass = _FakeHass(entries=[entry1, entry2, entry3, entry4])
 
     assert asyncio.run(integration.async_setup(hass, {})) is True
     assert (integration.DOMAIN, "force_update") in hass.services.registered
@@ -806,8 +807,8 @@ def test_force_update_continues_after_single_coordinator_failure() -> None:
     assert good_entry.runtime_data.coordinator.calls == 1
 
 
-def test_force_update_propagates_cancelled_error() -> None:
-    """Cancellation must propagate when refresh scheduling is cancelled."""
+def test_force_update_handles_cancelled_error() -> None:
+    """Cancellation results are handled gracefully and do not fail the service."""
 
     class _CancelledCoordinator:
         async def async_request_refresh(self):
@@ -829,7 +830,9 @@ def test_force_update_logs_do_not_expose_secrets(caplog) -> None:
         async def async_request_refresh(self):
             raise RuntimeError(
                 "api_key=secret-123 lat=12.345678 lon=-98.765432 "
-                "url=https://example.test/pollen?token=secret-123 payload={'raw': 'x'}"
+                "url=https://example.test/pollen?token=secret-123 payload=line1\n"
+                "token=secret-123\nlocation.latitude=12.345678\n"
+                "location.longitude=-98.765432"
             )
 
     entry = _FakeEntry(
@@ -852,7 +855,10 @@ def test_force_update_logs_do_not_expose_secrets(caplog) -> None:
     assert "12.345678" not in text
     assert "-98.765432" not in text
     assert "https://example.test/pollen?token=secret-123" not in text
-    assert "payload={'raw': 'x'}" not in text
+    assert "payload=line1" not in text
+    assert "location.latitude=12.345678" not in text
+    assert "location.longitude=-98.765432" not in text
+    assert "Manual refresh failed for entry entry-secrets (RuntimeError):" in text
 
 
 def test_migrate_entry_moves_mode_to_options() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -111,14 +111,34 @@ def test_redact_sensitive_values_redacts_exact_api_key():
     assert "***" in redacted
 
 
-def test_redact_sensitive_values_redacts_key_query_parameter():
-    """Key query parameters should have their values redacted."""
+def test_redact_sensitive_values_redacts_unquoted_key_query_parameter():
+    """Unquoted key query parameters should have their values redacted."""
 
     redacted = redact_sensitive_values("https://example.test/?key=bad-key&days=5")
 
     assert "bad-key" not in redacted
     assert "key=***" in redacted
     assert "days=5" in redacted
+
+
+def test_redact_sensitive_values_redacts_quoted_key_query_parameters():
+    """Quoted key parameters should be redacted while preserving quotes."""
+
+    redacted = redact_sensitive_values("key=\"secret-one\" key='secret-two'")
+
+    assert 'key="***"' in redacted
+    assert "key='***'" in redacted
+    assert "secret-one" not in redacted
+    assert "secret-two" not in redacted
+
+
+def test_redact_sensitive_values_redacts_urlencoded_unquoted_key_parameter():
+    """URL-encoded key parameters should have their values redacted."""
+
+    redacted = redact_sensitive_values("https://example.test/?key%3Dsecret-three")
+
+    assert "key%3D***" in redacted
+    assert "secret-three" not in redacted
 
 
 def test_redact_sensitive_values_redacts_coordinate_query_parameters():
@@ -162,21 +182,30 @@ def test_redact_sensitive_values_redacts_explicit_coordinates():
     assert redacted.count("***") == 2
 
 
-def test_redact_sensitive_values_redacts_quoted_url_assignments():
-    """Quoted URL assignments should keep quotes while redacting URL contents."""
+def test_redact_sensitive_values_redacts_single_quoted_url_assignment():
+    """Single-quoted URL assignment should keep quotes while redacting URL contents."""
 
-    message = (
-        'url="https://example.test/pollen?token=secret-token&key=bad-key" '
-        "url='https://example.test/pollen?api_key=secret-token&days=5'"
+    redacted = redact_sensitive_values(
+        "url='https://example.test/pollen?token=secret-token&key=bad-key'"
     )
 
-    redacted = redact_sensitive_values(message, api_key="secret-token")
-
-    assert 'url="***"' in redacted
     assert "url='***'" in redacted
     assert "https://example.test" not in redacted
     assert "token=secret-token" not in redacted
     assert "key=bad-key" not in redacted
+
+
+def test_redact_sensitive_values_redacts_double_quoted_url_assignment():
+    """Double-quoted URL assignment should keep quotes while redacting URL contents."""
+
+    redacted = redact_sensitive_values(
+        'url="https://example.test/pollen?token=secret-token&api_key=secret-token"',
+        api_key="secret-token",
+    )
+
+    assert 'url="***"' in redacted
+    assert "https://example.test" not in redacted
+    assert "token=secret-token" not in redacted
     assert "api_key=secret-token" not in redacted
 
 
@@ -184,12 +213,14 @@ def test_redact_sensitive_values_redacts_unquoted_url_assignment():
     """Unquoted URL assignment should be redacted without exposing query values."""
 
     redacted = redact_sensitive_values(
-        "url=https://example.test/pollen?token=abc&days=3"
+        "url=https://example.test/pollen?token=abc&key=bad-key&api_key=zzz&days=3"
     )
 
     assert "url=***" in redacted
     assert "https://example.test" not in redacted
     assert "token=abc" not in redacted
+    assert "key=bad-key" not in redacted
+    assert "api_key=zzz" not in redacted
 
 
 def test_redact_sensitive_values_redacts_payload_line_without_swallowing_following_lines():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -162,6 +162,22 @@ def test_redact_sensitive_values_redacts_explicit_coordinates():
     assert redacted.count("***") == 2
 
 
+def test_redact_sensitive_values_redacts_payload_line_without_swallowing_following_lines():
+    """Payload line is redacted while later lines are still independently sanitized."""
+
+    redacted = redact_sensitive_values(
+        "payload=line1\nkey=abc123\nlocation.latitude=40.4168",
+        latitude=40.4168,
+    )
+
+    assert "payload=line1" not in redacted
+    assert "payload=***" in redacted
+    assert "abc123" not in redacted
+    assert "key=***" in redacted
+    assert "40.4168" not in redacted
+    assert "location.latitude=***" in redacted
+
+
 def test_redact_sensitive_values_preserves_unrelated_numbers():
     """Unrelated numbers should not be redacted."""
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -162,6 +162,36 @@ def test_redact_sensitive_values_redacts_explicit_coordinates():
     assert redacted.count("***") == 2
 
 
+def test_redact_sensitive_values_redacts_quoted_url_assignments():
+    """Quoted URL assignments should keep quotes while redacting URL contents."""
+
+    message = (
+        'url="https://example.test/pollen?token=secret-token&key=bad-key" '
+        "url='https://example.test/pollen?api_key=secret-token&days=5'"
+    )
+
+    redacted = redact_sensitive_values(message, api_key="secret-token")
+
+    assert 'url="***"' in redacted
+    assert "url='***'" in redacted
+    assert "https://example.test" not in redacted
+    assert "token=secret-token" not in redacted
+    assert "key=bad-key" not in redacted
+    assert "api_key=secret-token" not in redacted
+
+
+def test_redact_sensitive_values_redacts_unquoted_url_assignment():
+    """Unquoted URL assignment should be redacted without exposing query values."""
+
+    redacted = redact_sensitive_values(
+        "url=https://example.test/pollen?token=abc&days=3"
+    )
+
+    assert "url=***" in redacted
+    assert "https://example.test" not in redacted
+    assert "token=abc" not in redacted
+
+
 def test_redact_sensitive_values_redacts_payload_line_without_swallowing_following_lines():
     """Payload line is redacted while later lines are still independently sanitized."""
 


### PR DESCRIPTION
### Motivation

- Add focused regression coverage for the global `pollenlevels.force_update` service before a planned Home Assistant test-stub refactor.
- Tests must assert service registration, empty service schema, per-entry refresh fan-out, safe skipping of entries without `runtime_data`/coordinator, resilience to a failing coordinator, cancellation handling, and secret-safe logging.
- Keep changes focused and minimal; only modify runtime code where needed to harden log redaction.

### Description

- Added focused tests in `tests/test_init.py` covering:
  - `test_force_update_service_is_registered_with_empty_schema`
  - `test_force_update_requests_refresh_per_entry`
  - `test_force_update_continues_after_single_coordinator_failure`
  - `test_force_update_handles_cancelled_error`
  - `test_force_update_logs_do_not_expose_secrets`
- Extended the fake service registry in `tests/test_init.py` to capture registered service schemas.
- Hardened `pollenlevels.force_update` failure logging by switching from `redact_api_key(...)` to `redact_sensitive_values(...)` and passing entry latitude/longitude so precise coordinates are redacted before logging.
- Extended `custom_components/pollenlevels/util.py` redaction helpers to cover:
  - explicit API keys;
  - `key=` query parameters;
  - quoted `key="..."` and `key='...'` values;
  - URL-encoded `key%3D...` values;
  - `location.latitude` / `location.longitude` parameters;
  - explicit coordinate values when latitude/longitude are known;
  - `url=` assignments with quoted and unquoted URLs;
  - single-line `payload=` fragments without swallowing following lines.
- Added regression coverage in `tests/test_util.py` for quoted/unquoted key parameters, URL assignments, payload-line redaction, URL-encoded coordinate parameters, and preservation of unrelated numeric values.
- Preserved current runtime cancellation behavior for the global service: coordinator cancellation results are handled gracefully and are not re-raised by the service handler.

### Out of scope

- No changes to entity IDs, unique IDs, translations, manifest versioning, config entry data/options, or public service names.
- No test-stub migration in this PR.
- No change to `coordinator.last_update_success` handling in `pollenlevels.force_update`; that would be a separate functional PR if desired.

### Testing

- `pytest tests/test_init.py`
- `pytest tests/test_util.py`
- `pytest`
- `ruff check .`
- `black --check .`
- GitHub Actions passed:
  - Lint
  - tests
  - Validate with hassfest
  - Validate with HACS