### PR TITLE
test: audit remaining Home Assistant stubs

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,7 +6,7 @@ import datetime as dt
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Any
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -16,13 +16,17 @@ from tests._ha_stubs import (
     stub_custom_components_packages,
 )
 
-diag: ModuleType
-PollenLevelsRuntimeData: type[object]
-CONF_API_KEY: str
-CONF_FORECAST_DAYS: str
-CONF_LANGUAGE_CODE: str
-CONF_LATITUDE: str
-CONF_LONGITUDE: str
+
+class DiagnosticsModules(NamedTuple):
+    """Diagnostics modules/constants imported under fixture-scoped HA stubs."""
+
+    diag: ModuleType
+    PollenLevelsRuntimeData: type[object]
+    CONF_API_KEY: str
+    CONF_FORECAST_DAYS: str
+    CONF_LANGUAGE_CODE: str
+    CONF_LATITUDE: str
+    CONF_LONGITUDE: str
 
 
 class _ConfigEntry:
@@ -82,13 +86,9 @@ def _install_diagnostics_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-@pytest.fixture(autouse=True)
-def _diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> DiagnosticsModules:
     """Import diagnostics with fixture-scoped Home Assistant stubs."""
-
-    global diag, PollenLevelsRuntimeData
-    global CONF_API_KEY, CONF_FORECAST_DAYS, CONF_LANGUAGE_CODE
-    global CONF_LATITUDE, CONF_LONGITUDE
 
     _install_diagnostics_import_stubs(monkeypatch)
 
@@ -104,28 +104,32 @@ def _diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> None:
         PollenLevelsRuntimeData as ImportedRuntimeData,
     )
 
