### PR TITLE
Refactor util tests to fixture-scoped imports

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,88 +1,39 @@
 """Tests for shared utilities."""
 
+import importlib
 import sys
-import types
-from pathlib import Path
+from collections.abc import Iterator
+from types import ModuleType
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-_SENTINEL = object()
+from tests._ha_stubs import clear_integration_modules, stub_custom_components_packages
 
 
-def _set_module(
-    snapshot: dict[str, object], name: str, module: types.ModuleType
-) -> None:
-    """Set a temporary module while preserving its previous value."""
+@pytest.fixture
+def util_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
+    """Import util.py with local package stubs scoped to each test."""
 
-    snapshot.setdefault(name, sys.modules.get(name, _SENTINEL))
-    sys.modules[name] = module
+    clear_integration_modules(monkeypatch=monkeypatch)
+    stub_custom_components_packages(monkeypatch=monkeypatch)
 
-
-def _restore_modules(snapshot: dict[str, object]) -> None:
-    """Restore modules changed only for importing the util module under test."""
-
-    for name, module in reversed(snapshot.items()):
-        if module is _SENTINEL:
-            sys.modules.pop(name, None)
-        else:
-            sys.modules[name] = module  # type: ignore[assignment]
-
-
-def _install_util_import_stubs() -> dict[str, object]:
-    """Install package stubs required to import util.py directly."""
-
-    snapshot: dict[str, object] = {}
-
-    custom_components_pkg = types.ModuleType("custom_components")
-    custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
-    _set_module(snapshot, "custom_components", custom_components_pkg)
-
-    pollenlevels_pkg = types.ModuleType("custom_components.pollenlevels")
-    pollenlevels_pkg.__path__ = [str(ROOT / "custom_components" / "pollenlevels")]
-    _set_module(snapshot, "custom_components.pollenlevels", pollenlevels_pkg)
-
-    for name in (
-        "custom_components.pollenlevels.const",
-        "custom_components.pollenlevels.util",
-    ):
-        snapshot.setdefault(name, sys.modules.get(name, _SENTINEL))
-
-    return snapshot
-
-
-def _import_util_module() -> types.ModuleType:
-    """Import util.py with local stubs and avoid leaking them globally."""
-
-    snapshot = _install_util_import_stubs()
+    imported_util = importlib.import_module("custom_components.pollenlevels.util")
     try:
-        from custom_components.pollenlevels import util as imported_util
-
-        return imported_util
+        yield imported_util
     finally:
         pollenlevels_pkg = sys.modules.get("custom_components.pollenlevels")
         if pollenlevels_pkg is not None and hasattr(pollenlevels_pkg, "util"):
             delattr(pollenlevels_pkg, "util")
-        _restore_modules(snapshot)
+        clear_integration_modules()
 
 
-util_mod = _import_util_module()
-redact_api_key = util_mod.redact_api_key
-redact_sensitive_values = util_mod.redact_sensitive_values
-safe_parse_int = util_mod.safe_parse_int
-parse_finite_float = util_mod.parse_finite_float
-validate_latitude = util_mod.validate_latitude
-validate_location_pair = util_mod.validate_location_pair
-validate_longitude = util_mod.validate_longitude
-
-
-def test_redact_api_key_handles_non_utf8_bytes():
+def test_redact_api_key_handles_non_utf8_bytes(util_module):
     """Bytes payloads with invalid UTF-8 are decoded with replacement and redacted."""
 
     api_key = "SECRET"
     payload = b"\xff" + api_key.encode() + b"\xfe"
 
-    redacted = redact_api_key(payload, api_key)
+    redacted = util_module.redact_api_key(payload, api_key)
 
     assert "SECRET" not in redacted
     assert "***" in redacted
@@ -90,41 +41,47 @@ def test_redact_api_key_handles_non_utf8_bytes():
     assert "\ufffd" in redacted
 
 
-def test_redact_api_key_returns_empty_string_for_none():
+def test_redact_api_key_returns_empty_string_for_none(util_module):
     """None inputs should yield an empty string."""
 
-    assert redact_api_key(None, "anything") == ""
+    assert util_module.redact_api_key(None, "anything") == ""
 
 
-def test_redact_sensitive_values_returns_empty_string_for_none():
+def test_redact_sensitive_values_returns_empty_string_for_none(util_module):
     """None inputs should yield an empty string."""
 
-    assert redact_sensitive_values(None, api_key="SECRET") == ""
+    assert util_module.redact_sensitive_values(None, api_key="SECRET") == ""
 
 
-def test_redact_sensitive_values_redacts_exact_api_key():
+def test_redact_sensitive_values_redacts_exact_api_key(util_module):
     """Exact API key values should be redacted."""
 
