### PR TITLE
Cache daily summary on coordinator

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -19,6 +19,7 @@ from .const import (
     MAX_FORECAST_DAYS,
     MIN_FORECAST_DAYS,
 )
+from .summary import daily_summary as _daily_summary
 from .util import redact_api_key, safe_parse_int
 
 if TYPE_CHECKING:
@@ -197,6 +198,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self._stale_dailyinfo_warned = False
 
         self.data: dict[str, dict[str, Any]] = {}
+        self.daily_summary_cache: dict[str, Any] = _daily_summary({})
+        self.daily_summary_cache_data_ref: object = self.data
         self.last_updated: datetime | None = None
 
     def _utcnow(self) -> datetime:
@@ -533,6 +536,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             base = self._process_forecast_attributes(base, forecast_list)
             new_data[key] = base
 
+        self.daily_summary_cache = _daily_summary(new_data)
+        self.daily_summary_cache_data_ref = new_data
         self.data = new_data
         self.last_updated = self._utcnow()
         if _LOGGER.isEnabledFor(logging.DEBUG):

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -97,13 +97,24 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
         "data_keys_total": 0,
         "data_keys": [],
     }
-    data_map: dict[str, Any] = getattr(coordinator, "data", {}) or {}
+    raw_data_map = getattr(coordinator, "data", {})
+    data_map: dict[str, Any] = raw_data_map if isinstance(raw_data_map, dict) else {}
     all_keys = list(data_map.keys())
     coord_info["data_keys_total"] = len(all_keys)
     coord_info["data_keys"] = all_keys[:50]
 
     forecast_summary: dict[str, Any] = {}
-    daily_summary = _daily_summary(data_map)
+    daily_summary_cache = getattr(coordinator, "daily_summary_cache", None)
+    daily_summary_cache_data_ref = getattr(
+        coordinator, "daily_summary_cache_data_ref", None
+    )
+    if (
+        isinstance(daily_summary_cache, dict)
+        and daily_summary_cache_data_ref is data_map
+    ):
+        daily_summary = daily_summary_cache
+    else:
+        daily_summary = _daily_summary(data_map)
 
     type_main_keys = [
         k

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -484,17 +484,23 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
                 self.coordinator
             ),
         }
-        self._summary_data_ref: object = object()
-        self._summary_cache: dict[str, dict[str, Any]] = {}
 
     def _summary_payload(self, key: str) -> dict[str, Any]:
-        """Return a cached summary payload for the current coordinator data."""
-        data = self.coordinator.data
-        if data is not self._summary_data_ref:
-            self._summary_data_ref = data
-            self._summary_cache = _daily_summary(data or {})
+        """Return the coordinator-level summary payload for current data."""
+        raw_data = self.coordinator.data
+        data = raw_data if isinstance(raw_data, dict) else {}
+        summary_cache = getattr(self.coordinator, "daily_summary_cache", None)
+        summary_cache_data_ref = getattr(
+            self.coordinator, "daily_summary_cache_data_ref", None
+        )
 
-        return self._summary_cache[key]
+        if isinstance(summary_cache, dict) and summary_cache_data_ref is data:
+            return summary_cache[key]
+
+        summary_cache = _daily_summary(data)
+        self.coordinator.daily_summary_cache = summary_cache
+        self.coordinator.daily_summary_cache_data_ref = data
+        return summary_cache[key]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -488,18 +488,20 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
     def _summary_payload(self, key: str) -> dict[str, Any]:
         """Return the coordinator-level summary payload for current data."""
         raw_data = self.coordinator.data
-        data = raw_data if isinstance(raw_data, dict) else {}
+        if not isinstance(raw_data, dict):
+            return _daily_summary({})[key]
+
         summary_cache = getattr(self.coordinator, "daily_summary_cache", None)
         summary_cache_data_ref = getattr(
             self.coordinator, "daily_summary_cache_data_ref", None
         )
 
-        if isinstance(summary_cache, dict) and summary_cache_data_ref is data:
+        if isinstance(summary_cache, dict) and summary_cache_data_ref is raw_data:
             return summary_cache[key]
 
-        summary_cache = _daily_summary(data)
+        summary_cache = _daily_summary(raw_data)
         self.coordinator.daily_summary_cache = summary_cache