-    diag = imported_diag
-    PollenLevelsRuntimeData = ImportedRuntimeData
-    CONF_API_KEY = imported_conf_api_key
-    CONF_FORECAST_DAYS = imported_conf_forecast_days
-    CONF_LANGUAGE_CODE = imported_conf_language_code
-    CONF_LATITUDE = imported_conf_latitude
-    CONF_LONGITUDE = imported_conf_longitude
-    yield
+    modules = DiagnosticsModules(
+        diag=imported_diag,
+        PollenLevelsRuntimeData=ImportedRuntimeData,
+        CONF_API_KEY=imported_conf_api_key,
+        CONF_FORECAST_DAYS=imported_conf_forecast_days,
+        CONF_LANGUAGE_CODE=imported_conf_language_code,
+        CONF_LATITUDE=imported_conf_latitude,
+        CONF_LONGITUDE=imported_conf_longitude,
+    )
+    yield modules
     clear_integration_modules(monkeypatch=monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_rounds_coordinates_and_truncates_keys() -> None:
+async def test_diagnostics_rounds_coordinates_and_truncates_keys(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
     """Diagnostics should use rounded coordinates and limit data_keys length."""
 
     data = {
-        CONF_API_KEY: "secret-token",
-        CONF_LATITUDE: 12.3456,
-        CONF_LONGITUDE: 78.9876,
-        CONF_LANGUAGE_CODE: "en",
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LATITUDE: 12.3456,
+        diagnostics_modules.CONF_LONGITUDE: 78.9876,
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {CONF_FORECAST_DAYS: 3}
+    options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
@@ -138,15 +142,17 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys() -> None:
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={f"type_{idx}": {} for idx in range(60)},
     )
-    entry.runtime_data = PollenLevelsRuntimeData(
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
-    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
 
     assert diagnostics["request_params_example"]["key"] == "***"
-    assert CONF_LATITUDE not in diagnostics["entry"]["data"]
-    assert CONF_LONGITUDE not in diagnostics["entry"]["data"]
+    assert diagnostics_modules.CONF_LATITUDE not in diagnostics["entry"]["data"]
+    assert diagnostics_modules.CONF_LONGITUDE not in diagnostics["entry"]["data"]
     assert diagnostics["request_params_example"]["location.latitude"] == 12.3
     assert diagnostics["request_params_example"]["location.longitude"] == 79.0
     assert diagnostics["coordinator"]["data_keys_total"] == 60
@@ -163,16 +169,16 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys() -> None:
     ],
 )
 async def test_diagnostics_clamps_request_days(
-    raw_days: Any, expected_days: int
+    diagnostics_modules: DiagnosticsModules, raw_days: Any, expected_days: int
 ) -> None:
     """Diagnostics request params should always show a supported day count."""
 
     data = {
-        CONF_LATITUDE: 12.3,
-        CONF_LONGITUDE: 45.6,
-        CONF_LANGUAGE_CODE: "en",
+        diagnostics_modules.CONF_LATITUDE: 12.3,
+        diagnostics_modules.CONF_LONGITUDE: 45.6,
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {CONF_FORECAST_DAYS: raw_days}
+    options = {diagnostics_modules.CONF_FORECAST_DAYS: raw_days}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
@@ -185,25 +191,29 @@ async def test_diagnostics_clamps_request_days(
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={"type_grass": {"source": "type"}},
     )
-    entry.runtime_data = PollenLevelsRuntimeData(
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
-    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
 
     assert diagnostics["request_params_example"]["days"] == expected_days
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples() -> None:
+async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
     """Rounded coordinate helpers should drop non-finite values."""
 
     data = {
-        CONF_LATITUDE: "nan",
-        CONF_LONGITUDE: float("inf"),
-        CONF_LANGUAGE_CODE: "en",
+        diagnostics_modules.CONF_LATITUDE: "nan",
+        diagnostics_modules.CONF_LONGITUDE: float("inf"),
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {CONF_FORECAST_DAYS: 2}
+    options = {diagnostics_modules.CONF_FORECAST_DAYS: 2}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
@@ -216,11 +226,13 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples() -> No
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={"type_grass": {"source": "type"}},
     )
-    entry.runtime_data = PollenLevelsRuntimeData(
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
-    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
 
     assert diagnostics["approximate_location"]["latitude_rounded"] is None
     assert diagnostics["approximate_location"]["longitude_rounded"] is None
@@ -229,15 +241,17 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples() -> No
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_includes_daily_summary_sensor_snapshot() -> None:
+async def test_diagnostics_includes_daily_summary_sensor_snapshot(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
     """Diagnostics should summarize the daily summary sensors from coordinator data."""
 
     data = {
-        CONF_LATITUDE: 12.3,
-        CONF_LONGITUDE: 45.6,
-        CONF_LANGUAGE_CODE: "en",
+        diagnostics_modules.CONF_LATITUDE: 12.3,
+        diagnostics_modules.CONF_LONGITUDE: 45.6,
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {CONF_FORECAST_DAYS: 3}
+    options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
@@ -295,11 +309,13 @@ async def test_diagnostics_includes_daily_summary_sensor_snapshot() -> None:
             },
         },
     )
-    entry.runtime_data = PollenLevelsRuntimeData(
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
-    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
 
     daily_summary = diagnostics["daily_summary"]
     assert daily_summary["plants_in_season_today"] == {
@@ -333,7 +349,9 @@ async def test_diagnostics_includes_daily_summary_sensor_snapshot() -> None:
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_daily_summary_uses_empty_states_without_data() -> None:
+async def test_diagnostics_daily_summary_uses_empty_states_without_data(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
     """Diagnostics daily summary should be present even without coordinator data."""
 
     entry = _ConfigEntry(data={}, options={}, entry_id="entry", title="Home")
@@ -346,11 +364,13 @@ async def test_diagnostics_daily_summary_uses_empty_states_without_data() -> Non
         last_updated=None,
         data={},
     )
-    entry.runtime_data = PollenLevelsRuntimeData(
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
-    diagnostics = await diag.async_get_config_entry_diagnostics(None, entry)
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
 
     daily_summary = diagnostics["daily_summary"]
     assert daily_summary["plants_in_season_today"]["state"] is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -114,7 +114,9 @@ def diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> DiagnosticsModules:
         CONF_LONGITUDE=imported_conf_longitude,
     )
     yield modules
-    clear_integration_modules(monkeypatch=monkeypatch)
+    # Remove imported integration modules directly so pytest does not restore
+    # modules that were imported against these Home Assistant stubs.
+    clear_integration_modules()
 
 
 @pytest.mark.asyncio

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -11,32 +12,17 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
-    force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
 )
 
-components_mod = ModuleType("homeassistant.components")
-diagnostics_mod = ModuleType("homeassistant.components.diagnostics")
-
-
-def _async_redact_data(data: dict[str, Any], _redact: set[str]) -> dict[str, Any]:
-    def _walk(value):
-        if isinstance(value, dict):
-            return {
-                k: ("**REDACTED**" if k in _redact else _walk(v))
-                for k, v in value.items()
-            }
-        if isinstance(value, list):
-            return [_walk(v) for v in value]
-        return value
-
-    return _walk(data)
-
-
-diagnostics_mod.async_redact_data = _async_redact_data
-force_module("homeassistant.components", components_mod)
-force_module("homeassistant.components.diagnostics", diagnostics_mod)
+diag: ModuleType
+PollenLevelsRuntimeData: type[object]
+CONF_API_KEY: str
+CONF_FORECAST_DAYS: str
+CONF_LANGUAGE_CODE: str
+CONF_LATITUDE: str
+CONF_LONGITUDE: str
 
 
 class _ConfigEntry:
@@ -55,33 +41,78 @@ class _ConfigEntry:
         self.runtime_data = None
 
 
-stub_config_entry_class(_ConfigEntry)
+def _install_diagnostics_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install minimal Home Assistant stubs needed by diagnostics imports."""
 
-core_mod = ModuleType("homeassistant.core")
+    components_mod = ModuleType("homeassistant.components")
+    diagnostics_mod = ModuleType("homeassistant.components.diagnostics")
+
+    def _async_redact_data(data: dict[str, Any], _redact: set[str]) -> dict[str, Any]:
+        def _walk(value):
+            if isinstance(value, dict):
+                return {
+                    k: ("**REDACTED**" if k in _redact else _walk(v))
+                    for k, v in value.items()
+                }
+            if isinstance(value, list):
+                return [_walk(v) for v in value]
+            return value
+
+        return _walk(data)
+
+    diagnostics_mod.async_redact_data = _async_redact_data
+    monkeypatch.setitem(sys.modules, "homeassistant.components", components_mod)
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.components.diagnostics", diagnostics_mod
+    )
+
+    stub_config_entry_class(_ConfigEntry, monkeypatch=monkeypatch)
+
+    core_mod = ModuleType("homeassistant.core")
+
+    class _HomeAssistant:
+        pass
+
+    core_mod.HomeAssistant = _HomeAssistant
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core_mod)
+
+    clear_integration_modules(monkeypatch=monkeypatch)
+    stub_custom_components_packages(
+        root=Path(__file__).resolve().parents[1], monkeypatch=monkeypatch
+    )
 
 
-class _HomeAssistant:
-    pass
+@pytest.fixture(autouse=True)
+def _diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import diagnostics with fixture-scoped Home Assistant stubs."""
 
+    global diag, PollenLevelsRuntimeData
+    global CONF_API_KEY, CONF_FORECAST_DAYS, CONF_LANGUAGE_CODE
+    global CONF_LATITUDE, CONF_LONGITUDE
 
-core_mod.HomeAssistant = _HomeAssistant
-force_module("homeassistant.core", core_mod)
+    _install_diagnostics_import_stubs(monkeypatch)
 
-clear_integration_modules()
-stub_custom_components_packages(root=Path(__file__).resolve().parents[1])
+    from custom_components.pollenlevels import diagnostics as imported_diag
+    from custom_components.pollenlevels.const import (
+        CONF_API_KEY as imported_conf_api_key,
+        CONF_FORECAST_DAYS as imported_conf_forecast_days,
+        CONF_LANGUAGE_CODE as imported_conf_language_code,
+        CONF_LATITUDE as imported_conf_latitude,
+        CONF_LONGITUDE as imported_conf_longitude,
+    )
+    from custom_components.pollenlevels.runtime import (
+        PollenLevelsRuntimeData as ImportedRuntimeData,
+    )
 
-from custom_components.pollenlevels import diagnostics as diag  # noqa: E402
-from custom_components.pollenlevels.const import (  # noqa: E402
-    CONF_API_KEY,
-    CONF_FORECAST_DAYS,
-    CONF_LANGUAGE_CODE,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    DEFAULT_FORECAST_DAYS,
-    MAX_FORECAST_DAYS,
-    MIN_FORECAST_DAYS,
-)
-from custom_components.pollenlevels.runtime import PollenLevelsRuntimeData  # noqa: E402
+    diag = imported_diag
+    PollenLevelsRuntimeData = ImportedRuntimeData
+    CONF_API_KEY = imported_conf_api_key
+    CONF_FORECAST_DAYS = imported_conf_forecast_days
+    CONF_LANGUAGE_CODE = imported_conf_language_code
+    CONF_LATITUDE = imported_conf_latitude
+    CONF_LONGITUDE = imported_conf_longitude
+    yield
+    clear_integration_modules(monkeypatch=monkeypatch)
 
 
 @pytest.mark.asyncio
@@ -126,9 +157,9 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys() -> None:
 @pytest.mark.parametrize(
     ("raw_days", "expected_days"),
     [
-        (999, MAX_FORECAST_DAYS),
-        (-3, MIN_FORECAST_DAYS),
-        ("nan", DEFAULT_FORECAST_DAYS),
+        (999, 5),
+        (-3, 1),
+        ("nan", 2),
     ],
 )
 async def test_diagnostics_clamps_request_days(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,10 +24,14 @@ from tests._ha_stubs import (
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-const: types.ModuleType
-client_mod: types.ModuleType
-coordinator_mod: types.ModuleType
-sensor: types.ModuleType
+
+class SensorModules(NamedTuple):
+    """Integration modules imported under fixture-scoped Home Assistant stubs."""
+
+    const: types.ModuleType
+    client_mod: types.ModuleType
+    coordinator_mod: types.ModuleType
+    sensor: types.ModuleType
 
 
 def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -256,26 +260,26 @@ def _load_module(
     return module
 
 
-@pytest.fixture(autouse=True)
-def _sensor_import_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def sensor_modules(monkeypatch: pytest.MonkeyPatch) -> SensorModules:
     """Import sensor dependencies with fixture-scoped Home Assistant stubs."""
 
-    global const, client_mod, coordinator_mod, sensor
-
     _install_sensor_import_stubs(monkeypatch)
-    const = _load_module(
-        "custom_components.pollenlevels.const", "const.py", monkeypatch
+    modules = SensorModules(
+        const=_load_module(
+            "custom_components.pollenlevels.const", "const.py", monkeypatch
+        ),
+        client_mod=_load_module(
+            "custom_components.pollenlevels.client", "client.py", monkeypatch
+        ),
+        coordinator_mod=_load_module(
+            "custom_components.pollenlevels.coordinator", "coordinator.py", monkeypatch
+        ),
+        sensor=_load_module(
+            "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
+        ),
     )
-    client_mod = _load_module(
-        "custom_components.pollenlevels.client", "client.py", monkeypatch
-    )
-    coordinator_mod = _load_module(
-        "custom_components.pollenlevels.coordinator", "coordinator.py", monkeypatch
-    )
-    sensor = _load_module(
-        "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
-    )
-    yield
+    yield modules
     clear_integration_modules(monkeypatch=monkeypatch)
 
 
@@ -400,17 +404,18 @@ def _minimal_valid_payload(value: int = 2) -> dict[str, Any]:
 
 
 def _make_coordinator(
+    sensor_modules: SensorModules,
     loop: asyncio.AbstractEventLoop,
-    client: client_mod.GooglePollenApiClient,
+    client: Any,
     *,
     hours: int = 12,
     forecast_days: int = 1,
     create_d1: bool = False,
     create_d2: bool = False,
-) -> coordinator_mod.PollenDataUpdateCoordinator:
+) -> Any:
     """Build a coordinator with stable defaults for refresh tests."""
 
-    return coordinator_mod.PollenDataUpdateCoordinator(
+    return sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=DummyHass(loop),
         api_key="test",
         lat=1.0,
@@ -459,6 +464,7 @@ class RegistryStub:
 
 
 def _setup_registry_stub(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
     entries: list[RegistryEntry],
     *,
@@ -470,9 +476,9 @@ def _setup_registry_stub(
 
     # In Home Assistant, `async_remove()` is a method of the registry object returned by
     # `entity_registry.async_get(hass)`, not a module-level function.
-    monkeypatch.setattr(sensor.er, "async_get", lambda hass: registry)
+    monkeypatch.setattr(sensor_modules.sensor.er, "async_get", lambda hass: registry)
     monkeypatch.setattr(
-        sensor.er,
+        sensor_modules.sensor.er,
         "async_entries_for_config_entry",
         registry.async_entries_for_config_entry,
     )
@@ -491,7 +497,9 @@ def _summary_coordinator(data: dict[str, Any]):
     )
 
 
-def test_plants_in_season_counts_mixed_boolean_and_unknown_values() -> None:
+def test_plants_in_season_counts_mixed_boolean_and_unknown_values(
+    sensor_modules: SensorModules,
+) -> None:
     """Plants in season counts True/False and treats missing/non-boolean as unknown."""
 
     coordinator = _summary_coordinator(
@@ -519,7 +527,7 @@ def test_plants_in_season_counts_mixed_boolean_and_unknown_values() -> None:
         }
     )
 
-    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
     attrs = entity.extra_state_attributes
 
     assert entity.native_value == 1
@@ -533,7 +541,9 @@ def test_plants_in_season_counts_mixed_boolean_and_unknown_values() -> None:
     assert attrs["unknown_season_names"] == ["Birch", "Elm"]
 
 
-def test_plants_in_season_returns_none_without_boolean_season_data() -> None:
+def test_plants_in_season_returns_none_without_boolean_season_data(
+    sensor_modules: SensorModules,
+) -> None:
     """Plants in season returns None when plant entries lack explicit booleans."""
 
     coordinator = _summary_coordinator(
@@ -547,26 +557,29 @@ def test_plants_in_season_returns_none_without_boolean_season_data() -> None:
         }
     )
 
-    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
 
     assert entity.native_value is None
     assert entity.extra_state_attributes["unknown_season_count"] == 2
 
 
-def test_plants_in_season_returns_none_without_plant_entries() -> None:
+def test_plants_in_season_returns_none_without_plant_entries(
+    sensor_modules: SensorModules,
+) -> None:
     """Plants in season returns None when coordinator data has no plant entries."""
 
     coordinator = _summary_coordinator(
         {"type_grass": {"source": "type", "displayName": "Grass", "value": 2}}
     )
 
-    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
 
     assert entity.native_value is None
     assert entity.extra_state_attributes["total_plant_count"] == 0
 
 
 def test_summary_sensor_caches_payload_for_current_data_object(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Summary computation is cached per sensor while coordinator data is unchanged."""
@@ -583,10 +596,10 @@ def test_summary_sensor_caches_payload_for_current_data_object(
             }
         }
 
-    monkeypatch.setattr(sensor, "_daily_summary", fake_daily_summary)
+    monkeypatch.setattr(sensor_modules.sensor, "_daily_summary", fake_daily_summary)
     initial_data = {"plants_oak": {"source": "plant", "inSeason": True}}
     coordinator = _summary_coordinator(initial_data)
-    entity = sensor.PlantsInSeasonTodaySensor(coordinator)
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
 
     assert entity.native_value == 1
     assert entity.extra_state_attributes["plant_names"] == ["Plant 1"]
@@ -600,7 +613,9 @@ def test_summary_sensor_caches_payload_for_current_data_object(
     assert calls == [initial_data, updated_data]
 
 
-def test_overall_pollen_risk_returns_max_current_day_type_value() -> None:
+def test_overall_pollen_risk_returns_max_current_day_type_value(
+    sensor_modules: SensorModules,
+) -> None:
     """Overall pollen risk returns the maximum valid current-day type index."""
 
     coordinator = _summary_coordinator(
@@ -630,7 +645,7 @@ def test_overall_pollen_risk_returns_max_current_day_type_value() -> None:
         }
     )
 
-    entity = sensor.OverallPollenRiskTodaySensor(coordinator)
+    entity = sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator)
     attrs = entity.extra_state_attributes
 
     assert entity.native_value == 5
@@ -641,7 +656,9 @@ def test_overall_pollen_risk_returns_max_current_day_type_value() -> None:
     assert attrs["tie_count"] == 1
 
 
-def test_top_pollen_types_returns_single_winner_name() -> None:
+def test_top_pollen_types_returns_single_winner_name(
+    sensor_modules: SensorModules,
+) -> None:
     """Top pollen types returns one display name when there is a single winner."""
 
     coordinator = _summary_coordinator(
@@ -651,13 +668,15 @@ def test_top_pollen_types_returns_single_winner_name() -> None:
         }
     )
 
-    entity = sensor.TopPollenTypesTodaySensor(coordinator)
+    entity = sensor_modules.sensor.TopPollenTypesTodaySensor(coordinator)
 
     assert entity.native_value == "Grass"
     assert entity.extra_state_attributes["top_value"] == 4
 
 
-def test_top_pollen_types_returns_tied_names_and_attributes() -> None:
+def test_top_pollen_types_returns_tied_names_and_attributes(
+    sensor_modules: SensorModules,
+) -> None:
     """Top pollen types preserves all tied top values in state and attributes."""
 
     coordinator = _summary_coordinator(
@@ -686,7 +705,7 @@ def test_top_pollen_types_returns_tied_names_and_attributes() -> None:
         }
     )
 
-    entity = sensor.TopPollenTypesTodaySensor(coordinator)
+    entity = sensor_modules.sensor.TopPollenTypesTodaySensor(coordinator)
     attrs = entity.extra_state_attributes
 
     assert entity.native_value == "Grass, Weed"
@@ -697,7 +716,9 @@ def test_top_pollen_types_returns_tied_names_and_attributes() -> None:
     assert attrs["tie_count"] == 2
 
 
-def test_type_summary_sensors_ignore_per_day_d1_d2_values() -> None:
+def test_type_summary_sensors_ignore_per_day_d1_d2_values(
+    sensor_modules: SensorModules,
+) -> None:
     """Summary sensors ignore D+1 and D+2 per-day type sensors."""
 
     coordinator = _summary_coordinator(
@@ -716,15 +737,17 @@ def test_type_summary_sensors_ignore_per_day_d1_d2_values() -> None:
         }
     )
 
-    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
-    top = sensor.TopPollenTypesTodaySensor(coordinator)
+    risk = sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator)
+    top = sensor_modules.sensor.TopPollenTypesTodaySensor(coordinator)
 
     assert risk.native_value == 2
     assert risk.extra_state_attributes["top_pollen_names"] == ["Grass"]
     assert top.native_value == "Grass"
 
 
-def test_summary_fallback_codes_are_uppercase_from_data_keys() -> None:
+def test_summary_fallback_codes_are_uppercase_from_data_keys(
+    sensor_modules: SensorModules,
+) -> None:
     """Fallback summary codes from type_/plants_ keys are exposed uppercase."""
 
     coordinator = _summary_coordinator(
@@ -738,14 +761,14 @@ def test_summary_fallback_codes_are_uppercase_from_data_keys() -> None:
         }
     )
 
-    risk = sensor.OverallPollenRiskTodaySensor(coordinator)
-    plants = sensor.PlantsInSeasonTodaySensor(coordinator)
+    risk = sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator)
+    plants = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
 
     assert risk.extra_state_attributes["top_pollen_codes"] == ["GRASS"]
     assert plants.extra_state_attributes["plant_codes"] == ["OAK"]
 
 
-def test_summary_sensors_expose_attribution() -> None:
+def test_summary_sensors_expose_attribution(sensor_modules: SensorModules) -> None:
     """Summary sensors expose attribution attributes."""
 
     coordinator = _summary_coordinator(
@@ -760,36 +783,29 @@ def test_summary_sensors_expose_attribution() -> None:
     )
 
     entities = [
-        sensor.PlantsInSeasonTodaySensor(coordinator),
-        sensor.OverallPollenRiskTodaySensor(coordinator),
-        sensor.TopPollenTypesTodaySensor(coordinator),
+        sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator),
+        sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator),
+        sensor_modules.sensor.TopPollenTypesTodaySensor(coordinator),
     ]
 
     assert all(
-        entity.extra_state_attributes["Attribution"] == sensor.ATTRIBUTION
+        entity.extra_state_attributes["Attribution"]
+        == sensor_modules.sensor.ATTRIBUTION
         for entity in entities
     )
 
 
 @pytest.mark.parametrize(
-    ("entity_factory", "expected_unique_id"),
+    ("entity_kind", "expected_unique_id"),
     [
-        (
-            lambda coordinator: sensor.PollenSensor(coordinator, "type_grass"),
-            "entry_type_grass",
-        ),
-        (
-            lambda coordinator: sensor.OverallPollenRiskTodaySensor(coordinator),
-            "entry_overall_pollen_risk_today",
-        ),
-        (
-            lambda coordinator: sensor.RegionSensor(coordinator),
-            "entry_region",
-        ),
+        ("pollen", "entry_type_grass"),
+        ("overall_risk", "entry_overall_pollen_risk_today"),
+        ("region", "entry_region"),
     ],
 )
 def test_device_info_rounds_coordinates_for_placeholders(
-    entity_factory,
+    sensor_modules: SensorModules,
+    entity_kind: str,
     expected_unique_id: str,
 ) -> None:
     """All device groups show rounded coordinates without unique_id changes."""
@@ -808,7 +824,14 @@ def test_device_info_rounds_coordinates_for_placeholders(
     coordinator.lat = 39.123456
     coordinator.lon = -0.123456
 
-    entity = entity_factory(coordinator)
+    entity_factories = {
+        "pollen": lambda: sensor_modules.sensor.PollenSensor(coordinator, "type_grass"),
+        "overall_risk": lambda: sensor_modules.sensor.OverallPollenRiskTodaySensor(
+            coordinator
+        ),
+        "region": lambda: sensor_modules.sensor.RegionSensor(coordinator),
+    }
+    entity = entity_factories[entity_kind]()
     placeholders = entity.device_info["translation_placeholders"]
 
     assert placeholders["latitude"] == "39.12"
@@ -816,29 +839,34 @@ def test_device_info_rounds_coordinates_for_placeholders(
     assert entity.unique_id == expected_unique_id
 
 
-def test_top_pollen_types_today_does_not_expose_measurement_state_class() -> None:
+def test_top_pollen_types_today_does_not_expose_measurement_state_class(
+    sensor_modules: SensorModules,
+) -> None:
     """Top pollen types summary is textual and does not expose measurement state."""
 
-    entity = sensor.TopPollenTypesTodaySensor(_summary_coordinator({}))
+    entity = sensor_modules.sensor.TopPollenTypesTodaySensor(_summary_coordinator({}))
 
     assert (
         getattr(entity, "_attr_state_class", None)
-        != sensor.SensorStateClass.MEASUREMENT
+        != sensor_modules.sensor.SensorStateClass.MEASUREMENT
     )
 
 
-def test_plants_in_season_today_does_not_expose_measurement_state_class() -> None:
+def test_plants_in_season_today_does_not_expose_measurement_state_class(
+    sensor_modules: SensorModules,
+) -> None:
     """Plants in season summary count does not expose measurement state."""
 
-    entity = sensor.PlantsInSeasonTodaySensor(_summary_coordinator({}))
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(_summary_coordinator({}))
 
     assert (
         getattr(entity, "_attr_state_class", None)
-        != sensor.SensorStateClass.MEASUREMENT
+        != sensor_modules.sensor.SensorStateClass.MEASUREMENT
     )
 
 
 def test_type_sensor_preserves_source_with_single_day(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A single-day payload keeps the type sensor source and exposes no forecast."""
@@ -867,10 +895,10 @@ def test_type_sensor_preserves_source_with_single_day(
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -887,7 +915,9 @@ def test_type_sensor_preserves_source_with_single_day(
     assert "color_raw" not in entry
 
 
-def test_coordinator_preserves_last_data_when_dailyinfo_missing() -> None:
+def test_coordinator_preserves_last_data_when_dailyinfo_missing(
+    sensor_modules: SensorModules,
+) -> None:
     """Missing dailyInfo keeps the last successful data instead of clearing."""
 
     payload = {
@@ -916,10 +946,10 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing() -> None:
             ResponseSpec(status=200, payload={}),
         ]
     )
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -933,15 +963,15 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing() -> None:
     assert second_data == coordinator.data
 
 
-def test_coordinator_clamps_forecast_days_low() -> None:
+def test_coordinator_clamps_forecast_days_low(sensor_modules: SensorModules) -> None:
     """Forecast days are clamped to minimum for legacy or invalid values."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -957,20 +987,22 @@ def test_coordinator_clamps_forecast_days_low() -> None:
     finally:
         loop.close()
 
-    assert coordinator.forecast_days == const.MIN_FORECAST_DAYS
+    assert coordinator.forecast_days == sensor_modules.const.MIN_FORECAST_DAYS
 
 
-def test_coordinator_first_refresh_missing_dailyinfo_raises() -> None:
+def test_coordinator_first_refresh_missing_dailyinfo_raises(
+    sensor_modules: SensorModules,
+) -> None:
     """Missing dailyInfo on the first refresh should raise UpdateFailed."""
 
     session = SequenceSession([ResponseSpec(status=200, payload={})])
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="dailyInfo"):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="dailyInfo"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -978,23 +1010,27 @@ def test_coordinator_first_refresh_missing_dailyinfo_raises() -> None:
     assert coordinator.data == {}
 
 
-def test_coordinator_first_refresh_invalid_dailyinfo_type_raises() -> None:
+def test_coordinator_first_refresh_invalid_dailyinfo_type_raises(
+    sensor_modules: SensorModules,
+) -> None:
     """Non-list dailyInfo payload should raise UpdateFailed on first refresh."""
 
     session = SequenceSession([ResponseSpec(status=200, payload={"dailyInfo": {}})])
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="dailyInfo"):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="dailyInfo"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
 
-def test_coordinator_invalid_dailyinfo_items_keep_last_data() -> None:
+def test_coordinator_invalid_dailyinfo_items_keep_last_data(
+    sensor_modules: SensorModules,
+) -> None:
     """Invalid dailyInfo items should preserve previous successful coordinator data."""
 
     session = SequenceSession(
@@ -1019,10 +1055,10 @@ def test_coordinator_invalid_dailyinfo_items_keep_last_data() -> None:
             ResponseSpec(status=200, payload={"dailyInfo": ["bad-item"]}),
         ]
     )
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1035,7 +1071,9 @@ def test_coordinator_invalid_dailyinfo_items_keep_last_data() -> None:
     assert second_data == first_data
 
 
-def test_coordinator_mixed_dailyinfo_items_keep_last_data() -> None:
+def test_coordinator_mixed_dailyinfo_items_keep_last_data(
+    sensor_modules: SensorModules,
+) -> None:
     """Mixed valid/invalid dailyInfo items are treated as invalid payload."""
 
     session = SequenceSession(
@@ -1071,10 +1109,10 @@ def test_coordinator_mixed_dailyinfo_items_keep_last_data() -> None:
             ),
         ]
     )
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client, forecast_days=2)
+    coordinator = _make_coordinator(sensor_modules, loop, client, forecast_days=2)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1087,6 +1125,7 @@ def test_coordinator_mixed_dailyinfo_items_keep_last_data() -> None:
 
 
 def test_coordinator_stale_cached_data_raises_after_ttl(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Malformed dailyInfo raises once cached data is older than the TTL."""
@@ -1099,16 +1138,18 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
             ResponseSpec(status=200, payload={}),
         ]
     )
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client, hours=6)
+    coordinator = _make_coordinator(sensor_modules, loop, client, hours=6)
     monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
         now = start + datetime.timedelta(hours=24, seconds=1)
-        with pytest.raises(client_mod.UpdateFailed, match="cached data expired"):
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="cached data expired"
+        ):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -1116,15 +1157,17 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
     assert coordinator.data == first_data
 
 
-def test_coordinator_stale_data_ttl_accounts_for_update_interval() -> None:
+def test_coordinator_stale_data_ttl_accounts_for_update_interval(
+    sensor_modules: SensorModules,
+) -> None:
     """Effective stale-data TTL uses the larger of 24h and twice the interval."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        six_hour = coordinator_mod.PollenDataUpdateCoordinator(
+        six_hour = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -1137,7 +1180,7 @@ def test_coordinator_stale_data_ttl_accounts_for_update_interval() -> None:
             create_d2=False,
             client=client,
         )
-        twenty_four_hour = coordinator_mod.PollenDataUpdateCoordinator(
+        twenty_four_hour = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -1158,6 +1201,7 @@ def test_coordinator_stale_data_ttl_accounts_for_update_interval() -> None:
 
 
 def test_coordinator_success_after_malformed_response_updates_last_updated(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A later successful refresh updates last_updated after malformed dailyInfo."""
@@ -1173,10 +1217,10 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
             ResponseSpec(status=200, payload=_minimal_valid_payload(value=4)),
         ]
     )
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client, hours=6)
+    coordinator = _make_coordinator(sensor_modules, loop, client, hours=6)
     monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
 
     try:
@@ -1197,15 +1241,17 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
     assert coordinator.last_updated == second_refresh
 
 
-def test_coordinator_clamps_forecast_days_negative() -> None:
+def test_coordinator_clamps_forecast_days_negative(
+    sensor_modules: SensorModules,
+) -> None:
     """Negative forecast days are clamped to minimum."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -1221,18 +1267,18 @@ def test_coordinator_clamps_forecast_days_negative() -> None:
     finally:
         loop.close()
 
-    assert coordinator.forecast_days == const.MIN_FORECAST_DAYS
+    assert coordinator.forecast_days == sensor_modules.const.MIN_FORECAST_DAYS
 
 
-def test_coordinator_clamps_forecast_days_high() -> None:
+def test_coordinator_clamps_forecast_days_high(sensor_modules: SensorModules) -> None:
     """Forecast days are clamped to maximum for legacy or invalid values."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -1248,18 +1294,20 @@ def test_coordinator_clamps_forecast_days_high() -> None:
     finally:
         loop.close()
 
-    assert coordinator.forecast_days == const.MAX_FORECAST_DAYS
+    assert coordinator.forecast_days == sensor_modules.const.MAX_FORECAST_DAYS
 
 
-def test_coordinator_keeps_forecast_days_within_range() -> None:
+def test_coordinator_keeps_forecast_days_within_range(
+    sensor_modules: SensorModules,
+) -> None:
     """Valid forecast days remain unchanged after initialization."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
             hass=hass,
             api_key="test",
             lat=1.0,
@@ -1279,6 +1327,7 @@ def test_coordinator_keeps_forecast_days_within_range() -> None:
 
 
 def test_type_sensor_uses_forecast_metadata_when_today_missing(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When today lacks a type entry, use forecast metadata and keep type source."""
@@ -1328,11 +1377,11 @@ def test_type_sensor_uses_forecast_metadata_when_today_missing(
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1368,6 +1417,7 @@ def test_type_sensor_uses_forecast_metadata_when_today_missing(
 
 
 def test_plant_sensor_includes_forecast_attributes(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Plant sensors expose forecast attributes and derived convenience fields."""
@@ -1438,11 +1488,11 @@ def test_plant_sensor_includes_forecast_attributes(
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1497,14 +1547,16 @@ def test_plant_sensor_includes_forecast_attributes(
     ],
 )
 def test_extract_api_date_parses_integer_like_values(
-    day: dict[str, Any], expected: str | None
+    sensor_modules: SensorModules, day: dict[str, Any], expected: str | None
 ) -> None:
     """API date extraction accepts integer-like values and rejects malformed ones."""
 
-    assert coordinator_mod._extract_api_date(day) == expected
+    assert sensor_modules.coordinator_mod._extract_api_date(day) == expected
 
 
-def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None:
+def test_forecast_extraction_preserves_missing_index_and_date_behavior(
+    sensor_modules: SensorModules,
+) -> None:
     """Forecast entries preserve missing index and missing API date output."""
 
     payload = {
@@ -1587,11 +1639,11 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
     coordinator = _make_coordinator(
-        loop, client, forecast_days=3, create_d1=True, create_d2=True
+        sensor_modules, loop, client, forecast_days=3, create_d1=True, create_d2=True
     )
 
     try:
@@ -1642,7 +1694,9 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior() -> None
     assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
 
 
-def test_plant_forecast_matches_codes_case_insensitively() -> None:
+def test_plant_forecast_matches_codes_case_insensitively(
+    sensor_modules: SensorModules,
+) -> None:
     """Plant forecast should match even when code casing varies by day."""
 
     payload = {
@@ -1671,11 +1725,11 @@ def test_plant_forecast_matches_codes_case_insensitively() -> None:
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="test",
         lat=1.0,
@@ -1700,7 +1754,9 @@ def test_plant_forecast_matches_codes_case_insensitively() -> None:
     assert entry["tomorrow_value"] == 4
 
 
-def test_coordinator_accepts_numeric_string_color_channels() -> None:
+def test_coordinator_accepts_numeric_string_color_channels(
+    sensor_modules: SensorModules,
+) -> None:
     """Numeric string channels should be normalized into RGB/hex values."""
 
     payload = {
@@ -1723,10 +1779,10 @@ def test_coordinator_accepts_numeric_string_color_channels() -> None:
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1737,7 +1793,9 @@ def test_coordinator_accepts_numeric_string_color_channels() -> None:
     assert data["type_grass"]["color_rgb"] == [255, 0, 0]
 
 
-def test_coordinator_ignores_invalid_string_color_channels() -> None:
+def test_coordinator_ignores_invalid_string_color_channels(
+    sensor_modules: SensorModules,
+) -> None:
     """Non-numeric string channels should not emit RGB/hex values."""
 
     payload = {
@@ -1760,10 +1818,10 @@ def test_coordinator_ignores_invalid_string_color_channels() -> None:
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1774,7 +1832,9 @@ def test_coordinator_ignores_invalid_string_color_channels() -> None:
     assert data["type_grass"]["color_rgb"] is None
 
 
-def test_coordinator_ignores_nonfinite_color_channels() -> None:
+def test_coordinator_ignores_nonfinite_color_channels(
+    sensor_modules: SensorModules,
+) -> None:
     """Non-finite color channel values should not crash or emit invalid colors."""
 
     payload = {
@@ -1797,10 +1857,10 @@ def test_coordinator_ignores_nonfinite_color_channels() -> None:
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1811,7 +1871,9 @@ def test_coordinator_ignores_nonfinite_color_channels() -> None:
     assert data["type_grass"]["color_rgb"] is None
 
 
-def test_coordinator_type_keys_are_deterministic_sorted() -> None:
+def test_coordinator_type_keys_are_deterministic_sorted(
+    sensor_modules: SensorModules,
+) -> None:
     """Type sensor keys are emitted in stable sorted order."""
 
     payload = {
@@ -1835,10 +1897,10 @@ def test_coordinator_type_keys_are_deterministic_sorted() -> None:
     }
 
     fake_session = FakeSession(payload)
-    client = client_mod.GooglePollenApiClient(fake_session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1863,11 +1925,12 @@ def test_coordinator_type_keys_are_deterministic_sorted() -> None:
         "expected_entities",
     ),
     [
-        (False, True, 1, ["sensor.pollen_type_grass_d1"]),
-        (True, False, 1, ["sensor.pollen_type_grass_d2"]),
+        (False, True, 1, ["sensor_modules.sensor.pollen_type_grass_d1"]),
+        (True, False, 1, ["sensor_modules.sensor.pollen_type_grass_d2"]),
     ],
 )
 def test_cleanup_per_day_entities_removes_disabled_days(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
     allow_d1: bool,
     allow_d2: bool,
@@ -1878,31 +1941,33 @@ def test_cleanup_per_day_entities_removes_disabled_days(
 
     entries = [
         RegistryEntry(
-            "sensor.pollen_type_grass",
+            "sensor_modules.sensor.pollen_type_grass",
             "entry_type_grass",
             "sensor",
-            sensor.DOMAIN,
+            sensor_modules.sensor.DOMAIN,
         ),
         RegistryEntry(
-            "sensor.pollen_type_grass_d1",
+            "sensor_modules.sensor.pollen_type_grass_d1",
             "entry_type_grass_d1",
             "sensor",
-            sensor.DOMAIN,
+            sensor_modules.sensor.DOMAIN,
         ),
         RegistryEntry(
-            "sensor.pollen_type_grass_d2",
+            "sensor_modules.sensor.pollen_type_grass_d2",
             "entry_type_grass_d2",
             "sensor",
-            sensor.DOMAIN,
+            sensor_modules.sensor.DOMAIN,
         ),
     ]
-    registry = _setup_registry_stub(monkeypatch, entries, entry_id="entry")
+    registry = _setup_registry_stub(
+        sensor_modules, monkeypatch, entries, entry_id="entry"
+    )
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
     try:
         removed = loop.run_until_complete(
-            sensor._cleanup_per_day_entities(
+            sensor_modules.sensor._cleanup_per_day_entities(
                 hass, "entry", allow_d1=allow_d1, allow_d2=allow_d2
             )
         )
@@ -1913,15 +1978,15 @@ def test_cleanup_per_day_entities_removes_disabled_days(
     assert registry.removals == expected_entities
 
 
-def test_coordinator_raises_auth_failed() -> None:
+def test_coordinator_raises_auth_failed(sensor_modules: SensorModules) -> None:
     """401 responses trigger ConfigEntryAuthFailed for re-auth flows."""
 
     fake_session = FakeSession({}, status=401)
-    client = client_mod.GooglePollenApiClient(fake_session, "bad")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "bad")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -1936,21 +2001,21 @@ def test_coordinator_raises_auth_failed() -> None:
     )
 
     try:
-        with pytest.raises(client_mod.ConfigEntryAuthFailed):
+        with pytest.raises(sensor_modules.client_mod.ConfigEntryAuthFailed):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
 
-def test_coordinator_handles_forbidden() -> None:
+def test_coordinator_handles_forbidden(sensor_modules: SensorModules) -> None:
     """403 responses raise UpdateFailed without triggering re-auth."""
 
     fake_session = FakeSession({"error": {"message": "Forbidden"}}, status=403)
-    client = client_mod.GooglePollenApiClient(fake_session, "bad")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "bad")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -1965,22 +2030,24 @@ def test_coordinator_handles_forbidden() -> None:
     )
 
     try:
-        with pytest.raises(client_mod.UpdateFailed):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
 
-def test_coordinator_invalid_key_message_triggers_reauth() -> None:
+def test_coordinator_invalid_key_message_triggers_reauth(
+    sensor_modules: SensorModules,
+) -> None:
     """403 invalid API key messages should raise ConfigEntryAuthFailed."""
 
     payload = {"error": {"message": "API key not valid. Please pass a valid API key."}}
     fake_session = FakeSession(payload, status=403)
-    client = client_mod.GooglePollenApiClient(fake_session, "bad")
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "bad")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="bad",
         lat=1.0,
@@ -1995,19 +2062,22 @@ def test_coordinator_invalid_key_message_triggers_reauth() -> None:
     )
 
     try:
-        with pytest.raises(client_mod.ConfigEntryAuthFailed):
+        with pytest.raises(sensor_modules.client_mod.ConfigEntryAuthFailed):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
 
-def test_format_http_message_ignores_whitespace_only_message() -> None:
+def test_format_http_message_ignores_whitespace_only_message(
+    sensor_modules: SensorModules,
+) -> None:
     """Whitespace-only raw messages should not add a trailing HTTP suffix."""
 
-    assert client_mod._format_http_message(429, "   ") == "HTTP 429"
+    assert sensor_modules.client_mod._format_http_message(429, "   ") == "HTTP 429"
 
 
 def test_client_raises_dedicated_quota_error_after_terminal_429(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Terminal HTTP 429 responses raise the dedicated quota exception."""
@@ -2030,10 +2100,12 @@ def test_client_raises_dedicated_quota_error_after_terminal_429(
     async def _fast_sleep(_delay: float) -> None:
         return None
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     async def _run() -> None:
         await client.async_fetch_pollen_data(
@@ -2043,13 +2115,16 @@ def test_client_raises_dedicated_quota_error_after_terminal_429(
             language_code=None,
         )
 
-    with pytest.raises(client_mod.PollenQuotaExceededError, match="Quota exceeded"):
+    with pytest.raises(
+        sensor_modules.client_mod.PollenQuotaExceededError, match="Quota exceeded"
+    ):
         asyncio.run(_run())
 
     assert session.calls == 2
 
 
 def test_coordinator_retries_then_raises_on_rate_limit(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """429 responses are retried once then raise UpdateFailed with quota message."""
@@ -2073,16 +2148,20 @@ def test_coordinator_retries_then_raises_on_rate_limit(
     async def _fast_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="Quota exceeded"
+        ):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2091,7 +2170,10 @@ def test_coordinator_retries_then_raises_on_rate_limit(
     assert delays == [3.0]
 
 
-def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_coordinator_retry_after_http_date(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Retry-After as HTTP-date is converted to a delay before retry."""
 
     retry_after = "Wed, 10 Dec 2025 12:00:05 GMT"
@@ -2114,21 +2196,25 @@ def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> N
     async def _fast_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
     monkeypatch.setattr(
-        client_mod.dt_util,
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
+    monkeypatch.setattr(
+        sensor_modules.client_mod.dt_util,
         "utcnow",
         lambda: datetime.datetime(2025, 12, 10, 12, 0, 0, tzinfo=datetime.UTC),
     )
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="Quota exceeded"
+        ):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2150,6 +2236,7 @@ def test_coordinator_retry_after_http_date(monkeypatch: pytest.MonkeyPatch) -> N
     ],
 )
 def test_coordinator_retry_after_invalid_values_use_safe_default(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
     retry_after: str,
     now: datetime.datetime | None,
@@ -2179,18 +2266,22 @@ def test_coordinator_retry_after_invalid_values_use_safe_default(
         assert delay != float("-inf")
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
     if now is not None:
-        monkeypatch.setattr(client_mod.dt_util, "utcnow", lambda: now)
+        monkeypatch.setattr(sensor_modules.client_mod.dt_util, "utcnow", lambda: now)
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="Quota exceeded"):
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="Quota exceeded"
+        ):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2200,6 +2291,7 @@ def test_coordinator_retry_after_invalid_values_use_safe_default(
 
 
 def test_coordinator_retries_then_raises_on_server_errors(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """5xx responses retry once before raising UpdateFailed with status."""
@@ -2212,16 +2304,18 @@ def test_coordinator_retries_then_raises_on_server_errors(
     async def _fast_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="HTTP 502"):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="HTTP 502"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2231,6 +2325,7 @@ def test_coordinator_retries_then_raises_on_server_errors(
 
 
 def test_coordinator_retries_then_wraps_timeout(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Timeout errors retry once then surface as UpdateFailed with context."""
@@ -2241,16 +2336,18 @@ def test_coordinator_retries_then_wraps_timeout(
     async def _fast_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
 
-    client = client_mod.GooglePollenApiClient(session, "test")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="Timeout"):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="Timeout"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2260,14 +2357,15 @@ def test_coordinator_retries_then_wraps_timeout(
 
 
 def test_coordinator_retries_then_wraps_client_error(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Client errors retry once then raise UpdateFailed with redacted message."""
 
     session = SequenceSession(
         [
-            client_mod.ClientError("net down"),
-            client_mod.ClientError("net down"),
+            sensor_modules.client_mod.ClientError("net down"),
+            sensor_modules.client_mod.ClientError("net down"),
         ]
     )
     delays: list[float] = []
@@ -2275,14 +2373,16 @@ def test_coordinator_retries_then_wraps_client_error(
     async def _fast_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(client_mod.asyncio, "sleep", _fast_sleep)
-    monkeypatch.setattr(client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
 
-    client = client_mod.GooglePollenApiClient(session, "secret")
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "secret")
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="secret",
         lat=1.0,
@@ -2297,7 +2397,7 @@ def test_coordinator_retries_then_wraps_client_error(
     )
 
     try:
-        with pytest.raises(client_mod.UpdateFailed, match="net down"):
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="net down"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
@@ -2306,17 +2406,19 @@ def test_coordinator_retries_then_wraps_client_error(
     assert delays == [0.8]
 
 
-def test_async_setup_entry_raises_not_ready_if_runtime_data_missing() -> None:
+def test_async_setup_entry_raises_not_ready_if_runtime_data_missing(
+    sensor_modules: SensorModules,
+) -> None:
     """Missing runtime data causes setup to raise ConfigEntryNotReady."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         }
     )
 
@@ -2324,41 +2426,45 @@ def test_async_setup_entry_raises_not_ready_if_runtime_data_missing() -> None:
         return None
 
     try:
-        with pytest.raises(sensor.ConfigEntryNotReady):
+        with pytest.raises(sensor_modules.sensor.ConfigEntryNotReady):
             loop.run_until_complete(
-                sensor.async_setup_entry(hass, config_entry, _noop_add_entities)
+                sensor_modules.sensor.async_setup_entry(
+                    hass, config_entry, _noop_add_entities
+                )
             )
     finally:
         loop.close()
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
+async def test_async_setup_entry_skips_disabled_d1_d2_sensors(
+    sensor_modules: SensorModules,
+) -> None:
     """Setup does not recreate D+1/D+2 sensors when forecast days disable them."""
 
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_API_KEY: "key",
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
-        options={sensor.CONF_FORECAST_DAYS: 1},
+        options={sensor_modules.sensor.CONF_FORECAST_DAYS: 1},
         entry_id="entry",
     )
 
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "key")
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "key")
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="key",
         lat=1.0,
         lon=2.0,
-        hours=sensor.DEFAULT_UPDATE_INTERVAL,
+        hours=sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
         language=None,
         entry_id="entry",
-        entry_title=const.DEFAULT_ENTRY_TITLE,
+        entry_title=sensor_modules.const.DEFAULT_ENTRY_TITLE,
         forecast_days=3,
         create_d1=True,
         create_d2=True,
@@ -2371,7 +2477,7 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
         "type_grass_d1": {"source": "type", "name": "Grass D+1"},
         "type_grass_d2": {"source": "type", "name": "Grass D+2"},
     }
-    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
         coordinator=coordinator, client=client
     )
 
@@ -2380,7 +2486,7 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
     def _capture_entities(entities, _update_before_add=False):
         captured.extend(entities)
 
-    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
 
     unique_ids = {
         entity.unique_id
@@ -2394,19 +2500,19 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update() -> (
-    None
-):
+async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update(
+    sensor_modules: SensorModules,
+) -> None:
     """Setup uses first-refresh coordinator data and does not force entity update."""
 
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_API_KEY: "key",
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
@@ -2426,12 +2532,12 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         create_d1=False,
         create_d2=False,
         last_updated=None,
     )
-    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
@@ -2443,7 +2549,7 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
         captured.extend(entities)
         update_before_add_value = _update_before_add
 
-    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
 
     assert update_before_add_value is False
 
@@ -2456,18 +2562,20 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
+async def test_async_setup_entry_adds_daily_summary_sensors(
+    sensor_modules: SensorModules,
+) -> None:
     """Setup creates the three daily summary sensors."""
 
     entry_id = "summary_entry"
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_API_KEY: "key",
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id=entry_id,
     )
@@ -2493,12 +2601,12 @@ async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         create_d1=False,
         create_d2=False,
         last_updated=None,
     )
-    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
         coordinator=coordinator, client=object()
     )
 
@@ -2507,7 +2615,7 @@ async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
     def _capture_entities(entities, _update_before_add=False):
         captured.extend(entities)
 
-    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
 
     unique_ids = {
         entity.unique_id
@@ -2524,6 +2632,7 @@ async def test_async_setup_entry_adds_daily_summary_sensors() -> None:
 
 @pytest.mark.asyncio
 async def test_device_info_uses_default_title_when_blank(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Whitespace titles fall back to the default in translation placeholders."""
@@ -2531,34 +2640,34 @@ async def test_device_info_uses_default_title_when_blank(
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_API_KEY: "key",
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
     config_entry.title = "   "
 
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "key")
-    clean_title = const.DEFAULT_ENTRY_TITLE
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "key")
+    clean_title = sensor_modules.const.DEFAULT_ENTRY_TITLE
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="key",
         lat=1.0,
         lon=2.0,
-        hours=sensor.DEFAULT_UPDATE_INTERVAL,
+        hours=sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
         language=None,
         entry_id="entry",
         entry_title=clean_title,
-        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         create_d1=False,
         create_d2=False,
         client=client,
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
-    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
         coordinator=coordinator, client=client
     )
 
@@ -2567,18 +2676,21 @@ async def test_device_info_uses_default_title_when_blank(
     def _capture_entities(entities, _update_before_add=False):
         captured.extend(entities)
 
-    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
 
     region_sensor = next(
-        entity for entity in captured if isinstance(entity, sensor.RegionSensor)
+        entity
+        for entity in captured
+        if isinstance(entity, sensor_modules.sensor.RegionSensor)
     )
 
     placeholders = region_sensor.device_info["translation_placeholders"]
-    assert placeholders["title"] == const.DEFAULT_ENTRY_TITLE
+    assert placeholders["title"] == sensor_modules.const.DEFAULT_ENTRY_TITLE
 
 
 @pytest.mark.asyncio
 async def test_device_info_trims_custom_title(
+    sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Custom titles are trimmed before reaching translation placeholders."""
@@ -2586,34 +2698,34 @@ async def test_device_info_trims_custom_title(
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
         data={
-            sensor.CONF_API_KEY: "key",
-            sensor.CONF_LATITUDE: 1.0,
-            sensor.CONF_LONGITUDE: 2.0,
-            sensor.CONF_UPDATE_INTERVAL: sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor.CONF_FORECAST_DAYS: sensor.DEFAULT_FORECAST_DAYS,
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
     config_entry.title = "  My Location  "
 
-    client = client_mod.GooglePollenApiClient(FakeSession({}), "key")
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "key")
     clean_title = config_entry.title.strip()
-    coordinator = coordinator_mod.PollenDataUpdateCoordinator(
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
         hass=hass,
         api_key="key",
         lat=1.0,
         lon=2.0,
-        hours=sensor.DEFAULT_UPDATE_INTERVAL,
+        hours=sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
         language=None,
         entry_id="entry",
         entry_title=clean_title,
-        forecast_days=sensor.DEFAULT_FORECAST_DAYS,
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         create_d1=False,
         create_d2=False,
         client=client,
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
-    config_entry.runtime_data = sensor.PollenLevelsRuntimeData(
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
         coordinator=coordinator, client=client
     )
 
@@ -2622,10 +2734,12 @@ async def test_device_info_trims_custom_title(
     def _capture_entities(entities, _update_before_add=False):
         captured.extend(entities)
 
-    await sensor.async_setup_entry(hass, config_entry, _capture_entities)
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
 
     region_sensor = next(
-        entity for entity in captured if isinstance(entity, sensor.RegionSensor)
+        entity
+        for entity in captured
+        if isinstance(entity, sensor_modules.sensor.RegionSensor)
     )
 
     placeholders = region_sensor.device_info["translation_placeholders"]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1961,6 +1961,12 @@ def test_cleanup_per_day_entities_removes_disabled_days(
             sensor_modules.sensor.DOMAIN,
         ),
     ]
+    entity_ids = [entry.entity_id for entry in entries]
+    assert all(entity_id.startswith("sensor.") for entity_id in entity_ids)
+    assert all("sensor_modules." not in entity_id for entity_id in entity_ids)
+    assert all(entity_id.startswith("sensor.") for entity_id in expected_entities)
+    assert all("sensor_modules." not in entity_id for entity_id in expected_entities)
+
     registry = _setup_registry_stub(
         sensor_modules, monkeypatch, entries, entry_id="entry"
     )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,7 +14,6 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
-    force_module,
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
@@ -25,256 +24,259 @@ from tests._ha_stubs import (
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-# Ensure the custom_components namespace exists for relative imports.
-clear_integration_modules()
-stub_custom_components_packages(root=ROOT)
-
-# ---------------------------------------------------------------------------
-# Minimal Home Assistant stubs to import the integration module under test.
-# ---------------------------------------------------------------------------
-ha = stub_homeassistant_package()
-
-ha.components = types.ModuleType("homeassistant.components")
-force_module("homeassistant.components", ha.components)
-
-sensor_mod = types.ModuleType("homeassistant.components.sensor")
+const: types.ModuleType
+client_mod: types.ModuleType
+coordinator_mod: types.ModuleType
+sensor: types.ModuleType
 
 
-class _StubSensorEntity:  # pragma: no cover - no runtime behavior needed
-    def __init__(self, *args, **kwargs):
-        self._attr_unique_id = None
-        self._attr_device_info: dict[str, Any] | None = None
+def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install minimal Home Assistant stubs needed by sensor imports."""
 
-    @property
-    def unique_id(self):
-        return getattr(self, "_attr_unique_id", None)
+    clear_integration_modules(monkeypatch=monkeypatch)
+    stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
 
-    @property
-    def device_info(self):
-        return getattr(self, "_attr_device_info", None)
+    ha = stub_homeassistant_package(monkeypatch=monkeypatch)
 
+    ha.components = types.ModuleType("homeassistant.components")
+    monkeypatch.setitem(sys.modules, "homeassistant.components", ha.components)
 
-class _StubSensorDeviceClass:
-    DATE = "date"
-    TIMESTAMP = "timestamp"
+    sensor_mod = types.ModuleType("homeassistant.components.sensor")
 
+    class _StubSensorEntity:  # pragma: no cover - no runtime behavior needed
+        def __init__(self, *args, **kwargs):
+            self._attr_unique_id = None
+            self._attr_device_info: dict[str, Any] | None = None
 
-class _StubSensorStateClass:
-    MEASUREMENT = "measurement"
+        @property
+        def unique_id(self):
+            return getattr(self, "_attr_unique_id", None)
 
+        @property
+        def device_info(self):
+            return getattr(self, "_attr_device_info", None)
 
-sensor_mod.SensorDeviceClass = _StubSensorDeviceClass
-sensor_mod.SensorEntity = _StubSensorEntity
-sensor_mod.SensorStateClass = _StubSensorStateClass
-force_module("homeassistant.components.sensor", sensor_mod)
+    class _StubSensorDeviceClass:
+        DATE = "date"
+        TIMESTAMP = "timestamp"
 
-const_mod = types.ModuleType("homeassistant.const")
-force_module("homeassistant.const", const_mod)
+    class _StubSensorStateClass:
+        MEASUREMENT = "measurement"
 
-const_mod.ATTR_ATTRIBUTION = "Attribution"
-const_mod.CONF_NAME = "name"
-const_mod.CONF_LOCATION = "location"
-const_mod.CONF_LATITUDE = "latitude"
-const_mod.CONF_LONGITUDE = "longitude"
+    sensor_mod.SensorDeviceClass = _StubSensorDeviceClass
+    sensor_mod.SensorEntity = _StubSensorEntity
+    sensor_mod.SensorStateClass = _StubSensorStateClass
+    monkeypatch.setitem(sys.modules, "homeassistant.components.sensor", sensor_mod)
 
+    const_mod = types.ModuleType("homeassistant.const")
+    monkeypatch.setitem(sys.modules, "homeassistant.const", const_mod)
 
-class _StubConfigEntryNotReady(Exception):
-    pass
+    const_mod.ATTR_ATTRIBUTION = "Attribution"
+    const_mod.CONF_NAME = "name"
+    const_mod.CONF_LOCATION = "location"
+    const_mod.CONF_LATITUDE = "latitude"
+    const_mod.CONF_LONGITUDE = "longitude"
 
+    class _StubConfigEntryNotReady(Exception):
+        pass
 
-class _StubConfigEntryAuthFailed(Exception):
-    pass
+    class _StubConfigEntryAuthFailed(Exception):
+        pass
 
+    stub_exceptions(
+        monkeypatch=monkeypatch,
+        ConfigEntryNotReady=_StubConfigEntryNotReady,
+        ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+    )
 
-stub_exceptions(
-    ConfigEntryNotReady=_StubConfigEntryNotReady,
-    ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
-)
+    class _StubConfigEntry:
+        @classmethod
+        def __class_getitem__(cls, _item):
+            return cls
 
+    stub_config_entry_class(_StubConfigEntry, monkeypatch=monkeypatch)
 
-class _StubConfigEntry:
-    @classmethod
-    def __class_getitem__(cls, _item):
-        return cls
+    helpers_mod = types.ModuleType("homeassistant.helpers")
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers_mod)
 
+    entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
 
-stub_config_entry_class(_StubConfigEntry)
+    def _stub_async_get(_hass):  # pragma: no cover - not exercised in tests
+        class _Registry:
+            @staticmethod
+            def async_entries_for_config_entry(_registry, _entry_id):
+                return []
 
-helpers_mod = types.ModuleType("homeassistant.helpers")
-force_module("homeassistant.helpers", helpers_mod)
+        return _Registry()
 
-entity_registry_mod = types.ModuleType("homeassistant.helpers.entity_registry")
+    entity_registry_mod.async_get = _stub_async_get
+    entity_registry_mod.async_entries_for_config_entry = lambda *args, **kwargs: []
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.entity_registry", entity_registry_mod
+    )
 
+    aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    aiohttp_client_mod.async_get_clientsession = lambda hass: None
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.aiohttp_client", aiohttp_client_mod
+    )
 
-def _stub_async_get(_hass):  # pragma: no cover - not exercised in tests
-    class _Registry:
-        @staticmethod
-        def async_entries_for_config_entry(_registry, _entry_id):
-            return []
+    entity_mod = types.ModuleType("homeassistant.helpers.entity")
 
-    return _Registry()
+    class _StubEntityCategory:
+        DIAGNOSTIC = "diagnostic"
 
+    entity_mod.EntityCategory = _StubEntityCategory
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity_mod)
 
-entity_registry_mod.async_get = _stub_async_get
-entity_registry_mod.async_entries_for_config_entry = lambda *args, **kwargs: []
-force_module("homeassistant.helpers.entity_registry", entity_registry_mod)
+    entity_platform_mod = types.ModuleType("homeassistant.helpers.entity_platform")
 
-aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
-aiohttp_client_mod.async_get_clientsession = lambda hass: None
-force_module("homeassistant.helpers.aiohttp_client", aiohttp_client_mod)
+    def _add_entities_callback_stub(entities, update_before_add: bool = False) -> None:
+        return None
 
-entity_mod = types.ModuleType("homeassistant.helpers.entity")
+    entity_platform_mod.AddEntitiesCallback = _add_entities_callback_stub  # type: ignore[assignment]
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.entity_platform", entity_platform_mod
+    )
 
+    class _StubUpdateFailed(Exception):
+        pass
 
-class _StubEntityCategory:
-    DIAGNOSTIC = "diagnostic"
+    class _StubDataUpdateCoordinator:
+        def __init__(self, hass, logger, *, name: str, update_interval):
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+            self.data = None
+            self.last_updated = None
 
+        async def async_config_entry_first_refresh(self):
+            """Simulate a successful first refresh with minimal payload."""
 
-entity_mod.EntityCategory = _StubEntityCategory
-force_module("homeassistant.helpers.entity", entity_mod)
+            if self.data is None:
+                # Provide minimal successful payload so entity setup can proceed
+                self.data = {
+                    "date": {"source": "meta"},
+                    "region": {"source": "meta"},
+                }
+            if self.last_updated is None:
+                self.last_updated = "now"
 
-entity_platform_mod = types.ModuleType("homeassistant.helpers.entity_platform")
+            return None
 
+    class _StubCoordinatorEntity:
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+            self._attr_unique_id = None
+            self._attr_device_info = None
 
-def _add_entities_callback_stub(entities, update_before_add: bool = False) -> None:
-    return None
+        @property
+        def unique_id(self):  # pragma: no cover - simple data holder
+            return self._attr_unique_id
 
+        @property
+        def device_info(self):  # pragma: no cover - simple data holder
+            return self._attr_device_info
 
-entity_platform_mod.AddEntitiesCallback = _add_entities_callback_stub  # type: ignore[assignment]
-force_module("homeassistant.helpers.entity_platform", entity_platform_mod)
+    stub_update_coordinator_module(
+        update_failed=_StubUpdateFailed,
+        data_update_coordinator=_StubDataUpdateCoordinator,
+        coordinator_entity=_StubCoordinatorEntity,
+        monkeypatch=monkeypatch,
+    )
 
+    dt_mod = types.ModuleType("homeassistant.util.dt")
 
-class _StubUpdateFailed(Exception):
-    pass
+    def _stub_utcnow():
+        """Return a timezone-aware UTC datetime, similar to Home Assistant."""
 
+        from datetime import UTC, datetime
 
-class _StubDataUpdateCoordinator:
-    def __init__(self, hass, logger, *, name: str, update_interval):
-        self.hass = hass
-        self.logger = logger
-        self.name = name
-        self.update_interval = update_interval
-        self.data = None
-        self.last_updated = None
+        return datetime.now(UTC)
 
-    async def async_config_entry_first_refresh(self):
-        """Simulate a successful first refresh with minimal payload."""
+    dt_mod.utcnow = _stub_utcnow
 
-        if self.data is None:
-            # Provide minimal successful payload so entity setup can proceed
-            self.data = {
-                "date": {"source": "meta"},
-                "region": {"source": "meta"},
-            }
-        if self.last_updated is None:
-            self.last_updated = "now"
+    def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
+        from datetime import UTC, datetime
+        from email.utils import parsedate_to_datetime
+
+        try:
+            parsed = parsedate_to_datetime(value) if value is not None else None
+        except TypeError, ValueError, IndexError:
+            return None
+
+        if parsed is None:
+            return None
+
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+
+        if isinstance(parsed, datetime):
+            return parsed
 
         return None
 
+    dt_mod.parse_http_date = _stub_parse_http_date
+    monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
 
-class _StubCoordinatorEntity:
-    def __init__(self, coordinator):
-        self.coordinator = coordinator
-        self._attr_unique_id = None
-        self._attr_device_info = None
+    util_mod = types.ModuleType("homeassistant.util")
+    util_mod.dt = dt_mod
+    monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
 
-    @property
-    def unique_id(self):  # pragma: no cover - simple data holder
-        return self._attr_unique_id
+    aiohttp_mod = types.ModuleType("aiohttp")
 
-    @property
-    def device_info(self):  # pragma: no cover - simple data holder
-        return self._attr_device_info
+    class _StubClientError(Exception):
+        pass
 
+    class _StubClientSession:  # pragma: no cover - structure only
+        pass
 
-stub_update_coordinator_module(
-    update_failed=_StubUpdateFailed,
-    data_update_coordinator=_StubDataUpdateCoordinator,
-    coordinator_entity=_StubCoordinatorEntity,
-)
+    class _StubClientTimeout:
+        def __init__(self, total: float | None = None):
+            self.total = total
 
-dt_mod = types.ModuleType("homeassistant.util.dt")
-
-
-def _stub_utcnow():
-    """Return a timezone-aware UTC datetime, similar to Home Assistant."""
-
-    from datetime import UTC, datetime
-
-    return datetime.now(UTC)
+    aiohttp_mod.ClientError = _StubClientError
+    aiohttp_mod.ClientSession = _StubClientSession
+    aiohttp_mod.ClientTimeout = _StubClientTimeout
+    aiohttp_mod.ContentTypeError = ValueError
+    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp_mod)
 
 
-dt_mod.utcnow = _stub_utcnow
-
-
-def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
-    from datetime import UTC, datetime
-    from email.utils import parsedate_to_datetime
-
-    try:
-        parsed = parsedate_to_datetime(value) if value is not None else None
-    except TypeError, ValueError, IndexError:
-        return None
-
-    if parsed is None:
-        return None
-
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-
-    if isinstance(parsed, datetime):
-        return parsed
-
-    return None
-
-
-dt_mod.parse_http_date = _stub_parse_http_date
-force_module("homeassistant.util.dt", dt_mod)
-
-util_mod = types.ModuleType("homeassistant.util")
-util_mod.dt = dt_mod
-force_module("homeassistant.util", util_mod)
-
-aiohttp_mod = types.ModuleType("aiohttp")
-
-
-class _StubClientError(Exception):
-    pass
-
-
-class _StubClientSession:  # pragma: no cover - structure only
-    pass
-
-
-class _StubClientTimeout:
-    def __init__(self, total: float | None = None):
-        self.total = total
-
-
-aiohttp_mod.ClientError = _StubClientError
-aiohttp_mod.ClientSession = _StubClientSession
-aiohttp_mod.ClientTimeout = _StubClientTimeout
-aiohttp_mod.ContentTypeError = ValueError
-force_module("aiohttp", aiohttp_mod)
-
-
-def _load_module(module_name: str, relative_path: str):
+def _load_module(
+    module_name: str, relative_path: str, monkeypatch: pytest.MonkeyPatch
+) -> types.ModuleType:
     spec = importlib.util.spec_from_file_location(
         module_name, ROOT / "custom_components" / "pollenlevels" / relative_path
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
-    sys.modules[module_name] = module
+    monkeypatch.setitem(sys.modules, module_name, module)
     return module
 
 
-const = _load_module("custom_components.pollenlevels.const", "const.py")
-client_mod = _load_module("custom_components.pollenlevels.client", "client.py")
-coordinator_mod = _load_module(
-    "custom_components.pollenlevels.coordinator", "coordinator.py"
-)
-sensor = _load_module("custom_components.pollenlevels.sensor", "sensor.py")
+@pytest.fixture(autouse=True)
+def _sensor_import_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Import sensor dependencies with fixture-scoped Home Assistant stubs."""
+
+    global const, client_mod, coordinator_mod, sensor
+
+    _install_sensor_import_stubs(monkeypatch)
+    const = _load_module(
+        "custom_components.pollenlevels.const", "const.py", monkeypatch
+    )
+    client_mod = _load_module(
+        "custom_components.pollenlevels.client", "client.py", monkeypatch
+    )
+    coordinator_mod = _load_module(
+        "custom_components.pollenlevels.coordinator", "coordinator.py", monkeypatch
+    )
+    sensor = _load_module(
+        "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
+    )
+    yield
+    clear_integration_modules(monkeypatch=monkeypatch)
 
 
 class DummyHass:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1927,8 +1927,8 @@ def test_coordinator_type_keys_are_deterministic_sorted(
         "expected_entities",
     ),
     [
-        (False, True, 1, ["sensor_modules.sensor.pollen_type_grass_d1"]),
-        (True, False, 1, ["sensor_modules.sensor.pollen_type_grass_d2"]),
+        (False, True, 1, ["sensor.pollen_type_grass_d1"]),
+        (True, False, 1, ["sensor.pollen_type_grass_d2"]),
     ],
 )
 def test_cleanup_per_day_entities_removes_disabled_days(
@@ -1943,19 +1943,19 @@ def test_cleanup_per_day_entities_removes_disabled_days(
 
     entries = [
         RegistryEntry(
-            "sensor_modules.sensor.pollen_type_grass",
+            "sensor.pollen_type_grass",
             "entry_type_grass",
             "sensor",
             sensor_modules.sensor.DOMAIN,
         ),
         RegistryEntry(
-            "sensor_modules.sensor.pollen_type_grass_d1",
+            "sensor.pollen_type_grass_d1",
             "entry_type_grass_d1",
             "sensor",
             sensor_modules.sensor.DOMAIN,
         ),
         RegistryEntry(
-            "sensor_modules.sensor.pollen_type_grass_d2",
+            "sensor.pollen_type_grass_d2",
             "entry_type_grass_d2",
             "sensor",
             sensor_modules.sensor.DOMAIN,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -280,7 +280,9 @@ def sensor_modules(monkeypatch: pytest.MonkeyPatch) -> SensorModules:
         ),
     )
     yield modules
-    clear_integration_modules(monkeypatch=monkeypatch)
+    # Remove imported integration modules directly so pytest does not restore
+    # modules that were imported against these Home Assistant stubs.
+    clear_integration_modules()
 
 
 class DummyHass:


### PR DESCRIPTION
### Motivation
- Finish the stub-isolation work by auditing tests for module-level/import-time `homeassistant` stubbing and migrate any remaining unsafe cases to fixture-scoped `monkeypatch` setup. 
- Avoid changing runtime code and keep the changes small and test-only while preserving existing test semantics and Python 3.14 baseline.

### Description
- Moved module-level Home Assistant stub installation and direct imports into fixture-scoped helpers in `tests/test_sensor.py` to prevent import-time `sys.modules` mutation and to load integration modules under controlled fixtures. 
- Reworked `tests/test_diagnostics.py` to install `homeassistant.components`/`homeassistant.components.diagnostics`/`homeassistant.core` stubs via a fixture and import the integration under that fixture. 
- Left safe/local snapshot-restore patterns in `tests/test_client.py` and `tests/test_util.py` unchanged, and kept the lightweight `aiohttp` fallback in `tests/conftest.py` because they intentionally preserve and restore `sys.modules` or are not HA-specific stubs. 
- Files changed: `tests/test_sensor.py`, `tests/test_diagnostics.py`.

### Testing
- Ran compilation and linters: `python -m compileall -q custom_components tests` succeeded. 
- Ran import-order auto-fix and lint: `ruff check --fix --select I` succeeded and `ruff check .` succeeded. 
- Verified formatting: `black --check .` succeeded. 
- Ran full test suite and focused tests: `pytest -q` succeeded with `310 passed`, and the focused test runs all succeeded: `pytest -q tests/test_button.py` (7 passed), `pytest -q tests/test_init.py` (33 passed), `pytest -q tests/test_config_flow.py` (70 passed), `pytest -q tests/test_options_flow.py` (16 passed), `pytest -q tests/test_sensor.py` (68 passed), and `pytest -q tests/test_diagnostics.py` (7 passed). 
- Exact commands run and high-level results: `python -m compileall -q custom_components tests` (OK); `ruff check --fix --select I` (OK); `ruff check .` (OK); `black --check .` (OK); `pytest -q` (OK, 310 passed); `pytest -q tests/test_button.py` (OK, 7 passed); `pytest -q tests/test_init.py` (OK, 33 passed); `pytest -q tests/test_config_flow.py` (OK, 70 passed); `pytest -q tests/test_options_flow.py` (OK, 16 passed); `pytest -q tests/test_sensor.py` (OK, 68 passed); `pytest -q tests/test_diagnostics.py` (OK, 7 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e5e2e3248324bf6b28e769ad9a41)