### PR TITLE
Handle per-day entity registry removal failures

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -12,6 +12,7 @@ Key points:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable
 from datetime import date, datetime
@@ -122,7 +123,25 @@ async def _cleanup_per_day_entities(
             return False
         return uid.endswith(suffix)
 
-    removals: list[Awaitable[Any]] = []
+    removals: list[tuple[str, str, Awaitable[Any]]] = []
+
+    def _queue_removal(entity_id: str, unique_id: str) -> None:
+        """Remove an entity immediately or queue an awaitable registry removal."""
+        nonlocal removed
+        try:
+            removal = registry.async_remove(entity_id)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to remove stale per-day entity from registry: %s (%s)",
+                entity_id,
+                unique_id,
+            )
+            return
+
+        if inspect.isawaitable(removal):
+            removals.append((entity_id, unique_id, removal))
+        else:
+            removed += 1
 
     for ent in entries:
         if ent.domain != "sensor" or ent.platform != DOMAIN:
@@ -133,10 +152,7 @@ async def _cleanup_per_day_entities(
                 ent.entity_id,
                 ent.unique_id,
             )
-            removal = registry.async_remove(ent.entity_id)
-            if asyncio.iscoroutine(removal):
-                removals.append(removal)
-            removed += 1
+            _queue_removal(ent.entity_id, ent.unique_id)
             continue
         if not allow_d2 and _matches(ent.unique_id, "_d2"):
             _LOGGER.debug(
@@ -144,13 +160,24 @@ async def _cleanup_per_day_entities(
                 ent.entity_id,
                 ent.unique_id,
             )
-            removal = registry.async_remove(ent.entity_id)
-            if asyncio.iscoroutine(removal):
-                removals.append(removal)
-            removed += 1
+            _queue_removal(ent.entity_id, ent.unique_id)
 
     if removals:
-        await asyncio.gather(*removals)
+        results = await asyncio.gather(
+            *(removal for _, _, removal in removals), return_exceptions=True
+        )
+        for (entity_id, unique_id, _removal), result in zip(
+            removals, results, strict=True
+        ):
+            if isinstance(result, Exception):
+                _LOGGER.error(
+                    "Failed to remove stale per-day entity from registry: %s (%s)",
+                    entity_id,
+                    unique_id,
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+                continue
+            removed += 1
 
     if removed:
         _LOGGER.info(

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -169,6 +169,8 @@ async def _cleanup_per_day_entities(
         for (entity_id, unique_id, _removal), result in zip(
             removals, results, strict=True
         ):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
             if isinstance(result, Exception):
                 _LOGGER.error(
                     "Failed to remove stale per-day entity from registry: %s (%s)",

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Ubicació",
       "entry_type": "Ubicació",
-      "initiate_flow": "Afegeix ubicació",
+      "initiate_flow": {
+        "user": "Afegeix ubicació"
+      },
       "step": {
         "user": {
           "title": "Afegeix una ubicació de Pollen Levels",

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Ubicació",
+      "entry_type": "Ubicació",
+      "initiate_flow": "Afegeix ubicació",
       "step": {
         "user": {
           "title": "Afegeix una ubicació de Pollen Levels",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Umístění",
+      "entry_type": "Poloha",
+      "initiate_flow": "Přidat polohu",
       "step": {
         "user": {
           "title": "Přidat umístění Pollen Levels",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Umístění",
       "entry_type": "Poloha",
-      "initiate_flow": "Přidat polohu",
+      "initiate_flow": {
+        "user": "Přidat polohu"
+      },
       "step": {
         "user": {
           "title": "Přidat umístění Pollen Levels",

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Placering",
       "entry_type": "Placering",
-      "initiate_flow": "Tilføj placering",
+      "initiate_flow": {
+        "user": "Tilføj placering"
+      },
       "step": {
         "user": {
           "title": "Tilføj Pollen Levels-placering",

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Placering",
+      "entry_type": "Placering",
+      "initiate_flow": "Tilføj placering",
       "step": {
         "user": {
           "title": "Tilføj Pollen Levels-placering",

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Standort",
       "entry_type": "Standort",
-      "initiate_flow": "Standort hinzufügen",
+      "initiate_flow": {
+        "user": "Standort hinzufügen"
+      },
       "step": {
         "user": {
           "title": "Pollen Levels-Standort hinzufügen",

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Standort",
+      "entry_type": "Standort",
+      "initiate_flow": "Standort hinzufügen",
       "step": {
         "user": {
           "title": "Pollen Levels-Standort hinzufügen",

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -53,6 +53,8 @@
   "config_subentries": {
     "location": {
       "title": "Location",
+      "entry_type": "Location",
+      "initiate_flow": "Add location",
       "step": {
         "user": {
           "title": "Add Pollen Levels location",

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -54,7 +54,9 @@
     "location": {
       "title": "Location",
       "entry_type": "Location",
-      "initiate_flow": "Add location",
+      "initiate_flow": {
+        "user": "Add location"
+      },
       "step": {
         "user": {
           "title": "Add Pollen Levels location",

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Ubicación",
       "entry_type": "Ubicación",
-      "initiate_flow": "Añadir ubicación",
+      "initiate_flow": {
+        "user": "Añadir ubicación"
+      },
       "step": {
         "user": {
           "title": "Añadir ubicación de Pollen Levels",

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Ubicación",
+      "entry_type": "Ubicación",
+      "initiate_flow": "Añadir ubicación",
       "step": {
         "user": {
           "title": "Añadir ubicación de Pollen Levels",

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Sijainti",
+      "entry_type": "Sijainti",
+      "initiate_flow": "Lisää sijainti",
       "step": {
         "user": {
           "title": "Lisää Pollen Levels -sijainti",

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Sijainti",
       "entry_type": "Sijainti",
-      "initiate_flow": "Lisää sijainti",
+      "initiate_flow": {
+        "user": "Lisää sijainti"
+      },
       "step": {
         "user": {
           "title": "Lisää Pollen Levels -sijainti",

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Emplacement",
+      "entry_type": "Emplacement",
+      "initiate_flow": "Ajouter un emplacement",
       "step": {
         "user": {
           "title": "Ajouter un emplacement Pollen Levels",

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Emplacement",
       "entry_type": "Emplacement",
-      "initiate_flow": "Ajouter un emplacement",
+      "initiate_flow": {
+        "user": "Ajouter un emplacement"
+      },
       "step": {
         "user": {
           "title": "Ajouter un emplacement Pollen Levels",

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Hely",
       "entry_type": "Hely",
-      "initiate_flow": "Hely hozzáadása",
+      "initiate_flow": {
+        "user": "Hely hozzáadása"
+      },
       "step": {
         "user": {
           "title": "Pollen Levels hely hozzáadása",

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Hely",
+      "entry_type": "Hely",
+      "initiate_flow": "Hely hozzáadása",
       "step": {
         "user": {
           "title": "Pollen Levels hely hozzáadása",

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Posizione",
+      "entry_type": "Posizione",
+      "initiate_flow": "Aggiungi posizione",
       "step": {
         "user": {
           "title": "Aggiungi posizione Pollen Levels",

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Posizione",
       "entry_type": "Posizione",
-      "initiate_flow": "Aggiungi posizione",
+      "initiate_flow": {
+        "user": "Aggiungi posizione"
+      },
       "step": {
         "user": {
           "title": "Aggiungi posizione Pollen Levels",

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Plassering",
+      "entry_type": "Plassering",
+      "initiate_flow": "Legg til plassering",
       "step": {
         "user": {
           "title": "Legg til Pollen Levels-plassering",

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Plassering",
       "entry_type": "Plassering",
-      "initiate_flow": "Legg til plassering",
+      "initiate_flow": {
+        "user": "Legg til plassering"
+      },
       "step": {
         "user": {
           "title": "Legg til Pollen Levels-plassering",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Locatie",
       "entry_type": "Locatie",
-      "initiate_flow": "Locatie toevoegen",
+      "initiate_flow": {
+        "user": "Locatie toevoegen"
+      },
       "step": {
         "user": {
           "title": "Pollen Levels-locatie toevoegen",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Locatie",
+      "entry_type": "Locatie",
+      "initiate_flow": "Locatie toevoegen",
       "step": {
         "user": {
           "title": "Pollen Levels-locatie toevoegen",

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Lokalizacja",
+      "entry_type": "Lokalizacja",
+      "initiate_flow": "Dodaj lokalizację",
       "step": {
         "user": {
           "title": "Dodaj lokalizację Pollen Levels",

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Lokalizacja",
       "entry_type": "Lokalizacja",
-      "initiate_flow": "Dodaj lokalizację",
+      "initiate_flow": {
+        "user": "Dodaj lokalizację"
+      },
       "step": {
         "user": {
           "title": "Dodaj lokalizację Pollen Levels",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Local",
       "entry_type": "Local",
-      "initiate_flow": "Adicionar local",
+      "initiate_flow": {
+        "user": "Adicionar local"
+      },
       "step": {
         "user": {
           "title": "Adicionar local do Pollen Levels",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Local",
+      "entry_type": "Local",
+      "initiate_flow": "Adicionar local",
       "step": {
         "user": {
           "title": "Adicionar local do Pollen Levels",

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Localização",
+      "entry_type": "Localização",
+      "initiate_flow": "Adicionar localização",
       "step": {
         "user": {
           "title": "Adicionar localização do Pollen Levels",

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Localização",
       "entry_type": "Localização",
-      "initiate_flow": "Adicionar localização",
+      "initiate_flow": {
+        "user": "Adicionar localização"
+      },
       "step": {
         "user": {
           "title": "Adicionar localização do Pollen Levels",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Locație",
       "entry_type": "Locație",
-      "initiate_flow": "Adaugă locație",
+      "initiate_flow": {
+        "user": "Adaugă locație"
+      },
       "step": {
         "user": {
           "title": "Adaugă o locație Pollen Levels",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Locație",
+      "entry_type": "Locație",
+      "initiate_flow": "Adaugă locație",
       "step": {
         "user": {
           "title": "Adaugă o locație Pollen Levels",

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Местоположение",
       "entry_type": "Местоположение",
-      "initiate_flow": "Добавить местоположение",
+      "initiate_flow": {
+        "user": "Добавить местоположение"
+      },
       "step": {
         "user": {
           "title": "Добавить местоположение Pollen Levels",

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Местоположение",
+      "entry_type": "Местоположение",
+      "initiate_flow": "Добавить местоположение",
       "step": {
         "user": {
           "title": "Добавить местоположение Pollen Levels",

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Plats",
       "entry_type": "Plats",
-      "initiate_flow": "Lägg till plats",
+      "initiate_flow": {
+        "user": "Lägg till plats"
+      },
       "step": {
         "user": {
           "title": "Lägg till Pollen Levels-plats",

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Plats",
+      "entry_type": "Plats",
+      "initiate_flow": "Lägg till plats",
       "step": {
         "user": {
           "title": "Lägg till Pollen Levels-plats",

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "Місце",
+      "entry_type": "Місце",
+      "initiate_flow": "Додати місце",
       "step": {
         "user": {
           "title": "Додати місце Pollen Levels",

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "Місце",
       "entry_type": "Місце",
-      "initiate_flow": "Додати місце",
+      "initiate_flow": {
+        "user": "Додати місце"
+      },
       "step": {
         "user": {
           "title": "Додати місце Pollen Levels",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "位置",
+      "entry_type": "位置",
+      "initiate_flow": "添加位置",
       "step": {
         "user": {
           "title": "添加 Pollen Levels 位置",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "位置",
       "entry_type": "位置",
-      "initiate_flow": "添加位置",
+      "initiate_flow": {
+        "user": "添加位置"
+      },
       "step": {
         "user": {
           "title": "添加 Pollen Levels 位置",

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -124,6 +124,8 @@
   "config_subentries": {
     "location": {
       "title": "位置",
+      "entry_type": "位置",
+      "initiate_flow": "新增位置",
       "step": {
         "user": {
           "title": "新增 Pollen Levels 位置",

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -125,7 +125,9 @@
     "location": {
       "title": "位置",
       "entry_type": "位置",
-      "initiate_flow": "新增位置",
+      "initiate_flow": {
+        "user": "新增位置"
+      },
       "step": {
         "user": {
           "title": "新增 Pollen Levels 位置",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2057,6 +2057,52 @@ def test_cleanup_per_day_entities_logs_failed_removal_without_raising(
     assert "Failed to remove stale per-day entity from registry" in caplog.text
 
 
+def test_cleanup_per_day_entities_propagates_cancelled_removal(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelled async removals propagate instead of being counted as successes."""
+
+    entries = [
+        RegistryEntry(
+            "sensor.pollen_type_grass_d1",
+            "entry_type_grass_d1",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.pollen_type_grass_d2",
+            "entry_type_grass_d2",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+    ]
+    registry = _setup_registry_stub(
+        sensor_modules, monkeypatch, entries, entry_id="entry"
+    )
+
+    async def _async_remove(entity_id: str) -> None:
+        if entity_id == "sensor.pollen_type_grass_d1":
+            raise asyncio.CancelledError
+        registry.removals.append(entity_id)
+
+    monkeypatch.setattr(registry, "async_remove", _async_remove)
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            loop.run_until_complete(
+                sensor_modules.sensor._cleanup_per_day_entities(
+                    hass, "entry", allow_d1=False, allow_d2=False
+                )
+            )
+    finally:
+        loop.close()
+
+    assert registry.removals == ["sensor.pollen_type_grass_d2"]
+
+
 def test_coordinator_raises_auth_failed(sensor_modules: SensorModules) -> None:
     """401 responses trigger ConfigEntryAuthFailed for re-auth flows."""
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import importlib.util
+import logging
 import sys
 import types
 from pathlib import Path
@@ -2004,6 +2005,56 @@ def test_cleanup_per_day_entities_removes_disabled_days(
 
     assert removed == expected_removed
     assert registry.removals == expected_entities
+
+
+def test_cleanup_per_day_entities_logs_failed_removal_without_raising(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Failed async removals are logged without aborting the cleanup."""
+
+    entries = [
+        RegistryEntry(
+            "sensor.pollen_type_grass_d1",
+            "entry_type_grass_d1",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.pollen_type_grass_d2",
+            "entry_type_grass_d2",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+    ]
+    registry = _setup_registry_stub(
+        sensor_modules, monkeypatch, entries, entry_id="entry"
+    )
+
+    async def _async_remove(entity_id: str) -> None:
+        if entity_id == "sensor.pollen_type_grass_d1":
+            msg = "registry removal failed"
+            raise RuntimeError(msg)
+        registry.removals.append(entity_id)
+
+    monkeypatch.setattr(registry, "async_remove", _async_remove)
+    caplog.set_level(logging.ERROR, logger=sensor_modules.sensor._LOGGER.name)
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    try:
+        removed = loop.run_until_complete(
+            sensor_modules.sensor._cleanup_per_day_entities(
+                hass, "entry", allow_d1=False, allow_d2=False
+            )
+        )
+    finally:
+        loop.close()
+
+    assert removed == 1
+    assert registry.removals == ["sensor.pollen_type_grass_d2"]
+    assert "Failed to remove stale per-day entity from registry" in caplog.text
 
 
 def test_coordinator_raises_auth_failed(sensor_modules: SensorModules) -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -335,7 +335,7 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
         "config.error.already_configured",
         "config_subentries.location.title",
         "config_subentries.location.entry_type",
-        "config_subentries.location.initiate_flow",
+        "config_subentries.location.initiate_flow.user",
         "config_subentries.location.step.user.title",
         "config_subentries.location.step.user.description",
         "config_subentries.location.step.reconfigure.title",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -327,6 +327,48 @@ def test_translations_match_english_keyset() -> None:
     assert not problems, "Translation keys mismatch: " + "; ".join(problems)
 
 
+def test_config_subentries_location_schema_shape() -> None:
+    """Validate hassfest-required location subentry translation shape."""
+
+    problems: list[str] = []
+    for translation_path in TRANSLATIONS_DIR.glob("*.json"):
+        data = _load_translation(translation_path)
+        location = data.get("config_subentries", {}).get("location", {})
+
+        entry_type = location.get("entry_type")
+        if not isinstance(entry_type, str) or not entry_type.strip():
+            problems.append(
+                f"{translation_path.name}: config_subentries.location.entry_type "
+                "must be a non-empty string"
+            )
+
+        initiate_flow = location.get("initiate_flow")
+        if isinstance(initiate_flow, str):
+            problems.append(
+                f"{translation_path.name}: config_subentries.location.initiate_flow "
+                "must be an object, not a string"
+            )
+            continue
+        if not isinstance(initiate_flow, dict):
+            problems.append(
+                f"{translation_path.name}: config_subentries.location.initiate_flow "
+                "must be an object"
+            )
+            continue
+
+        initiate_user = initiate_flow.get("user")
+        if not isinstance(initiate_user, str) or not initiate_user.strip():
+            problems.append(
+                f"{translation_path.name}: "
+                "config_subentries.location.initiate_flow.user must be a "
+                "non-empty string"
+            )
+
+    assert not problems, "Invalid location subentry translation shape: " + "; ".join(
+        problems
+    )
+
+
 def test_v3_subentry_translation_strings_are_localized() -> None:
     """Ensure new v3 location-subentry strings are not copied from English."""
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -334,6 +334,8 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
     localized_paths = {
         "config.error.already_configured",
         "config_subentries.location.title",
+        "config_subentries.location.entry_type",
+        "config_subentries.location.initiate_flow",
         "config_subentries.location.step.user.title",
         "config_subentries.location.step.user.description",
         "config_subentries.location.step.reconfigure.title",


### PR DESCRIPTION
### Motivation

- Prevent a failing async entity registry removal from aborting setup when cleaning up stale per-day sensors.
- Ensure the cleanup counter reflects successful removals instead of attempted removals.
- Preserve cancellation semantics by propagating `asyncio.CancelledError` instead of counting cancelled removals as successful.
- Keep `config_subentries.location` translations compatible with Hassfest requirements for config subentries.

### Description

- Updated `_cleanup_per_day_entities()` to queue awaitable registry removals together with their `entity_id` and `unique_id` context.
- Replaced `await asyncio.gather(*removals)` with `asyncio.gather(..., return_exceptions=True)` so individual registry removal failures can be logged without aborting the whole cleanup.
- Count removals only after they complete successfully.
- Re-raise `asyncio.CancelledError` results before handling ordinary exceptions, so task/shutdown cancellation is not swallowed.
- Log failed asynchronous removals with entity context.
- Keep immediate non-awaitable registry removals counted as successful when no exception is raised.
- Added the required `config_subentries.location.entry_type` and `config_subentries.location.initiate_flow.user` translation keys across locales so Hassfest validates the v3 subentry translation schema.

### Tests

- Added `test_cleanup_per_day_entities_logs_failed_removal_without_raising`.
- Added `test_cleanup_per_day_entities_propagates_cancelled_removal`.
- Existing translation and Hassfest validation now cover the required `config_subentries.location` shape.

### Validation

- `python -m compileall -q custom_components tests`
- `python -m ruff check .`
- `python -m black --check .`
- `python -m pytest tests/test_sensor.py -q`
- `python -m pytest -q`
- GitHub Actions:
  - `Lint`: passed
  - `tests`: passed
  - `Validate with hassfest`: passed
  - `Validate with HACS`: passed

### Notes

- The translation key additions are intentional: Hassfest requires `entry_type` and `initiate_flow.user` for `config_subentries.location`.
- No migration, sensor entity behavior, diagnostics, versioning, or API client behavior is changed beyond stale per-day entity cleanup.