### PR TITLE
Remove global aiohttp test fallback

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import sys
 
 import pytest
-
-from tests._ha_stubs import stub_aiohttp_module
-
-sys.modules.setdefault("aiohttp", stub_aiohttp_module(install=False))
 
 
 def pytest_configure(config: pytest.Config) -> None:


### PR DESCRIPTION
### Motivation
- Ensure aiohttp stubs are provided only by fixture-scoped helpers (not globally at import time) to complete the stub isolation cleanup and avoid hidden test import-order coupling.

### Description
- Remove the import-time global `aiohttp` fallback from `tests/conftest.py` and drop the now-unused `sys` and `stub_aiohttp_module` imports, leaving the pytest asyncio support hook unchanged.

### Testing
- Ran `python -m compileall -q custom_components tests`, `ruff check .`, `black --check .`, and the test matrix `pytest -q` and the focused test orders; all test runs completed successfully with no failures, the global `aiohttp` fallback is absent, and no runtime files in `custom_components/pollenlevels/` were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bfcf32c4883248f756e0cd22605bc)