### PR TITLE
chore: align v2.3.0 changelog date with release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.3.0] - 2026-05-26
+## [2.3.0] - 2026-05-31
 ### Added
 - Added the per-location "Update now" button entity to the stable release,
   promoted from v2.3.0b1 after validation in a real Home Assistant instance.


### PR DESCRIPTION
### Motivation
- Align the v2.3.0 `CHANGELOG.md` heading date with the actual stable release publication date.

### Description
- Update the v2.3.0 heading in `CHANGELOG.md` from `## [2.3.0] - 2026-05-26` to `## [2.3.0] - 2026-05-31` and make no other changes.

### Testing
- Ran `ruff check --fix --select I .`, `ruff check .`, and `black --check .`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9e2d6f248324966952c8184600c6)