### PR TITLE
Preserve legacy None device subentry links during migration

### DIFF
--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -552,12 +552,19 @@ def _migrate_device_registry_for_merged_entry(
         elif not source_subentry_ids:
             source_subentry_ids = {None}
 
+        valid_source_subentry_ids = {
+            subentry_id
+            for subentry_id in source_subentry_ids
+            if subentry_id in targets_by_source_subentry
+        }
         target_subentries: list[ConfigSubentry] = []
         for source_subentry_id in sorted(
             source_subentry_ids, key=lambda item: item or ""
         ):
             if source_subentry_id not in targets_by_source_subentry:
                 if source is parent:
+                    continue
+                if source_subentry_id is None and valid_source_subentry_ids:
                     continue
                 _LOGGER.error(
                     "Cannot move device %s from entry %s to parent %s: no target "

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -416,19 +416,27 @@ def _parent_legacy_location_target(
     )
 
 
-def _normalize_subentry_ids(value: Any) -> set[str]:
-    """Return a normalized string set from a stored subentry-id value."""
+def _normalize_subentry_ids(value: Any) -> set[str | None]:
+    """Return a normalized subentry-id set while preserving legacy None links."""
     if value is None:
-        return set()
+        return {None}
     if isinstance(value, str):
-        return {value} if value else set()
+        return {value} if value else {None}
     try:
-        return {item for item in value if isinstance(item, str) and item}
+        ids: set[str | None] = set()
+        for item in value:
+            if item is None:
+                ids.add(None)
+            elif isinstance(item, str) and item:
+                ids.add(item)
+        return ids or {None}
     except TypeError:
-        return set()
+        return {None}
 
 
-def _device_source_subentry_ids(device: Any, source_entry_id: str) -> set[str] | None:
+def _device_source_subentry_ids(
+    device: Any, source_entry_id: str
+) -> set[str | None] | None:
     """Return known source subentry IDs for a device, or None if unavailable."""
     for attr in ("config_entries_subentries", "config_entry_subentries"):
         mapping = getattr(device, attr, None)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2738,6 +2738,97 @@ def test_migrate_a1_state_repairs_registry_without_duplicate_subentries(
     }
 
 
+def test_migrate_mixed_device_registry_state_removes_leftover_none_association(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Migration should remove stale legacy main-entry device links."""
+    integration = integration_modules.integration
+
+    existing_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-home",
+        },
+        subentry_id="existing-home",
+        title="Home",
+        unique_id="1.0000_2.0000",
+    )
+    entry = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        title="Home",
+        data={integration.CONF_API_KEY: "shared-key"},
+        version=integration.TARGET_ENTRY_VERSION - 1,
+        subentries={existing_subentry.subentry_id: existing_subentry},
+        unique_id=integration.api_key_unique_id("shared-key"),
+    )
+    hass = _FakeHass(entries=[entry])
+
+    entity_registry_mod = sys.modules["homeassistant.helpers.entity_registry"]
+    monkeypatch.setattr(
+        entity_registry_mod,
+        "async_entries_for_config_entry",
+        lambda *_args, **_kwargs: [],
+    )
+
+    device = types.SimpleNamespace(
+        id="device-home",
+        config_entries={"legacy-home"},
+        config_entries_subentries={"legacy-home": {None, "existing-home"}},
+    )
+    devices = [device]
+    removed_devices: list[str] = []
+    device_updates: list[tuple[str, dict[str, Any]]] = []
+
+    class _DeviceRegistry:
+        def async_update_device(self, device_id: str, **kwargs: Any) -> None:
+            device_updates.append((device_id, kwargs))
+            assert device_id == device.id
+            if add_entry := kwargs.get("add_config_entry_id"):
+                device.config_entries.add(add_entry)
+                device.config_entries_subentries.setdefault(add_entry, set()).add(
+                    kwargs.get("add_config_subentry_id")
+                )
+            if remove_entry := kwargs.get("remove_config_entry_id"):
+                if "remove_config_subentry_id" in kwargs:
+                    subentries = device.config_entries_subentries.setdefault(
+                        remove_entry, set()
+                    )
+                    subentries.discard(kwargs["remove_config_subentry_id"])
+                    if not subentries:
+                        device.config_entries.discard(remove_entry)
+                else:
+                    device.config_entries.discard(remove_entry)
+                    device.config_entries_subentries.pop(remove_entry, None)
+
+    device_registry_mod = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry_mod.async_get = lambda _hass: _DeviceRegistry()
+    device_registry_mod.async_entries_for_config_entry = lambda _registry, entry_id: [
+        device for device in devices if entry_id in device.config_entries
+    ]
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.device_registry", device_registry_mod
+    )
+
+    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
+
+    assert entry.version == integration.TARGET_ENTRY_VERSION
+    assert entry.subentries == {existing_subentry.subentry_id: existing_subentry}
+    assert hass.config_entries.added_subentries == []
+    assert device in devices
+    assert removed_devices == []
+    assert device.config_entries_subentries == {"legacy-home": {"existing-home"}}
+    assert (
+        "device-home",
+        {
+            "remove_config_entry_id": "legacy-home",
+            "remove_config_subentry_id": None,
+        },
+    ) in device_updates
+
+
 def test_migrate_grouped_parent_retry_after_parent_registry_failure_is_idempotent(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2205,6 +2205,187 @@ def test_migrate_grouped_multi_subentry_source_moves_registries_by_location(
     assert hass.config_entries.removed_entries == ["legacy-source"]
 
 
+def test_migrate_grouped_source_mixed_none_and_subentry_skips_leftover_none(
+    integration_modules: _InitModules, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A grouped source device should ignore stale None if a valid subentry exists."""
+    integration = integration_modules.integration
+
+    parent_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-home",
+        },
+        subentry_id="parent-location",
+        title="Home",
+        unique_id="1.0000_2.0000",
+    )
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        data={integration.CONF_API_KEY: "shared-key"},
+        version=integration.TARGET_ENTRY_VERSION,
+        subentries={parent_subentry.subentry_id: parent_subentry},
+        unique_id=integration.api_key_unique_id("shared-key"),
+    )
+    source_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 3.0,
+            integration.CONF_LONGITUDE: 4.0,
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-office",
+        },
+        subentry_id="source-location",
+        title="Office",
+        unique_id="3.0000_4.0000",
+    )
+    source = _FakeEntry(
+        integration,
+        entry_id="legacy-office",
+        data={integration.CONF_API_KEY: "shared-key"},
+        version=integration.TARGET_ENTRY_VERSION,
+        subentries={source_subentry.subentry_id: source_subentry},
+    )
+    hass = _FakeHass(entries=[parent, source])
+
+    entity_registry_mod = sys.modules["homeassistant.helpers.entity_registry"]
+    monkeypatch.setattr(
+        entity_registry_mod,
+        "async_entries_for_config_entry",
+        lambda *_args, **_kwargs: [],
+    )
+
+    device_updates: list[tuple[str, dict[str, Any]]] = []
+
+    class _DeviceRegistry:
+        def async_update_device(self, device_id: str, **kwargs: Any) -> None:
+            device_updates.append((device_id, kwargs))
+
+    device_registry_mod = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry_mod.async_get = lambda _hass: _DeviceRegistry()
+    device_registry_mod.async_entries_for_config_entry = lambda _registry, entry_id: (
+        [
+            types.SimpleNamespace(
+                id="device-office",
+                config_entries={"legacy-office"},
+                config_entries_subentries={"legacy-office": {None, "source-location"}},
+            )
+        ]
+        if entry_id == "legacy-office"
+        else []
+    )
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.device_registry", device_registry_mod
+    )
+
+    assert asyncio.run(integration.async_migrate_entry(hass, parent)) is True
+
+    office_subentry = next(
+        subentry
+        for subentry in parent.subentries.values()
+        if subentry.data[integration.CONF_LEGACY_ENTRY_ID] == "legacy-office"
+    )
+    assert device_updates == [
+        (
+            "device-office",
+            {
+                "add_config_entry_id": "legacy-home",
+                "add_config_subentry_id": office_subentry.subentry_id,
+            },
+        ),
+        ("device-office", {"remove_config_entry_id": "legacy-office"}),
+    ]
+    assert source.data == {
+        integration.CONF_API_KEY: "shared-key",
+        "merged_into_entry_id": "legacy-home",
+    }
+    assert hass.config_entries.removed_entries == ["legacy-office"]
+
+
+def test_migrate_grouped_source_only_none_device_association_keeps_source(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A grouped source with only an unmapped None device link stays retryable."""
+    integration = integration_modules.integration
+
+    parent_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-home",
+        },
+        subentry_id="parent-location",
+        title="Home",
+        unique_id="1.0000_2.0000",
+    )
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        data={integration.CONF_API_KEY: "shared-key"},
+        version=integration.TARGET_ENTRY_VERSION,
+        subentries={parent_subentry.subentry_id: parent_subentry},
+        unique_id=integration.api_key_unique_id("shared-key"),
+    )
+    source_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 3.0,
+            integration.CONF_LONGITUDE: 4.0,
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-office",
+        },
+        subentry_id="source-location",
+        title="Office",
+        unique_id="3.0000_4.0000",
+    )
+    source = _FakeEntry(
+        integration,
+        entry_id="legacy-office",
+        data={integration.CONF_API_KEY: "shared-key"},
+        version=integration.TARGET_ENTRY_VERSION,
+        subentries={source_subentry.subentry_id: source_subentry},
+    )
+    hass = _FakeHass(entries=[parent, source])
+
+    entity_registry_mod = sys.modules["homeassistant.helpers.entity_registry"]
+    monkeypatch.setattr(
+        entity_registry_mod,
+        "async_entries_for_config_entry",
+        lambda *_args, **_kwargs: [],
+    )
+
+    device_updates: list[tuple[str, dict[str, Any]]] = []
+
+    class _DeviceRegistry:
+        def async_update_device(self, device_id: str, **kwargs: Any) -> None:
+            device_updates.append((device_id, kwargs))
+
+    device_registry_mod = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry_mod.async_get = lambda _hass: _DeviceRegistry()
+    device_registry_mod.async_entries_for_config_entry = lambda _registry, entry_id: (
+        [
+            types.SimpleNamespace(
+                id="device-office",
+                config_entries={"legacy-office"},
+                config_entries_subentries={"legacy-office": {None}},
+            )
+        ]
+        if entry_id == "legacy-office"
+        else []
+    )
+    monkeypatch.setitem(
+        sys.modules, "homeassistant.helpers.device_registry", device_registry_mod
+    )
+
+    with caplog.at_level("ERROR", logger=integration.__name__):
+        assert asyncio.run(integration.async_migrate_entry(hass, parent)) is False
+
+    assert device_updates == []
+    assert source.data == {integration.CONF_API_KEY: "shared-key"}
+    assert hass.config_entries.removed_entries == []
+    assert "no target subentry for source subentry legacy-entry" in caplog.text
+
+
 def test_migrate_grouped_entry_keeps_clean_v3_source_with_unmigratable_subentry(
     integration_modules: _InitModules,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
### Motivation

- Harden v3 device-registry migration for mixed or interrupted states where a device may be associated both with a valid location subentry and a legacy no-subentry link (`None`).
- Ensure leftover legacy main-entry device associations are removed so devices do not remain under “Devices not belonging to a subentry”.
- Keep grouped migrations conservative when a source device only has an unmapped legacy `None` association and no valid target subentry.

### Description

- Changed `_normalize_subentry_ids()` to preserve legacy `None` values and return `set[str | None]`.
- Changed `_device_source_subentry_ids()` to return `set[str | None] | None` so migration code can distinguish unavailable mappings from explicit legacy no-subentry links.
- Updated grouped device-registry migration so a non-parent source device with `{None, "<source_subentry_id>"}` skips the stale `None` association when another valid source subentry target exists.
- Preserved the conservative failure path for non-parent source devices that only have `{None}` and no valid target subentry.
- Kept the explicit normalization loop intentionally for clarity around mixed `None`/`str` registry state.

### Tests

- Added `test_migrate_grouped_source_mixed_none_and_subentry_skips_leftover_none`.
- Added `test_migrate_grouped_source_only_none_device_association_keeps_source`.
- Added/kept `test_migrate_mixed_device_registry_state_removes_leftover_none_association`.
- These tests cover:
  - mixed source device state `{None, "source-location"}`;
  - conservative failure for source devices with only `{None}`;
  - repair of parent devices with `{None, "existing-home"}` without creating duplicate subentries.

### Validation

- GitHub Actions:
  - `Lint`: passed
  - `tests`: passed
  - `Validate with hassfest`: passed
  - `Validate with HACS`: passed

### Notes

- No version bump is included here because `prototype/v3-subentries` is already prepared as `3.0.0a2`.
- No diagnostics, translations, sensors, API client, or runtime behavior outside registry migration are changed.