### PR TITLE
test: centralize aiohttp test stubs

### DIFF
--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -11,6 +11,38 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 
 
+class StubClientError(Exception):
+    """Minimal aiohttp ClientError stub."""
+
+
+class StubClientSession:  # pragma: no cover - structure only
+    """Minimal aiohttp ClientSession stub."""
+
+
+class StubClientTimeout:
+    """Minimal aiohttp ClientTimeout stub."""
+
+    def __init__(self, total: float | int | None = None) -> None:
+        self.total = total
+
+
+def stub_aiohttp_module(
+    *,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    install: bool = True,
+) -> ModuleType:
+    """Build and optionally install a lightweight ``aiohttp`` stub module."""
+
+    module = ModuleType("aiohttp")
+    module.ClientError = StubClientError
+    module.ClientSession = StubClientSession
+    module.ClientTimeout = StubClientTimeout
+    module.ContentTypeError = ValueError
+    if not install:
+        return module
+    return _set_module("aiohttp", module, monkeypatch=monkeypatch)
+
+
 def force_module(name: str, module: ModuleType) -> ModuleType:
     """Force a module into ``sys.modules`` and return it."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,32 +5,23 @@ from __future__ import annotations
 import asyncio
 import inspect
 import sys
-from types import ModuleType
 
 import pytest
 
-aiohttp_mod = sys.modules.setdefault("aiohttp", ModuleType("aiohttp"))
+from tests._ha_stubs import (
+    StubClientError,
+    StubClientSession,
+    StubClientTimeout,
+    stub_aiohttp_module,
+)
 
-
-class _StubClientError(Exception):
-    pass
-
-
-class _StubClientSession:  # pragma: no cover - structure only
-    pass
-
-
-class _StubClientTimeout:
-    def __init__(self, total: float | None = None):
-        self.total = total
-
-
+aiohttp_mod = sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))
 if not hasattr(aiohttp_mod, "ClientError"):
-    aiohttp_mod.ClientError = _StubClientError
+    aiohttp_mod.ClientError = StubClientError
 if not hasattr(aiohttp_mod, "ClientSession"):
-    aiohttp_mod.ClientSession = _StubClientSession
+    aiohttp_mod.ClientSession = StubClientSession
 if not hasattr(aiohttp_mod, "ClientTimeout"):
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
+    aiohttp_mod.ClientTimeout = StubClientTimeout
 if not hasattr(aiohttp_mod, "ContentTypeError"):
     aiohttp_mod.ContentTypeError = ValueError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,22 +8,9 @@ import sys
 
 import pytest
 
-from tests._ha_stubs import (
-    StubClientError,
-    StubClientSession,
-    StubClientTimeout,
-    stub_aiohttp_module,
-)
+from tests._ha_stubs import stub_aiohttp_module
 
-aiohttp_mod = sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))
-if not hasattr(aiohttp_mod, "ClientError"):
-    aiohttp_mod.ClientError = StubClientError
-if not hasattr(aiohttp_mod, "ClientSession"):
-    aiohttp_mod.ClientSession = StubClientSession
-if not hasattr(aiohttp_mod, "ClientTimeout"):
-    aiohttp_mod.ClientTimeout = StubClientTimeout
-if not hasattr(aiohttp_mod, "ContentTypeError"):
-    aiohttp_mod.ContentTypeError = ValueError
+sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,23 +10,10 @@ from typing import Any
 
 import pytest
 
+from tests._ha_stubs import stub_aiohttp_module
+
 ROOT = Path(__file__).resolve().parents[1]
 _SENTINEL = object()
-
-
-class _StubClientError(Exception):
-    """Minimal aiohttp ClientError stub."""
-
-
-class _StubClientSession:
-    """Minimal aiohttp ClientSession stub."""
-
-
-class _StubClientTimeout:
-    """Minimal aiohttp ClientTimeout stub."""
-
-    def __init__(self, total: float | None = None) -> None:
-        self.total = total
 
 
 class _StubConfigEntryAuthFailed(Exception):
@@ -69,12 +56,7 @@ def _install_client_import_stubs() -> dict[str, object]:
     pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
     _set_module(snapshot, "custom_components.pollenlevels", pollenlevels_pkg)
 
-    aiohttp_mod = types.ModuleType("aiohttp")
-    aiohttp_mod.ClientError = _StubClientError
-    aiohttp_mod.ClientSession = _StubClientSession
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
-    aiohttp_mod.ContentTypeError = ValueError
-    _set_module(snapshot, "aiohttp", aiohttp_mod)
+    _set_module(snapshot, "aiohttp", stub_aiohttp_module(install=False))
 
     ha_mod = types.ModuleType("homeassistant")
     _set_module(snapshot, "homeassistant", ha_mod)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,6 +18,7 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
+    stub_aiohttp_module,
     stub_custom_components_packages,
     stub_exceptions,
     stub_homeassistant_package,
@@ -193,19 +194,6 @@ class _SelectSelector:
         self.config = config
 
 
-class _StubClientError(Exception):
-    pass
-
-
-class _StubClientTimeout:
-    def __init__(self, *, total: float | int):
-        self.total = total
-
-
-class _StubClientSession:
-    pass
-
-
 class _StubInvalid(Exception):
     def __init__(self, error_message=""):
         super().__init__(error_message)
@@ -328,12 +316,7 @@ def _install_homeassistant_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     ha_mod.helpers = helpers_mod
     ha_mod.config_entries = config_entries_mod
 
-    aiohttp_mod = ModuleType("aiohttp")
-    aiohttp_mod.ClientError = _StubClientError
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
-    aiohttp_mod.ClientSession = _StubClientSession
-    aiohttp_mod.ContentTypeError = ValueError
-    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp_mod)
+    stub_aiohttp_module(monkeypatch=monkeypatch)
 
     vol_mod = ModuleType("voluptuous")
     vol_mod.Invalid = _StubInvalid

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,6 +14,7 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
+    stub_aiohttp_module,
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
@@ -228,23 +229,7 @@ def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     util_mod.dt = dt_mod
     monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
 
-    aiohttp_mod = types.ModuleType("aiohttp")
-
-    class _StubClientError(Exception):
-        pass
-
-    class _StubClientSession:  # pragma: no cover - structure only
-        pass
-
-    class _StubClientTimeout:
-        def __init__(self, total: float | None = None):
-            self.total = total
-
-    aiohttp_mod.ClientError = _StubClientError
-    aiohttp_mod.ClientSession = _StubClientSession
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
-    aiohttp_mod.ContentTypeError = ValueError
-    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp_mod)
+    stub_aiohttp_module(monkeypatch=monkeypatch)
 
 
 def _load_module(


### PR DESCRIPTION
### Motivation
- Reduce duplicated lightweight `aiohttp` stubs across tests by providing a single minimal helper while keeping test behavior and import order unchanged.

### Description
- Added shared stub classes and a builder `stub_aiohttp_module` to `tests/_ha_stubs.py`, centralizing `StubClientError`, `StubClientSession`, `StubClientTimeout`, and a function that builds an `aiohttp` module exposing `ClientError`, `ClientSession`, `ClientTimeout`, and `ContentTypeError = ValueError`.
- Updated `tests/conftest.py` to reuse the shared helper and keep the global fallback via `sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))` to avoid fixture-order/import-order coupling while still removing local duplicate definitions.
- Replaced local `aiohttp` stub definitions in `tests/test_sensor.py` and `tests/test_config_flow.py` with calls to `stub_aiohttp_module(monkeypatch=monkeypatch)`.
- Updated `tests/test_client.py` to use `stub_aiohttp_module(install=False)` inside its snapshot/restore import pattern so the snapshot behavior remains local and unchanged.
- Files changed: `tests/_ha_stubs.py`, `tests/conftest.py`, `tests/test_sensor.py`, `tests/test_config_flow.py`, `tests/test_client.py`.
- No runtime code under `custom_components/pollenlevels/` was modified.

### Testing
- Commands run (exact):
  - `python -m compileall -q custom_components tests`
  - `ruff check --fix --select I .` (fixed 2 import-order issues)
  - `ruff check .`
  - `black .` (reformatted `tests/test_config_flow.py`)
  - `black --check .`
  - `pytest -q tests/test_sensor.py` — 68 passed
  - `pytest -q tests/test_config_flow.py` — 70 passed
  - `pytest -q tests/test_client.py` — 12 passed
  - `pytest -q tests/test_diagnostics.py` — 7 passed
  - `pytest -q` — full suite: 310 passed
- Outcomes: `compileall`, `ruff`, `black`, and all `pytest` runs succeeded after formatting; the only automatic fix required was import-order via `ruff` and a one-file reformat by `black` which were applied.
- Centralized aiohttp definitions: `StubClientError`, `StubClientSession`, `StubClientTimeout`, and the `stub_aiohttp_module` helper which returns/install a module exposing `ClientError`, `ClientSession`, `ClientTimeout`, and `ContentTypeError = ValueError`.
- `tests/conftest.py` retains a global fallback (`sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))`) to ensure suite-wide availability early in test startup and to avoid changing import/fixture ordering semantics.
- Confirmation: this is a test-only refactor and does not change runtime behavior of the integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a953f7e5c832485884500eb63f365)