### PR TITLE
Clean up shared Home Assistant test stubs

### DIFF
--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -43,9 +43,18 @@ def stub_aiohttp_module(
     return _set_module("aiohttp", module, monkeypatch=monkeypatch)
 
 
-def force_module(name: str, module: ModuleType) -> ModuleType:
-    """Force a module into ``sys.modules`` and return it."""
+def force_module(
+    name: str, module: ModuleType, *, monkeypatch: pytest.MonkeyPatch | None = None
+) -> ModuleType:
+    """Install ``module`` into ``sys.modules`` and return it.
 
+    Prefer passing ``monkeypatch`` from fixtures so pytest restores any previous
+    module after the test. Omitting it intentionally performs a direct install.
+    """
+
+    if monkeypatch is not None:
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
     sys.modules[name] = module
     return module
 
@@ -56,10 +65,7 @@ def _set_module(
     # Intentionally replace target modules to keep stubs deterministic and avoid
     # import-order coupling across suites. Fixtures can pass monkeypatch so
     # teardown restores previous state automatically.
-    if monkeypatch is not None:
-        monkeypatch.setitem(sys.modules, name, module)
-        return module
-    return force_module(name, module)
+    return force_module(name, module, monkeypatch=monkeypatch)
 
 
 def stub_homeassistant_package(
@@ -250,6 +256,8 @@ def stub_util_dt_module(*, monkeypatch: pytest.MonkeyPatch | None = None) -> Mod
 def stub_config_entry_class(
     cls: type[object], *, monkeypatch: pytest.MonkeyPatch | None = None
 ) -> ModuleType:
+    """Install a minimal ``homeassistant.config_entries`` module."""
+
     module = ModuleType("homeassistant.config_entries")
     module.ConfigEntry = cls
     _set_module("homeassistant.config_entries", module, monkeypatch=monkeypatch)
@@ -261,6 +269,8 @@ def stub_exceptions(
     monkeypatch: pytest.MonkeyPatch | None = None,
     **exception_types: type[Exception],
 ) -> ModuleType:
+    """Install a minimal ``homeassistant.exceptions`` module."""
+
     module = ModuleType("homeassistant.exceptions")
     for name, exc in exception_types.items():
         setattr(module, name, exc)
@@ -275,6 +285,8 @@ def stub_update_coordinator_module(
     coordinator_entity: type[object],
     monkeypatch: pytest.MonkeyPatch | None = None,
 ) -> ModuleType:
+    """Install a minimal update coordinator module with caller-provided types."""
+
     module = ModuleType("homeassistant.helpers.update_coordinator")
     module.UpdateFailed = update_failed
     module.DataUpdateCoordinator = data_update_coordinator


### PR DESCRIPTION
### Motivation
- Make the shared test stub installers consistent in how they install modules into `sys.modules` and accept fixture-provided `monkeypatch` for safer teardown.
- Keep the shared stubs small, explicit, and composable after selector/datetime extraction work, and avoid introducing a large consolidated stub.

### Description
- Updated `force_module` to accept `monkeypatch: pytest.MonkeyPatch | None = None` and prefer `monkeypatch.setitem` when provided while preserving direct-install behavior when omitted.
- Routed `_set_module` to call `force_module(..., monkeypatch=monkeypatch)` so all shared installers use the same installation path.
- Added short docstrings to `stub_config_entry_class`, `stub_exceptions`, and `stub_update_coordinator_module` to clarify intent without changing behavior.
- Changes are limited to `tests/_ha_stubs.py` and do not touch runtime code under `custom_components/pollenlevels/`.

### Testing
- `python -m compileall -q custom_components tests` completed successfully.
- `ruff check --fix --select I .` and `ruff check .` completed successfully.
- `black .` and `black --check .` completed successfully.
- `pytest -q tests/test_stub_hygiene.py` passed (1 test).
- Earlier in the audit the full test suite was exercised and reported `311 passed`; the focused hygiene test passed after the cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9ae890308324a82fef7be1e651e1)