### PR TITLE
Add test stub hygiene guard

### DIFF
--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -1,0 +1,137 @@
+"""Guard against import-time installation of test stubs."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS_DIR = ROOT / "tests"
+
+STUB_INSTALL_HELPERS = {
+    "force_module",
+    "stub_aiohttp_module",
+    "stub_config_entry_class",
+    "stub_custom_components_packages",
+    "stub_exceptions",
+    "stub_homeassistant_package",
+    "stub_update_coordinator_module",
+}
+
+
+class ImportTimeStubMutationVisitor(ast.NodeVisitor):
+    """Find sys.modules mutations that execute while importing a test module."""
+
+    def __init__(self) -> None:
+        self.scope_depth = 0
+        self.sys_aliases = {"sys"}
+        self.sys_modules_aliases: set[str] = set()
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        if self.scope_depth == 0:
+            for alias in node.names:
+                if alias.name == "sys":
+                    self.sys_aliases.add(alias.asname or alias.name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if self.scope_depth == 0 and node.module == "sys":
+            for alias in node.names:
+                if alias.name == "modules":
+                    self.sys_modules_aliases.add(alias.asname or alias.name)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_nested_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_nested_scope(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_nested_scope(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if self.scope_depth == 0:
+            for target in node.targets:
+                self._check_assignment_target(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if self.scope_depth == 0:
+            self._check_assignment_target(node.target)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:
+        if self.scope_depth == 0:
+            self._check_assignment_target(node.target)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self.scope_depth == 0:
+            if self._is_sys_modules_method_call(node, {"setdefault", "update"}):
+                self.violations.append(
+                    (node.lineno, "top-level sys.modules mutation call")
+                )
+            elif self._is_stub_install_helper_call(node):
+                self.violations.append(
+                    (node.lineno, "top-level stub installation helper call")
+                )
+        self.generic_visit(node)
+
+    def _visit_nested_scope(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+    ) -> None:
+        self.scope_depth += 1
+        self.generic_visit(node)
+        self.scope_depth -= 1
+
+    def _check_assignment_target(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
+            self.violations.append((target.lineno, "top-level sys.modules assignment"))
+
+    def _is_sys_modules_method_call(self, node: ast.Call, names: set[str]) -> bool:
+        return (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in names
+            and self._is_sys_modules(node.func.value)
+        )
+
+    def _is_stub_install_helper_call(self, node: ast.Call) -> bool:
+        if isinstance(node.func, ast.Name):
+            return node.func.id in STUB_INSTALL_HELPERS
+        if isinstance(node.func, ast.Attribute):
+            return node.func.attr in STUB_INSTALL_HELPERS
+        return False
+
+    def _is_sys_modules(self, node: ast.expr) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "modules"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.sys_aliases
+        ) or (isinstance(node, ast.Name) and node.id in self.sys_modules_aliases)
+
+
+def test_tests_do_not_install_stubs_at_import_time() -> None:
+    """Keep Home Assistant and aiohttp stubs fixture- or helper-scoped."""
+
+    paths = sorted(TESTS_DIR.glob("test_*.py")) + [TESTS_DIR / "conftest.py"]
+    violations: list[str] = []
+
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = ImportTimeStubMutationVisitor()
+        visitor.visit(tree)
+        source_lines = path.read_text(encoding="utf-8").splitlines()
+        for line_number, reason in visitor.violations:
+            source = source_lines[line_number - 1].strip()
+            violations.append(
+                f"{path.relative_to(ROOT)}:{line_number}: {reason}: {source}"
+            )
+
+    assert not violations, "\n".join(
+        [
+            "Stub modules must not be installed while importing test modules.",
+            "Move the operation into a fixture, test, or helper function instead.",
+            *violations,
+        ]
+    )

--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -30,6 +30,7 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         self.sys_aliases = {"sys"}
         self.sys_modules_aliases: set[str] = set()
         self.stub_helper_aliases = set(STUB_INSTALL_HELPERS)
+        self.local_stub_wrappers: set[str] = set()
         self.violations: list[tuple[int, str]] = []
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -49,32 +50,40 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                     self.stub_helper_aliases.add(local_name)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        if self.scope_depth == 0 and self._function_body_has_import_time_stub(node):
+            self.local_stub_wrappers.add(node.name)
         self._visit_function_header(node)
         self._visit_nested_body(node.body)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if self.scope_depth == 0 and self._function_body_has_import_time_stub(node):
+            self.local_stub_wrappers.add(node.name)
         self._visit_function_header(node)
         self._visit_nested_body(node.body)
 
-    def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        for decorator in node.decorator_list:
-            self.visit(decorator)
-        for base in node.bases:
-            self.visit(base)
-        for keyword in node.keywords:
-            self.visit(keyword)
-        for statement in node.body:
-            self.visit(statement)
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_argument_defaults(node.args)
+        self.scope_depth += 1
+        self.visit(node.body)
+        self.scope_depth -= 1
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if self.scope_depth == 0:
             for target in node.targets:
                 self._check_assignment_target(target)
+                self._track_sys_modules_alias(target, node.value)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         if self.scope_depth == 0:
             self._check_assignment_target(node.target)
+            self._track_sys_modules_alias(node.target, node.value)
+        self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        if self.scope_depth == 0:
+            self._check_assignment_target(node.target)
+            self._track_sys_modules_alias(node.target, node.value)
         self.generic_visit(node)
 
     def visit_AugAssign(self, node: ast.AugAssign) -> None:
@@ -100,6 +109,10 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                 self.violations.append(
                     (node.lineno, "top-level stub installation helper call")
                 )
+            elif self._is_local_stub_wrapper_call(node):
+                self.violations.append(
+                    (node.lineno, "top-level local stub wrapper call")
+                )
         self.generic_visit(node)
 
     def _visit_function_header(
@@ -119,6 +132,32 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         for statement in body:
             self.visit(statement)
         self.scope_depth -= 1
+
+    def _function_body_has_import_time_stub(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> bool:
+        visitor = self._copy_for_function_body()
+        for statement in node.body:
+            visitor.visit(statement)
+        return bool(visitor.violations)
+
+    def _copy_for_function_body(self) -> ImportTimeStubMutationVisitor:
+        visitor = ImportTimeStubMutationVisitor()
+        visitor.sys_aliases = set(self.sys_aliases)
+        visitor.sys_modules_aliases = set(self.sys_modules_aliases)
+        visitor.stub_helper_aliases = set(self.stub_helper_aliases)
+        visitor.local_stub_wrappers = set(self.local_stub_wrappers)
+        return visitor
+
+    def _track_sys_modules_alias(
+        self, target: ast.expr, value: ast.expr | None
+    ) -> None:
+        if (
+            isinstance(target, ast.Name)
+            and value is not None
+            and self._is_sys_modules(value)
+        ):
+            self.sys_modules_aliases.add(target.id)
 
     def _check_assignment_target(self, target: ast.expr) -> None:
         if self._is_sys_modules(target):
@@ -146,6 +185,12 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
             return node.func.attr in STUB_INSTALL_HELPERS
         return False
 
+    def _is_local_stub_wrapper_call(self, node: ast.Call) -> bool:
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.local_stub_wrappers
+        )
+
     def _is_sys_modules(self, node: ast.expr) -> bool:
         return (
             isinstance(node, ast.Attribute)
@@ -159,6 +204,16 @@ def _violation_reasons(source: str) -> list[str]:
     visitor = ImportTimeStubMutationVisitor()
     visitor.visit(ast.parse(source))
     return [reason for _line, reason in visitor.violations]
+
+
+def _scanned_test_paths() -> list[Path]:
+    paths = {
+        *TESTS_DIR.rglob("test_*.py"),
+        *TESTS_DIR.rglob("conftest.py"),
+        *TESTS_DIR.rglob("__init__.py"),
+    }
+    paths.discard(TESTS_DIR / "_ha_stubs.py")
+    return sorted(paths)
 
 
 @pytest.mark.parametrize(
@@ -217,6 +272,35 @@ install_ha()
 """,
             "top-level stub installation helper call",
         ),
