### PR TITLE
test: guard sensor entity IDs in cleanup tests

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1962,6 +1962,11 @@ def test_cleanup_per_day_entities_removes_disabled_days(
         ),
     ]
     entity_ids = [entry.entity_id for entry in entries]
+    assert entity_ids == [
+        "sensor.pollen_type_grass",
+        "sensor.pollen_type_grass_d1",
+        "sensor.pollen_type_grass_d2",
+    ]
     assert all(entity_id.startswith("sensor.") for entity_id in entity_ids)
     assert all("sensor_modules." not in entity_id for entity_id in entity_ids)
     assert all(entity_id.startswith("sensor.") for entity_id in expected_entities)


### PR DESCRIPTION
### Motivation
- Add a small regression guard to `test_cleanup_per_day_entities_removes_disabled_days()` so future fixture/module refactors cannot accidentally replace Home Assistant `sensor.*` entity ID literals with module-path-like strings while keeping the test passing.

### Description
- In `tests/test_sensor.py` I inserted an explicit invariant immediately after the `entries` list and before `_setup_registry_stub(...)` that asserts the exact `entity_ids` and enforces that every registry/expected entity ID starts with `"sensor."` and does not contain `"sensor_modules."`, specifically:

```python
entity_ids = [entry.entity_id for entry in entries]
assert entity_ids == [
    "sensor.pollen_type_grass",
    "sensor.pollen_type_grass_d1",
    "sensor.pollen_type_grass_d2",
]
assert all(entity_id.startswith("sensor.") for entity_id in entity_ids)
assert all("sensor_modules." not in entity_id for entity_id in entity_ids)
assert all(entity_id.startswith("sensor.") for entity_id in expected_entities)
assert all("sensor_modules." not in entity_id for entity_id in expected_entities)
```

### Testing
- Ran formatting/lint and test commands: `ruff check --fix --select I .`, `black tests/test_sensor.py`, `python -m compileall -q custom_components tests`, `ruff check .`, `black --check .`, `pytest -q tests/test_sensor.py` (68 passed), `pytest -q tests/test_diagnostics.py` (7 passed), and `pytest -q` (310 passed), and all commands completed successfully with no failures, and a targeted search confirmed no quoted test strings contain `sensor_modules.sensor.`, `diagnostics_modules.`, `_modules.sensor.`, or `_modules.button.`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8f16e1cc8324ae8ebd8d57c7dd94)