### PR TITLE
Clarify force_update cancellation test and add no-coordinators noop test

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -803,8 +803,8 @@ def test_force_update_continues_after_single_coordinator_failure() -> None:
     assert good_entry.runtime_data.coordinator.calls == 1
 
 
-def test_force_update_handles_cancelled_error(caplog) -> None:
-    """Cancellation results are handled gracefully and do not fail the service."""
+def test_force_update_handles_per_entry_cancelled_error(caplog) -> None:
+    """Per-entry cancellation results should not abort the global service."""
 
     class _CancelledCoordinator:
         async def async_request_refresh(self):
@@ -820,6 +820,18 @@ def test_force_update_handles_cancelled_error(caplog) -> None:
         asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
 
     assert "Manual refresh cancelled for entry entry-cancel" in caplog.text
+
+
+def test_force_update_no_coordinators_is_noop(caplog) -> None:
+    """Calling force_update with no coordinators should be a safe no-op."""
+
+    hass = _FakeHass(entries=[])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    with caplog.at_level("DEBUG"):
+        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert "No coordinators available for force_update" in caplog.text
 
 
 def test_force_update_logs_do_not_expose_secrets(caplog) -> None:


### PR DESCRIPTION
### Motivation
- Make the cancellation regression test contract explicit that the cancellation is per-entry and does not imply swallowing global HA task cancellation.
- Add missing coverage for the no-op branch when there are no runtime coordinators so the service call is safe in that case.
- Keep the change test-only and avoid any runtime behavior modifications.

### Description
- Rename the test `test_force_update_handles_cancelled_error` to `test_force_update_handles_per_entry_cancelled_error` and update its docstring to `"""Per-entry cancellation results should not abort the global service."""` in `tests/test_init.py`.
- Add a new test `test_force_update_no_coordinators_is_noop` in `tests/test_init.py` that sets up an empty `hass` (no entries), asserts `async_setup` returns `True`, calls the `pollenlevels.force_update` service, and checks the debug log contains `No coordinators available for force_update`.
- No files under `custom_components/pollenlevels/` or other runtime code were modified.

### Testing
- Ran `ruff check --fix --select I tests/test_init.py && ruff check .` and the checks passed.
- Ran `black --check .` and the check passed.
- Ran `pytest tests/test_init.py` and all tests in that file passed (`33 passed`).
- Ran full `pytest` and the entire suite passed (`310 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173c1969f08324b468f0b4a20d7b52)