+        (
+            """
+import sys
+
+sys_modules = sys.modules
+sys_modules["homeassistant"] = object()
+""",
+            "top-level sys.modules assignment",
+        ),
+        (
+            """
+import sys
+
+sys_modules = sys.modules
+sys_modules.setdefault("aiohttp", object())
+""",
+            "top-level sys.modules mutation call",
+        ),
+        (
+            """
+from tests._ha_stubs import stub_homeassistant_package
+
+def setup_stubs():
+    stub_homeassistant_package()
+
+setup_stubs()
+""",
+            "top-level local stub wrapper call",
+        ),
     ],
 )
 def test_import_time_stub_visitor_flags_reviewed_patterns(
@@ -238,18 +322,28 @@ def helper():
 class StubContainer:
     def helper(self, default=None):
         sys.modules["homeassistant"] = object()
+
+cb = lambda: install_ha()
 """
 
     assert _violation_reasons(source) == []
 
 
+def test_scanned_test_paths_include_pytest_imported_modules() -> None:
+    paths = {path.relative_to(ROOT).as_posix() for path in _scanned_test_paths()}
+
+    assert "tests/__init__.py" in paths
+    assert "tests/conftest.py" in paths
+    assert "tests/test_stub_hygiene.py" in paths
+    assert "tests/_ha_stubs.py" not in paths
+
+
 def test_tests_do_not_install_stubs_at_import_time() -> None:
     """Keep Home Assistant and aiohttp stubs fixture- or helper-scoped."""
 
-    paths = sorted(TESTS_DIR.glob("test_*.py")) + [TESTS_DIR / "conftest.py"]
     violations: list[str] = []
 
-    for path in paths:
+    for path in _scanned_test_paths():
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         visitor = ImportTimeStubMutationVisitor()
         visitor.visit(tree)

--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[1]
 TESTS_DIR = ROOT / "tests"
 
 STUB_INSTALL_HELPERS = {
+    "clear_integration_modules",
     "force_module",
     "stub_aiohttp_module",
     "stub_config_entry_class",
@@ -65,9 +66,17 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
             self._check_assignment_target(node.target)
         self.generic_visit(node)
 
+    def visit_Delete(self, node: ast.Delete) -> None:
+        if self.scope_depth == 0:
+            for target in node.targets:
+                self._check_delete_target(target)
+        self.generic_visit(node)
+
     def visit_Call(self, node: ast.Call) -> None:
         if self.scope_depth == 0:
-            if self._is_sys_modules_method_call(node, {"setdefault", "update"}):
+            if self._is_sys_modules_method_call(
+                node, {"clear", "pop", "popitem", "setdefault", "update"}
+            ):
                 self.violations.append(
                     (node.lineno, "top-level sys.modules mutation call")
                 )
@@ -85,8 +94,16 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         self.scope_depth -= 1
 
     def _check_assignment_target(self, target: ast.expr) -> None:
-        if isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
+        if self._is_sys_modules(target):
+            self.violations.append(
+                (target.lineno, "top-level sys.modules reassignment")
+            )
+        elif isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
             self.violations.append((target.lineno, "top-level sys.modules assignment"))
+
+    def _check_delete_target(self, target: ast.expr) -> None:
+        if isinstance(target, ast.Subscript) and self._is_sys_modules(target.value):
+            self.violations.append((target.lineno, "top-level sys.modules deletion"))
 
     def _is_sys_modules_method_call(self, node: ast.Call, names: set[str]) -> bool:
         return (

--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 TESTS_DIR = ROOT / "tests"
 
@@ -27,6 +29,7 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         self.scope_depth = 0
         self.sys_aliases = {"sys"}
         self.sys_modules_aliases: set[str] = set()
+        self.stub_helper_aliases = set(STUB_INSTALL_HELPERS)
         self.violations: list[tuple[int, str]] = []
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -36,19 +39,32 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                     self.sys_aliases.add(alias.asname or alias.name)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if self.scope_depth == 0 and node.module == "sys":
+        if self.scope_depth == 0:
             for alias in node.names:
-                if alias.name == "modules":
-                    self.sys_modules_aliases.add(alias.asname or alias.name)
+                imported_name = alias.name
+                local_name = alias.asname or imported_name
+                if node.module == "sys" and imported_name == "modules":
+                    self.sys_modules_aliases.add(local_name)
+                if imported_name in STUB_INSTALL_HELPERS:
+                    self.stub_helper_aliases.add(local_name)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        self._visit_nested_scope(node)
+        self._visit_function_header(node)
+        self._visit_nested_body(node.body)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        self._visit_nested_scope(node)
+        self._visit_function_header(node)
+        self._visit_nested_body(node.body)
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
-        self._visit_nested_scope(node)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword)
+        for statement in node.body:
+            self.visit(statement)
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if self.scope_depth == 0:
@@ -86,11 +102,22 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                 )
         self.generic_visit(node)
 
-    def _visit_nested_scope(
-        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+    def _visit_function_header(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
     ) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_argument_defaults(node.args)
+
+    def _visit_argument_defaults(self, arguments: ast.arguments) -> None:
+        for default in [*arguments.defaults, *arguments.kw_defaults]:
+            if default is not None:
+                self.visit(default)
+
+    def _visit_nested_body(self, body: list[ast.stmt]) -> None:
         self.scope_depth += 1
-        self.generic_visit(node)
+        for statement in body:
+            self.visit(statement)
         self.scope_depth -= 1
 
     def _check_assignment_target(self, target: ast.expr) -> None:
@@ -114,7 +141,7 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
 
     def _is_stub_install_helper_call(self, node: ast.Call) -> bool:
         if isinstance(node.func, ast.Name):
-            return node.func.id in STUB_INSTALL_HELPERS
+            return node.func.id in self.stub_helper_aliases
         if isinstance(node.func, ast.Attribute):
             return node.func.attr in STUB_INSTALL_HELPERS
         return False
@@ -126,6 +153,94 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
             and isinstance(node.value, ast.Name)
             and node.value.id in self.sys_aliases
         ) or (isinstance(node, ast.Name) and node.id in self.sys_modules_aliases)
+
+
+def _violation_reasons(source: str) -> list[str]:
+    visitor = ImportTimeStubMutationVisitor()
+    visitor.visit(ast.parse(source))
+    return [reason for _line, reason in visitor.violations]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_reason"),
+    [
+        (
+            """
+import sys
+
+class StubContainer:
+    sys.modules["homeassistant"] = object()
+""",
+            "top-level sys.modules assignment",
+        ),
+        (
+            """
+import sys
+
+def test_stub(default=sys.modules.setdefault("aiohttp", object())):
+    pass
+""",
+            "top-level sys.modules mutation call",
+        ),
+        (
+            """
+import sys
+
+async def test_stub(default=sys.modules.setdefault("aiohttp", object())):
+    pass
+""",
+            "top-level sys.modules mutation call",
+        ),
+        (
+            """
+import sys
+
+class StubContainer:
+    def helper(self, default=sys.modules.setdefault("aiohttp", object())):
+        pass
+""",
+            "top-level sys.modules mutation call",
+        ),
+        (
+            """
+from sys import modules
+
+modules |= {"homeassistant": object()}
+""",
+            "top-level sys.modules reassignment",
+        ),
+        (
+            """
+from tests._ha_stubs import stub_homeassistant_package as install_ha
+
+install_ha()
+""",
+            "top-level stub installation helper call",
+        ),
+    ],
+)
+def test_import_time_stub_visitor_flags_reviewed_patterns(
+    source: str, expected_reason: str
+) -> None:
+    assert expected_reason in _violation_reasons(source)
+
+
+def test_import_time_stub_visitor_allows_function_scoped_setup() -> None:
+    source = """
+import sys
+from tests._ha_stubs import stub_homeassistant_package as install_ha
+
+def helper():
+    sys.modules["homeassistant"] = object()
+    sys.modules.setdefault("aiohttp", object())
+    install_ha()
+
+class StubContainer:
+    def helper(self, default=None):
+        sys.modules["homeassistant"] = object()
+"""
+
+    assert _violation_reasons(source) == []
 
 
 def test_tests_do_not_install_stubs_at_import_time() -> None:

--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -30,7 +30,6 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         self.sys_aliases = {"sys"}
         self.sys_modules_aliases: set[str] = set()
         self.stub_helper_aliases = set(STUB_INSTALL_HELPERS)
-        self.local_stub_wrappers: set[str] = set()
         self.violations: list[tuple[int, str]] = []
 
     def visit_Import(self, node: ast.Import) -> None:
@@ -50,14 +49,10 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                     self.stub_helper_aliases.add(local_name)
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
-        if self.scope_depth == 0 and self._function_body_has_import_time_stub(node):
-            self.local_stub_wrappers.add(node.name)
         self._visit_function_header(node)
         self._visit_nested_body(node.body)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
-        if self.scope_depth == 0 and self._function_body_has_import_time_stub(node):
-            self.local_stub_wrappers.add(node.name)
         self._visit_function_header(node)
         self._visit_nested_body(node.body)
 
@@ -109,10 +104,6 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
                 self.violations.append(
                     (node.lineno, "top-level stub installation helper call")
                 )
-            elif self._is_local_stub_wrapper_call(node):
-                self.violations.append(
-                    (node.lineno, "top-level local stub wrapper call")
-                )
         self.generic_visit(node)
 
     def _visit_function_header(
@@ -132,22 +123,6 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         for statement in body:
             self.visit(statement)
         self.scope_depth -= 1
-
-    def _function_body_has_import_time_stub(
-        self, node: ast.FunctionDef | ast.AsyncFunctionDef
-    ) -> bool:
-        visitor = self._copy_for_function_body()
-        for statement in node.body:
-            visitor.visit(statement)
-        return bool(visitor.violations)
-
-    def _copy_for_function_body(self) -> ImportTimeStubMutationVisitor:
-        visitor = ImportTimeStubMutationVisitor()
-        visitor.sys_aliases = set(self.sys_aliases)
-        visitor.sys_modules_aliases = set(self.sys_modules_aliases)
-        visitor.stub_helper_aliases = set(self.stub_helper_aliases)
-        visitor.local_stub_wrappers = set(self.local_stub_wrappers)
-        return visitor
 
     def _track_sys_modules_alias(
         self, target: ast.expr, value: ast.expr | None
@@ -184,12 +159,6 @@ class ImportTimeStubMutationVisitor(ast.NodeVisitor):
         if isinstance(node.func, ast.Attribute):
             return node.func.attr in STUB_INSTALL_HELPERS
         return False
-
-    def _is_local_stub_wrapper_call(self, node: ast.Call) -> bool:
-        return (
-            isinstance(node.func, ast.Name)
-            and node.func.id in self.local_stub_wrappers
-        )
 
     def _is_sys_modules(self, node: ast.expr) -> bool:
         return (
@@ -289,17 +258,6 @@ sys_modules = sys.modules
 sys_modules.setdefault("aiohttp", object())
 """,
             "top-level sys.modules mutation call",
-        ),
-        (
-            """
-from tests._ha_stubs import stub_homeassistant_package
-
-def setup_stubs():
-    stub_homeassistant_package()
-
-setup_stubs()
-""",
-            "top-level local stub wrapper call",
         ),
     ],
 )


### PR DESCRIPTION
### Closed in favor of a smaller replacement PR

This PR became too broad while trying to cover many AST edge cases. The original intent was useful, but the implementation started drifting toward a custom linter.

Closing this in favor of a smaller, focused hygiene guard that only blocks the concrete import-time stub patterns this cleanup originally wanted to prevent.