### PR TITLE
Refactor remaining aiohttp test stubs

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,6 +14,7 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
+    stub_aiohttp_module,
     stub_config_entry_class,
     stub_custom_components_packages,
     stub_exceptions,
@@ -67,19 +68,6 @@ class _StubSensorDeviceClass:  # pragma: no cover - structure only
 
 class _StubSensorStateClass:  # pragma: no cover - structure only
     MEASUREMENT = "measurement"
-
-
-class _StubClientError(Exception):
-    pass
-
-
-class _StubClientSession:  # pragma: no cover - structure only
-    pass
-
-
-class _StubClientTimeout:
-    def __init__(self, total: float | None = None):
-        self.total = total
 
 
 class _StubEntityCategory:
@@ -189,12 +177,7 @@ def stub_init_ha_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(
         sys.modules, "homeassistant.helpers.aiohttp_client", aiohttp_client_mod
     )
-    aiohttp_mod = types.ModuleType("aiohttp")
-    aiohttp_mod.ClientError = _StubClientError
-    aiohttp_mod.ClientSession = _StubClientSession
-    aiohttp_mod.ClientTimeout = _StubClientTimeout
-    aiohttp_mod.ContentTypeError = ValueError
-    monkeypatch.setitem(sys.modules, "aiohttp", aiohttp_mod)
+    stub_aiohttp_module(monkeypatch=monkeypatch)
 
     cv_mod = types.ModuleType("homeassistant.helpers.config_validation")
     cv_mod.config_entry_only_config_schema = lambda _domain: lambda config: config

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -16,6 +16,7 @@ import pytest
 
 from tests._ha_stubs import (
     clear_integration_modules,
+    stub_aiohttp_module,
     stub_custom_components_packages,
     stub_exceptions,
     stub_homeassistant_package,
@@ -217,23 +218,7 @@ def options_flow_env(monkeypatch: pytest.MonkeyPatch) -> OptionsFlowEnv:
     ha_mod.helpers = helpers_mod
     ha_mod.config_entries = config_entries_mod
 
-    aiohttp_mod = ModuleType("aiohttp")
-
-    class StubClientError(Exception):
-        pass
-
-    class StubClientTimeout:
-        def __init__(self, *, total: float | int):
-            self.total = total
-
-    class StubClientSession:
-        pass
-
-    aiohttp_mod.ClientError = StubClientError
-    aiohttp_mod.ClientTimeout = StubClientTimeout
-    aiohttp_mod.ClientSession = StubClientSession
-    aiohttp_mod.ContentTypeError = ValueError
-    monkeypatch.setitem(sys_modules, "aiohttp", aiohttp_mod)
+    stub_aiohttp_module(monkeypatch=monkeypatch)
 
     vol_mod = ModuleType("voluptuous")
 


### PR DESCRIPTION
### Motivation
- Consolidate duplicated lightweight `aiohttp` test stubs by reusing the shared `stub_aiohttp_module()` helper to reduce duplication and keep test fixtures consistent.

### Description
- Replaced local `aiohttp` module setups in `tests/test_init.py` and `tests/test_options_flow.py` with `stub_aiohttp_module(monkeypatch=monkeypatch)`.
- Removed duplicate test-only classes `_StubClientError`, `_StubClientSession`, and `_StubClientTimeout` from `tests/test_init.py` and the corresponding `StubClientError`, `StubClientSession`, and `StubClientTimeout` from `tests/test_options_flow.py` where they were no longer needed.
- Changes are test-only and limited to `tests/test_init.py` and `tests/test_options_flow.py`, with no runtime files modified.

### Testing
- Ran `python -m compileall -q custom_components tests` and it succeeded.
- Ran `ruff check .` and `black --check .` and both checks passed.
- Ran `pytest -q tests/test_init.py` (33 passed), `pytest -q tests/test_options_flow.py` (16 passed), `pytest -q tests/test_config_flow.py` (70 passed), and a full `pytest -q` run (310 passed), all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bdc697f2083249490a18bcca1bc04)