-        self.coordinator.daily_summary_cache_data_ref = data
+        self.coordinator.daily_summary_cache_data_ref = raw_data
         return summary_cache[key]
 
     @property

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -596,11 +596,11 @@ def test_plants_in_season_returns_none_without_plant_entries(
     assert entity.extra_state_attributes["total_plant_count"] == 0
 
 
-def test_summary_sensor_caches_payload_for_current_data_object(
+def test_summary_sensor_shares_cached_payload_between_sensors(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Summary computation is cached per sensor while coordinator data is unchanged."""
+    """Summary computation is shared by summary sensors for current data."""
 
     calls: list[dict[str, Any]] = []
 
@@ -617,17 +617,22 @@ def test_summary_sensor_caches_payload_for_current_data_object(
     monkeypatch.setattr(sensor_modules.sensor, "_daily_summary", fake_daily_summary)
     initial_data = {"plants_oak": {"source": "plant", "inSeason": True}}
     coordinator = _summary_coordinator(initial_data)
-    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
+    first_entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
+    second_entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
 
-    assert entity.native_value == 1
-    assert entity.extra_state_attributes["plant_names"] == ["Plant 1"]
+    assert first_entity.native_value == 1
+    assert first_entity.extra_state_attributes["plant_names"] == ["Plant 1"]
+    assert second_entity.native_value == 1
+    assert second_entity.extra_state_attributes["plant_names"] == ["Plant 1"]
     assert calls == [initial_data]
 
     updated_data = {"plants_pine": {"source": "plant", "inSeason": True}}
     coordinator.data = updated_data
 
-    assert entity.native_value == 2
-    assert entity.extra_state_attributes["plant_names"] == ["Plant 2"]
+    assert first_entity.native_value == 2
+    assert first_entity.extra_state_attributes["plant_names"] == ["Plant 2"]
+    assert second_entity.native_value == 2
+    assert second_entity.extra_state_attributes["plant_names"] == ["Plant 2"]
     assert calls == [initial_data, updated_data]
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -636,6 +636,34 @@ def test_summary_sensor_shares_cached_payload_between_sensors(
     assert calls == [initial_data, updated_data]
 
 
+def test_summary_sensor_does_not_mutate_coordinator_cache_for_non_dict_data(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Summary fallback for non-dict data does not store temporary empty dicts."""
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_daily_summary(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+        calls.append(data)
+        return {"plants_in_season_today": {"state": None}}
+
+    monkeypatch.setattr(sensor_modules.sensor, "_daily_summary", fake_daily_summary)
+    sentinel_ref = object()
+    sentinel_cache = {"sentinel": {"state": "cached"}}
+    coordinator = _summary_coordinator({})
+    coordinator.data = None
+    coordinator.daily_summary_cache = sentinel_cache
+    coordinator.daily_summary_cache_data_ref = sentinel_ref
+    entity = sensor_modules.sensor.PlantsInSeasonTodaySensor(coordinator)
+
+    assert entity.native_value is None
+    assert entity.native_value is None
+    assert coordinator.daily_summary_cache is sentinel_cache
+    assert coordinator.daily_summary_cache_data_ref is sentinel_ref
+    assert calls == [{}, {}]
+
+
 def test_overall_pollen_risk_returns_max_current_day_type_value(
     sensor_modules: SensorModules,
 ) -> None:


### PR DESCRIPTION
### Motivation

- Avoid repeated `daily_summary` computation per summary sensor by computing it once per coordinator update and sharing the result.  
- Ensure diagnostics and summary sensors consume the same precomputed summary when it corresponds to the current coordinator `data`.  
- Keep a safe fallback so sensors and diagnostics still work during initialization or when coordinator `data` is not a dict.

### Description

- Add `daily_summary_cache` and `daily_summary_cache_data_ref` attributes to `PollenDataUpdateCoordinator` and initialize them with a safe empty summary via `daily_summary({})`.  
- Compute `daily_summary(new_data)` once inside `PollenDataUpdateCoordinator._async_update_data` and store the result in `daily_summary_cache` with `daily_summary_cache_data_ref` set to `new_data`.  
- Update `_BaseSummarySensor._summary_payload` in `custom_components/pollenlevels/sensor.py` to first read the coordinator-level cache and use a safe fallback that computes and stores the cache if it is missing or the data reference differs.  
- Change diagnostics in `custom_components/pollenlevels/diagnostics.py` to reuse the coordinator cache when `daily_summary_cache_data_ref` matches the coordinator `data`, falling back to `daily_summary(data_map)` otherwise.  
- Update tests in `tests/test_sensor.py` to verify that summary computation is shared between summary sensors (test renamed to `test_summary_sensor_shares_cached_payload_between_sensors`).

### Testing

- Ran `ruff check --fix --select I` and `ruff check` and formatting with `black .`, all completed successfully.  
- Ran targeted tests and full test suite with `pytest -q`, the modified tests passed and the full suite completed with `367 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee86ac5588324b0aaac83ffc7d6e9)