### PR TITLE
style: align syntax with Python 3.14 baseline

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -5,7 +5,7 @@ Key points:
 - Normalizes language (trim/omit when empty) before calling the API.
 - Redacts API keys in debug logs.
 - Minimal safe backoff: single retry on transient errors (Timeout/5xx/429).
-- Timeout handling: on modern Python (3.11+), built-in `TimeoutError` also covers
+- Timeout handling: on Python 3.14, built-in `TimeoutError` also covers
   `asyncio.TimeoutError`, so catching `TimeoutError` is sufficient and preferred.
 """
 


### PR DESCRIPTION
### Motivation
- Align repository source and documentation with the declared Python 3.14+ baseline by removing wording that could imply older-Python compatibility guidance while avoiding any runtime or API changes.

### Description
- Updated the Python-version wording in the module docstring of `custom_components/pollenlevels/sensor.py` to reference Python 3.14 and reviewed `custom_components/pollenlevels/` and `tests/` for Python 3.12/3.13 compatibility holdovers, leaving PEP 758 unparenthesized multiple-exception handlers intact where intentional; Python baseline note: This repository intentionally targets Python 3.14+ only. The tooling and CI are aligned with that baseline (`requires-python >=3.14`, Ruff `py314`, Black `py314`, GitHub Actions Python 3.14). Python 3.14 syntax such as PEP 758 unparenthesized multiple-exception handlers is therefore intentional and should not be changed for Python 3.12/3.13 compatibility.

### Testing
- Commands run: `python -m compileall -q custom_components tests` (succeeded), `ruff check --fix --select I .` (passed), `ruff check .` (passed), `black .` (passed), `black --check .` (passed), and `pytest -q` (all tests passed: `310 passed`), plus targeted runs `pytest -q tests/test_options_flow.py` (`16 passed`), `pytest -q tests/test_config_flow.py` (`70 passed`), and `pytest -q tests/test_init.py` (`33 passed`).
- Files changed: `custom_components/pollenlevels/sensor.py` (one-line docstring wording change). 
- Confirmation: no behavior, public API, manifest, translations, entity names, or unique IDs were changed; this is a style/documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a0e05c00832494c10bab726aadd7)