### PR TITLE
Centralize Home Assistant selector stubs in test helpers and update tests to use them

### DIFF
--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -95,6 +95,120 @@ def stub_custom_components_packages(
     )
 
 
+class StubLocationSelectorConfig:
+    """Minimal location selector config stub."""
+
+    def __init__(self, *, radius: bool | None = None) -> None:
+        self.radius = radius
+
+
+class StubLocationSelector:
+    """Minimal location selector stub."""
+
+    def __init__(self, config: StubLocationSelectorConfig) -> None:
+        self.config = config
+
+
+class StubNumberSelectorConfig:
+    """Minimal number selector config stub."""
+
+    def __init__(
+        self,
+        *,
+        min: float | None = None,
+        max: float | None = None,
+        step: float | None = None,
+        mode: str | None = None,
+        unit_of_measurement: str | None = None,
+    ) -> None:
+        self.min = min
+        self.max = max
+        self.step = step
+        self.mode = mode
+        self.unit_of_measurement = unit_of_measurement
+
+
+class StubNumberSelectorMode:
+    """Minimal number selector mode stub."""
+
+    BOX = "BOX"
+
+
+class StubNumberSelector:
+    """Minimal number selector stub."""
+
+    def __init__(self, config: StubNumberSelectorConfig) -> None:
+        self.config = config
+
+
+class StubTextSelectorConfig:
+    """Minimal text selector config stub."""
+
+    def __init__(self, *, type: str | None = None) -> None:  # noqa: A003
+        self.type = type
+
+
+class StubTextSelectorType:
+    """Minimal text selector type stub."""
+
+    TEXT = "TEXT"
+    PASSWORD = "PASSWORD"
+
+
+class StubTextSelector:
+    """Minimal text selector stub."""
+
+    def __init__(self, config: StubTextSelectorConfig) -> None:
+        self.config = config
+
+
+class StubSelectSelectorConfig:
+    """Minimal select selector config stub."""
+
+    def __init__(self, *, mode: str | None = None, options=None) -> None:
+        self.mode = mode
+        self.options = options
+
+
+class StubSelectSelectorMode:
+    """Minimal select selector mode stub."""
+
+    DROPDOWN = "DROPDOWN"
+
+
+class StubSelectSelector:
+    """Minimal select selector stub."""
+
+    def __init__(self, config: StubSelectSelectorConfig) -> None:
+        self.config = config
+
+
+def stub_selector_module(
+    *,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    include_section: bool = False,
+) -> ModuleType:
+    """Install a lightweight ``homeassistant.helpers.selector`` stub module."""
+
+    module = ModuleType("homeassistant.helpers.selector")
+    module.LocationSelector = StubLocationSelector
+    module.LocationSelectorConfig = StubLocationSelectorConfig
+    module.NumberSelector = StubNumberSelector
+    module.NumberSelectorConfig = StubNumberSelectorConfig
+    module.NumberSelectorMode = StubNumberSelectorMode
+    module.TextSelector = StubTextSelector
+    module.TextSelectorConfig = StubTextSelectorConfig
+    module.TextSelectorType = StubTextSelectorType
+    module.SelectSelector = StubSelectSelector
+    module.SelectSelectorConfig = StubSelectSelectorConfig
+    module.SelectSelectorMode = StubSelectSelectorMode
+    if include_section:
+        module.section = lambda key: key
+    return _set_module(
+        "homeassistant.helpers.selector", module, monkeypatch=monkeypatch
+    )
+
+
 def stub_config_entry_class(
     cls: type[object], *, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> ModuleType:

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -165,7 +165,7 @@ class StubTextSelector:
 class StubSelectSelectorConfig:
     """Minimal select selector config stub."""
 
-    def __init__(self, *, mode: str | None = None, options=None) -> None:
+    def __init__(self, *, mode: str | None = None, options: list | None = None) -> None:
         self.mode = mode
         self.options = options
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -22,6 +22,7 @@ from tests._ha_stubs import (
     stub_custom_components_packages,
     stub_exceptions,
     stub_homeassistant_package,
+    stub_selector_module,
     stub_update_coordinator_module,
 )
 
@@ -128,72 +129,6 @@ def _parse_http_date(value: str):
         return None
 
 
-class _LocationSelectorConfig:
-    def __init__(self, *, radius: bool | None = None):
-        self.radius = radius
-
-
-class _LocationSelector:
-    def __init__(self, config: _LocationSelectorConfig):
-        self.config = config
-
-
-class _NumberSelectorConfig:
-    def __init__(
-        self,
-        *,
-        min: float | None = None,
-        max: float | None = None,
-        step: float | None = None,
-        mode: str | None = None,
-        unit_of_measurement: str | None = None,
-    ) -> None:
-        self.min = min
-        self.max = max
-        self.step = step
-        self.mode = mode
-        self.unit_of_measurement = unit_of_measurement
-
-
-class _NumberSelectorMode:
-    BOX = "BOX"
-
-
-class _NumberSelector:
-    def __init__(self, config: _NumberSelectorConfig):
-        self.config = config
-
-
-class _TextSelectorConfig:
-    def __init__(self, *, type: str | None = None):  # noqa: A003
-        self.type = type
-
-
-class _TextSelectorType:
-    TEXT = "TEXT"
-    PASSWORD = "PASSWORD"
-
-
-class _TextSelector:
-    def __init__(self, config: _TextSelectorConfig):
-        self.config = config
-
-
-class _SelectSelectorConfig:
-    def __init__(self, *, mode: str | None = None, options=None):
-        self.mode = mode
-        self.options = options
-
-
-class _SelectSelectorMode:
-    DROPDOWN = "DROPDOWN"
-
-
-class _SelectSelector:
-    def __init__(self, config: _SelectSelectorConfig):
-        self.config = config
-
-
 class _StubInvalid(Exception):
     def __init__(self, error_message=""):
         super().__init__(error_message)
@@ -298,20 +233,7 @@ def _install_homeassistant_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
     monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
 
-    selector_mod = ModuleType("homeassistant.helpers.selector")
-    selector_mod.LocationSelector = _LocationSelector
-    selector_mod.LocationSelectorConfig = _LocationSelectorConfig
-    selector_mod.NumberSelector = _NumberSelector
-    selector_mod.NumberSelectorConfig = _NumberSelectorConfig
-    selector_mod.NumberSelectorMode = _NumberSelectorMode
-    selector_mod.TextSelector = _TextSelector
-    selector_mod.TextSelectorConfig = _TextSelectorConfig
-    selector_mod.TextSelectorType = _TextSelectorType
-    selector_mod.SelectSelector = _SelectSelector
-    selector_mod.SelectSelectorConfig = _SelectSelectorConfig
-    selector_mod.SelectSelectorMode = _SelectSelectorMode
-    selector_mod.section = lambda key: key
-    monkeypatch.setitem(sys.modules, "homeassistant.helpers.selector", selector_mod)
+    stub_selector_module(monkeypatch=monkeypatch, include_section=True)
 
     ha_mod.helpers = helpers_mod
     ha_mod.config_entries = config_entries_mod

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -20,6 +20,7 @@ from tests._ha_stubs import (
     stub_custom_components_packages,
     stub_exceptions,
     stub_homeassistant_package,
+    stub_selector_module,
     stub_update_coordinator_module,
 )
 
@@ -145,75 +146,7 @@ def options_flow_env(monkeypatch: pytest.MonkeyPatch) -> OptionsFlowEnv:
     monkeypatch.setitem(sys_modules, "homeassistant.util", util_mod)
     monkeypatch.setitem(sys_modules, "homeassistant.util.dt", dt_mod)
 
-    selector_mod = ModuleType("homeassistant.helpers.selector")
-
-    class LocationSelectorConfig:
-        def __init__(self, *, radius: bool | None = None):
-            self.radius = radius
-
-    class LocationSelector:
-        def __init__(self, config: LocationSelectorConfig):
-            self.config = config
-
-    class NumberSelectorConfig:
-        def __init__(
-            self,
-            *,
-            min: float | None = None,
-            max: float | None = None,
-            step: float | None = None,
-            mode: str | None = None,
-            unit_of_measurement: str | None = None,
-        ) -> None:
-            self.min = min
-            self.max = max
-            self.step = step
-            self.mode = mode
-            self.unit_of_measurement = unit_of_measurement
-
-    class NumberSelectorMode:
-        BOX = "BOX"
-
-    class NumberSelector:
-        def __init__(self, config: NumberSelectorConfig):
-            self.config = config
-
-    class TextSelectorConfig:
-        def __init__(self, *, type: str | None = None):  # noqa: A003
-            self.type = type
-
-    class TextSelectorType:
-        TEXT = "TEXT"
-        PASSWORD = "PASSWORD"
-
-    class TextSelector:
-        def __init__(self, config: TextSelectorConfig):
-            self.config = config
-
-    class SelectSelectorConfig:
-        def __init__(self, *, mode: str | None = None, options=None):
-            self.mode = mode
-            self.options = options
-
-    class SelectSelectorMode:
-        DROPDOWN = "DROPDOWN"
-
-    class SelectSelector:
-        def __init__(self, config: SelectSelectorConfig):
-            self.config = config
-
-    selector_mod.LocationSelector = LocationSelector
-    selector_mod.LocationSelectorConfig = LocationSelectorConfig
-    selector_mod.NumberSelector = NumberSelector
-    selector_mod.NumberSelectorConfig = NumberSelectorConfig
-    selector_mod.NumberSelectorMode = NumberSelectorMode
-    selector_mod.TextSelector = TextSelector
-    selector_mod.TextSelectorConfig = TextSelectorConfig
-    selector_mod.TextSelectorType = TextSelectorType
-    selector_mod.SelectSelector = SelectSelector
-    selector_mod.SelectSelectorConfig = SelectSelectorConfig
-    selector_mod.SelectSelectorMode = SelectSelectorMode
-    monkeypatch.setitem(sys_modules, "homeassistant.helpers.selector", selector_mod)
+    stub_selector_module(monkeypatch=monkeypatch)
 
     ha_mod.helpers = helpers_mod
     ha_mod.config_entries = config_entries_mod


### PR DESCRIPTION
### Motivation

- Consolidate duplicated minimal `homeassistant.helpers.selector` stubs into a single shared helper to reduce duplication and make selector stubbing reusable across tests.

### Description

- Add lightweight selector stub classes and a helper function `stub_selector_module` to `tests/_ha_stubs.py` that provide `LocationSelector`, `NumberSelector`, `TextSelector`, `SelectSelector` and related config and mode classes, and optional `section` support via `include_section`.
- Replace inline selector stub definitions in `tests/test_config_flow.py` and `tests/test_options_flow.py` with calls to `stub_selector_module` (passing `include_section=True` where the `section` helper was previously required).
- Remove the duplicated selector class definitions from the two test modules so the shared helper provides the stubs.

### Testing

- Ran `pytest tests/test_config_flow.py` and `pytest tests/test_options_flow.py` against the modified code and both test files completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7f82e6f88324ae69f307de0fefb6)