### PR TITLE
Add shared `stub_util_dt_module` to consolidate Home Assistant datetime test stubs

### DIFF
--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -209,6 +209,44 @@ def stub_selector_module(
     )
 
 
+def stub_util_dt_module(*, monkeypatch: pytest.MonkeyPatch | None = None) -> ModuleType:
+    """Install lightweight ``homeassistant.util`` and ``homeassistant.util.dt`` stubs."""
+
+    util_mod = ModuleType("homeassistant.util")
+    dt_mod = ModuleType("homeassistant.util.dt")
+
+    def _stub_utcnow():
+        from datetime import UTC, datetime
+
+        return datetime.now(UTC)
+
+    def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
+        from datetime import UTC, datetime
+        from email.utils import parsedate_to_datetime
+
+        try:
+            parsed = parsedate_to_datetime(value) if value is not None else None
+        except TypeError, ValueError, IndexError, OverflowError:
+            return None
+
+        if parsed is None:
+            return None
+
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+
+        if isinstance(parsed, datetime):
+            return parsed
+
+        return None
+
+    dt_mod.utcnow = _stub_utcnow
+    dt_mod.parse_http_date = _stub_parse_http_date
+    util_mod.dt = dt_mod
+    _set_module("homeassistant.util", util_mod, monkeypatch=monkeypatch)
+    return _set_module("homeassistant.util.dt", dt_mod, monkeypatch=monkeypatch)
+
+
 def stub_config_entry_class(
     cls: type[object], *, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> ModuleType:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -18,6 +17,7 @@ from tests._ha_stubs import (
     stub_exceptions,
     stub_homeassistant_package,
     stub_update_coordinator_module,
+    stub_util_dt_module,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -53,13 +53,7 @@ def client_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
         coordinator_entity=object,
     )
 
-    util_mod = ModuleType("homeassistant.util")
-    dt_mod = ModuleType("homeassistant.util.dt")
-    dt_mod.parse_http_date = lambda _value: None
-    dt_mod.utcnow = lambda: datetime.now(UTC)
-    util_mod.dt = dt_mod
-    monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
-    monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
+    stub_util_dt_module(monkeypatch=monkeypatch)
 
     imported_client = importlib.import_module("custom_components.pollenlevels.client")
     yield imported_client

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,11 +6,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
-import email.utils
 import importlib
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -24,6 +22,7 @@ from tests._ha_stubs import (
     stub_homeassistant_package,
     stub_selector_module,
     stub_update_coordinator_module,
+    stub_util_dt_module,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -122,13 +121,6 @@ class _StubCoordinatorEntity:
         self.coordinator = coordinator
 
 
-def _parse_http_date(value: str):
-    try:
-        return email.utils.parsedate_to_datetime(value)
-    except TypeError, ValueError, IndexError, OverflowError:
-        return None
-
-
 class _StubInvalid(Exception):
     def __init__(self, error_message=""):
         super().__init__(error_message)
@@ -225,13 +217,7 @@ def _install_homeassistant_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch=monkeypatch,
     )
 
-    util_mod = ModuleType("homeassistant.util")
-    dt_mod = ModuleType("homeassistant.util.dt")
-    dt_mod.parse_http_date = _parse_http_date
-    dt_mod.utcnow = lambda: datetime.now(UTC)
-    util_mod.dt = dt_mod
-    monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
-    monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
+    stub_util_dt_module(monkeypatch=monkeypatch)
 
     stub_selector_module(monkeypatch=monkeypatch, include_section=True)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from tests._ha_stubs import (
     stub_exceptions,
     stub_homeassistant_package,
     stub_update_coordinator_module,
+    stub_util_dt_module,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -111,33 +112,6 @@ class _StubDataUpdateCoordinator:
         return asyncio.create_task(self.async_refresh())
 
 
-def _stub_utcnow():
-    from datetime import UTC, datetime
-
-    return datetime.now(UTC)
-
-
-def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
-    from datetime import UTC, datetime
-    from email.utils import parsedate_to_datetime
-
-    try:
-        parsed = parsedate_to_datetime(value) if value is not None else None
-    except TypeError, ValueError, IndexError:
-        return None
-
-    if parsed is None:
-        return None
-
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-
-    if isinstance(parsed, datetime):
-        return parsed
-
-    return None
-
-
 def _stub_async_get(_hass):  # pragma: no cover - structure only
     class _Registry:
         @staticmethod
@@ -199,14 +173,7 @@ def stub_init_ha_modules(monkeypatch: pytest.MonkeyPatch) -> None:
     entity_mod = types.ModuleType("homeassistant.helpers.entity")
     entity_mod.EntityCategory = _StubEntityCategory
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity_mod)
-    dt_mod = types.ModuleType("homeassistant.util.dt")
-    dt_mod.utcnow = _stub_utcnow
-    dt_mod.parse_http_date = _stub_parse_http_date
-    monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
-
-    util_mod = types.ModuleType("homeassistant.util")
-    util_mod.dt = dt_mod
-    monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
+    stub_util_dt_module(monkeypatch=monkeypatch)
     stub_exceptions(
         ConfigEntryNotReady=_StubConfigEntryNotReady,
         ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import email.utils
 import importlib
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any
@@ -22,6 +20,7 @@ from tests._ha_stubs import (
     stub_homeassistant_package,
     stub_selector_module,
     stub_update_coordinator_module,
+    stub_util_dt_module,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -131,20 +130,7 @@ def options_flow_env(monkeypatch: pytest.MonkeyPatch) -> OptionsFlowEnv:
         monkeypatch=monkeypatch,
     )
 
-    util_mod = ModuleType("homeassistant.util")
-    dt_mod = ModuleType("homeassistant.util.dt")
-
-    def _parse_http_date(value: str):
-        try:
-            return email.utils.parsedate_to_datetime(value)
-        except TypeError, ValueError, IndexError, OverflowError:
-            return None
-
-    dt_mod.parse_http_date = _parse_http_date
-    dt_mod.utcnow = lambda: datetime.now(UTC)
-    util_mod.dt = dt_mod
-    monkeypatch.setitem(sys_modules, "homeassistant.util", util_mod)
-    monkeypatch.setitem(sys_modules, "homeassistant.util.dt", dt_mod)
+    stub_util_dt_module(monkeypatch=monkeypatch)
 
     stub_selector_module(monkeypatch=monkeypatch)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,6 +20,7 @@ from tests._ha_stubs import (
     stub_exceptions,
     stub_homeassistant_package,
     stub_update_coordinator_module,
+    stub_util_dt_module,
 )
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -191,43 +192,7 @@ def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch=monkeypatch,
     )
 
-    dt_mod = types.ModuleType("homeassistant.util.dt")
-
-    def _stub_utcnow():
-        """Return a timezone-aware UTC datetime, similar to Home Assistant."""
-
-        from datetime import UTC, datetime
-
-        return datetime.now(UTC)
-
-    dt_mod.utcnow = _stub_utcnow
-
-    def _stub_parse_http_date(value: str | None):  # pragma: no cover - stub only
-        from datetime import UTC, datetime
-        from email.utils import parsedate_to_datetime
-
-        try:
-            parsed = parsedate_to_datetime(value) if value is not None else None
-        except TypeError, ValueError, IndexError:
-            return None
-
-        if parsed is None:
-            return None
-
-        if parsed.tzinfo is None:
-            return parsed.replace(tzinfo=UTC)
-
-        if isinstance(parsed, datetime):
-            return parsed
-
-        return None
-
-    dt_mod.parse_http_date = _stub_parse_http_date
-    monkeypatch.setitem(sys.modules, "homeassistant.util.dt", dt_mod)
-
-    util_mod = types.ModuleType("homeassistant.util")
-    util_mod.dt = dt_mod
-    monkeypatch.setitem(sys.modules, "homeassistant.util", util_mod)
+    stub_util_dt_module(monkeypatch=monkeypatch)
 
     stub_aiohttp_module(monkeypatch=monkeypatch)
 


### PR DESCRIPTION
### Motivation
- Multiple tests replicated tiny `homeassistant.util` / `homeassistant.util.dt` fixtures (`utcnow`, `parse_http_date`) which duplicated logic and bloated test files.  
- Introduce a small, explicit helper to centralize that stub installation and make test stubs easier to maintain while preserving existing behavior.

### Description
- Added `stub_util_dt_module(*, monkeypatch: pytest.MonkeyPatch | None = None)` to `tests/_ha_stubs.py` which installs fresh `ModuleType` objects for `homeassistant.util` and `homeassistant.util.dt` and provides `utcnow` and `parse_http_date` implementations.  
- Replaced the duplicated fixture-local stubs in `tests/test_client.py`, `tests/test_init.py`, `tests/test_sensor.py`, `tests/test_config_flow.py`, and `tests/test_options_flow.py` with calls to `stub_util_dt_module(...)`.  
- No runtime or integration code was changed; only test files were modified (`tests/_ha_stubs.py` and the five test files above).  

### Testing
- Ran `python -m compileall -q custom_components tests`, `ruff check .`, and `black --check .` which all passed.  
- Executed targeted pytest runs for the modified tests and the test hygiene check: `pytest -q tests/test_client.py`, `pytest -q tests/test_init.py`, `pytest -q tests/test_sensor.py`, `pytest -q tests/test_config_flow.py`, `pytest -q tests/test_options_flow.py`, and `pytest -q tests/test_stub_hygiene.py`, all of which passed.  
- Ran the full test suite; all tests passed (`311 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c936d3c14832485dafc5e987c83ab)