-    redacted = redact_sensitive_values("API key SECRET failed", api_key="SECRET")
+    redacted = util_module.redact_sensitive_values(
+        "API key SECRET failed", api_key="SECRET"
+    )
 
     assert "SECRET" not in redacted
     assert "***" in redacted
 
 
-def test_redact_sensitive_values_redacts_unquoted_key_query_parameter():
+def test_redact_sensitive_values_redacts_unquoted_key_query_parameter(util_module):
     """Unquoted key query parameters should have their values redacted."""
 
-    redacted = redact_sensitive_values("https://example.test/?key=bad-key&days=5")
+    redacted = util_module.redact_sensitive_values(
+        "https://example.test/?key=bad-key&days=5"
+    )
 
     assert "bad-key" not in redacted
     assert "key=***" in redacted
     assert "days=5" in redacted
 
 
-def test_redact_sensitive_values_redacts_quoted_key_query_parameters():
+def test_redact_sensitive_values_redacts_quoted_key_query_parameters(util_module):
     """Quoted key parameters should be redacted while preserving quotes."""
 
-    redacted = redact_sensitive_values("key=\"secret-one\" key='secret-two'")
+    redacted = util_module.redact_sensitive_values(
+        "key=\"secret-one\" key='secret-two'"
+    )
 
     assert 'key="***"' in redacted
     assert "key='***'" in redacted
@@ -132,19 +89,21 @@ def test_redact_sensitive_values_redacts_quoted_key_query_parameters():
     assert "secret-two" not in redacted
 
 
-def test_redact_sensitive_values_redacts_urlencoded_unquoted_key_parameter():
+def test_redact_sensitive_values_redacts_urlencoded_unquoted_key_parameter(util_module):
     """URL-encoded key parameters should have their values redacted."""
 
-    redacted = redact_sensitive_values("https://example.test/?key%3Dsecret-three")
+    redacted = util_module.redact_sensitive_values(
+        "https://example.test/?key%3Dsecret-three"
+    )
 
     assert "key%3D***" in redacted
     assert "secret-three" not in redacted
 
 
-def test_redact_sensitive_values_redacts_coordinate_query_parameters():
+def test_redact_sensitive_values_redacts_coordinate_query_parameters(util_module):
     """Coordinate query parameters should have their values redacted."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "location.latitude=40.4168&location.longitude=-3.7038&days=5"
     )
 
@@ -155,10 +114,10 @@ def test_redact_sensitive_values_redacts_coordinate_query_parameters():
     assert "days=5" in redacted
 
 
-def test_redact_sensitive_values_redacts_url_encoded_coordinate_parameters():
+def test_redact_sensitive_values_redacts_url_encoded_coordinate_parameters(util_module):
     """URL-encoded coordinate parameters should have their values redacted."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "location.latitude%3D40.4168&location.longitude%3D-3.7038"
     )
 
@@ -168,10 +127,10 @@ def test_redact_sensitive_values_redacts_url_encoded_coordinate_parameters():
     assert "location.longitude%3D***" in redacted
 
 
-def test_redact_sensitive_values_redacts_explicit_coordinates():
+def test_redact_sensitive_values_redacts_explicit_coordinates(util_module):
     """Explicit coordinate values should be redacted when they appear in text."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "Coordinates 40.416800 and -3.703800 failed",
         latitude=40.4168,
         longitude=-3.7038,
@@ -182,10 +141,10 @@ def test_redact_sensitive_values_redacts_explicit_coordinates():
     assert redacted.count("***") == 2
 
 
-def test_redact_sensitive_values_redacts_single_quoted_url_assignment():
+def test_redact_sensitive_values_redacts_single_quoted_url_assignment(util_module):
     """Single-quoted URL assignment should keep quotes while redacting URL contents."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "url='https://example.test/pollen?token=secret-token&key=bad-key'"
     )
 
@@ -195,10 +154,10 @@ def test_redact_sensitive_values_redacts_single_quoted_url_assignment():
     assert "key=bad-key" not in redacted
 
 
-def test_redact_sensitive_values_redacts_double_quoted_url_assignment():
+def test_redact_sensitive_values_redacts_double_quoted_url_assignment(util_module):
     """Double-quoted URL assignment should keep quotes while redacting URL contents."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         'url="https://example.test/pollen?token=secret-token&api_key=secret-token"',
         api_key="secret-token",
     )
@@ -209,10 +168,10 @@ def test_redact_sensitive_values_redacts_double_quoted_url_assignment():
     assert "api_key=secret-token" not in redacted
 
 
-def test_redact_sensitive_values_redacts_unquoted_url_assignment():
+def test_redact_sensitive_values_redacts_unquoted_url_assignment(util_module):
     """Unquoted URL assignment should be redacted without exposing query values."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "url=https://example.test/pollen?token=abc&key=bad-key&api_key=zzz&days=3"
     )
 
@@ -223,10 +182,12 @@ def test_redact_sensitive_values_redacts_unquoted_url_assignment():
     assert "api_key=zzz" not in redacted
 
 
-def test_redact_sensitive_values_redacts_payload_line_without_swallowing_following_lines():
+def test_redact_sensitive_values_redacts_payload_line_without_swallowing_following_lines(
+    util_module,
+):
     """Payload line is redacted while later lines are still independently sanitized."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         "payload=line1\nkey=abc123\nlocation.latitude=40.4168",
         latitude=40.4168,
     )
@@ -239,10 +200,10 @@ def test_redact_sensitive_values_redacts_payload_line_without_swallowing_followi
     assert "location.latitude=***" in redacted
 
 
-def test_redact_sensitive_values_preserves_unrelated_numbers():
+def test_redact_sensitive_values_preserves_unrelated_numbers(util_module):
     """Unrelated numbers should not be redacted."""
 
-    redacted = redact_sensitive_values("HTTP 400 days=5 Retry-After: 30")
+    redacted = util_module.redact_sensitive_values("HTTP 400 days=5 Retry-After: 30")
 
     assert redacted == "HTTP 400 days=5 Retry-After: 30"
 
@@ -256,25 +217,29 @@ def test_redact_sensitive_values_preserves_unrelated_numbers():
     ],
 )
 def test_redact_sensitive_values_does_not_redact_partial_integer_coordinates(
-    message, latitude
+    util_module, message, latitude
 ):
     """Explicit integer coordinates should not redact partial numeric matches."""
 
-    assert redact_sensitive_values(message, latitude=latitude) == message
+    assert util_module.redact_sensitive_values(message, latitude=latitude) == message
 
 
 @pytest.mark.parametrize("message", ["value 140.0", "value 40.01"])
-def test_redact_sensitive_values_does_not_redact_partial_decimal_coordinates(message):
+def test_redact_sensitive_values_does_not_redact_partial_decimal_coordinates(
+    util_module, message
+):
     """Explicit decimal coordinates should not redact partial decimal matches."""
 
-    assert redact_sensitive_values(message, latitude=40.0) == message
+    assert util_module.redact_sensitive_values(message, latitude=40.0) == message
 
 
 @pytest.mark.parametrize("coordinate", ["40.0", "40.000000"])
-def test_redact_sensitive_values_still_redacts_exact_coordinate_values(coordinate):
+def test_redact_sensitive_values_still_redacts_exact_coordinate_values(
+    util_module, coordinate
+):
     """Exact explicit coordinate values should still be redacted."""
 
-    redacted = redact_sensitive_values(
+    redacted = util_module.redact_sensitive_values(
         f"Coordinates {coordinate} failed", latitude=40.0
     )
 
@@ -298,10 +263,10 @@ def test_redact_sensitive_values_still_redacts_exact_coordinate_values(coordinat
         ("inf", None),
     ],
 )
-def test_safe_parse_int(value, expected):
+def test_safe_parse_int(util_module, value, expected):
     """safe_parse_int accepts integer-like values and rejects invalid input."""
 
-    assert safe_parse_int(value) == expected
+    assert util_module.safe_parse_int(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -313,67 +278,70 @@ def test_safe_parse_int(value, expected):
         (" -3 ", -3.0),
     ],
 )
-def test_parse_finite_float_accepts_numeric_values(value, expected):
+def test_parse_finite_float_accepts_numeric_values(util_module, value, expected):
     """parse_finite_float returns normalized floats for finite numeric input."""
 
-    assert parse_finite_float(value) == expected
+    assert util_module.parse_finite_float(value) == expected
 
 
 @pytest.mark.parametrize(
     "value",
     [None, True, False, "not-a-number", "nan", "inf", float("nan"), float("inf")],
 )
-def test_parse_finite_float_rejects_invalid_values(value):
+def test_parse_finite_float_rejects_invalid_values(util_module, value):
     """parse_finite_float rejects bools, empty values, and non-finite numbers."""
 
-    assert parse_finite_float(value) is None
+    assert util_module.parse_finite_float(value) is None
 
 
 @pytest.mark.parametrize("value", [-90, -90.0, "-90", 0, "12.5", 90, "90"])
-def test_validate_latitude_accepts_valid_values(value):
+def test_validate_latitude_accepts_valid_values(util_module, value):
     """validate_latitude accepts numeric and numeric-string values in range."""
 
-    assert validate_latitude(value) == float(value)
+    assert util_module.validate_latitude(value) == float(value)
 
 
 @pytest.mark.parametrize("value", [-180, -180.0, "-180", 0, "12.5", 180, "180"])
-def test_validate_longitude_accepts_valid_values(value):
+def test_validate_longitude_accepts_valid_values(util_module, value):
     """validate_longitude accepts numeric and numeric-string values in range."""
 
-    assert validate_longitude(value) == float(value)
+    assert util_module.validate_longitude(value) == float(value)
 
 
 @pytest.mark.parametrize(
     "value",
     [None, True, False, "not-a-number", "nan", "inf", -90.1, 90.1],
 )
-def test_validate_latitude_rejects_invalid_values(value):
+def test_validate_latitude_rejects_invalid_values(util_module, value):
     """validate_latitude rejects invalid, non-finite, and out-of-range values."""
 
-    assert validate_latitude(value) is None
+    assert util_module.validate_latitude(value) is None
 
 
 @pytest.mark.parametrize(
     "value",
     [None, True, False, "not-a-number", "nan", "inf", -180.1, 180.1],
 )
-def test_validate_longitude_rejects_invalid_values(value):
+def test_validate_longitude_rejects_invalid_values(util_module, value):
     """validate_longitude rejects invalid, non-finite, and out-of-range values."""
 
-    assert validate_longitude(value) is None
+    assert util_module.validate_longitude(value) is None
 
 
-def test_validate_location_pair_accepts_valid_pair():
+def test_validate_location_pair_accepts_valid_pair(util_module):
     """validate_location_pair returns normalized floats for valid coordinates."""
 
-    assert validate_location_pair("40.4168", "-3.7038") == (40.4168, -3.7038)
+    assert util_module.validate_location_pair("40.4168", "-3.7038") == (
+        40.4168,
+        -3.7038,
+    )
 
 
 @pytest.mark.parametrize(
     ("latitude", "longitude"),
     [(None, 1), (1, None), (91, 1), (1, 181), (True, 1), (1, "bad")],
 )
-def test_validate_location_pair_rejects_invalid_pair(latitude, longitude):
+def test_validate_location_pair_rejects_invalid_pair(util_module, latitude, longitude):
     """validate_location_pair rejects pairs with any invalid coordinate."""
 
-    assert validate_location_pair(latitude, longitude) is None
+    assert util_module.validate_location_pair(latitude, longitude) is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,6 +24,8 @@ def util_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
         pollenlevels_pkg = sys.modules.get("custom_components.pollenlevels")
         if pollenlevels_pkg is not None and hasattr(pollenlevels_pkg, "util"):
             delattr(pollenlevels_pkg, "util")
+        # Do not use monkeypatch here: these modules were imported during the
+        # test and must be removed instead of registered for later restoration.
         clear_integration_modules()
 
 


### PR DESCRIPTION
### Motivation
- Remove the module-level import-time loading of `custom_components.pollenlevels.util` from `tests/test_util.py` so tests import the integration util module in a fixture scope and avoid import-time coupling. 
- Reuse the existing lightweight Home Assistant test stubs to keep test scaffolding consistent with other suites and to make integration-module cleanup deterministic.

### Description
- Add a `util_module` pytest fixture that calls `clear_integration_modules` and `stub_custom_components_packages`, imports `custom_components.pollenlevels.util`, yields the imported module, and performs cleanup after each test. 
- Replace the previous import helpers and module-level aliases with test usage like `util_module.redact_sensitive_values(...)` and `util_module.safe_parse_int(...)`. 
- Remove the local snapshot/restore helpers and module-level `util_mod` alias, reducing import-time mutation of `sys.modules`. 
- No runtime/integration source files were modified; only `tests/test_util.py` was changed.

### Testing
- Ran `python -m compileall -q custom_components tests` and it completed successfully. 
- Ran `ruff check .` (and `ruff check --fix --select I` where applicable) and there were no lint failures. 
- Ran `black --check .` (and `black` to reformat the test) and formatting checks passed. 
- Ran `pytest -q tests/test_util.py` and the file's tests passed (`82 passed`). 
- Ran `pytest -q tests/test_stub_hygiene.py` and it passed (`1 passed`). 
- Ran the full test suite with `pytest -q` and it completed successfully (`311 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c744693188324b3e04d1c8f4b610f)