### PR TITLE
Skip stale runtime location coordinators in force_update and report stale runtime locations in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.0.0a3] - 2026-06-02
+### Fixed
+- Skipped stale runtime location coordinators after a location subentry is
+  removed, preventing manual refreshes before the parent entry reloads.
+- Reported stale runtime locations in diagnostics while excluding them from the
+  normal active location diagnostics block.
+
 ## [3.0.0a2] - 2026-06-02
 ### Fixed
 - Repaired v3 migration of surviving legacy parent entity and device registry

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -50,6 +50,7 @@ from .runtime import (
 )
 from .sensor import ForecastSensorMode
 from .util import (
+    active_location_subentry_ids,
     api_key_unique_id as api_key_unique_id,
     normalize_sensor_mode,
     redact_sensitive_values,
@@ -194,11 +195,20 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
                 )
                 continue
 
+            active_subentry_ids = active_location_subentry_ids(entry)
             for location in locations.values():
+                subentry_id = location.subentry_id
+                if subentry_id not in active_subentry_ids:
+                    _LOGGER.debug(
+                        "Skipping stale Pollen Levels runtime location %s for entry %s",
+                        subentry_id,
+                        entry.entry_id,
+                    )
+                    continue
                 coordinator = getattr(location, "coordinator", None)
                 if not coordinator:
                     continue
-                targets.append((entry, location.subentry_id, coordinator))
+                targets.append((entry, subentry_id, coordinator))
 
         if not targets:
             _LOGGER.debug("No coordinators available for force_update")

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -52,6 +52,7 @@ from .sensor import ForecastSensorMode
 from .util import (
     active_location_subentry_ids,
     api_key_unique_id as api_key_unique_id,
+    has_legacy_location_data,
     normalize_sensor_mode,
     redact_sensitive_values,
     safe_parse_int,
@@ -196,7 +197,9 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
                 continue
 
             active_subentry_ids = active_location_subentry_ids(entry)
-            filter_stale_locations = bool(active_subentry_ids)
+            filter_stale_locations = bool(
+                active_subentry_ids
+            ) or not has_legacy_location_data(entry)
             for location in locations.values():
                 subentry_id = location.subentry_id
                 if filter_stale_locations and subentry_id not in active_subentry_ids:

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -196,9 +196,10 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
                 continue
 
             active_subentry_ids = active_location_subentry_ids(entry)
+            filter_stale_locations = bool(active_subentry_ids)
             for location in locations.values():
                 subentry_id = location.subentry_id
-                if subentry_id not in active_subentry_ids:
+                if filter_stale_locations and subentry_id not in active_subentry_ids:
                     _LOGGER.debug(
                         "Skipping stale Pollen Levels runtime location %s for entry %s",
                         subentry_id,

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -282,7 +282,7 @@ async def async_get_config_entry_diagnostics(
     first_location_payload: dict[str, Any] | None = None
     if runtime is not None:
         active_subentry_ids = active_location_subentry_ids(entry)
-        filter_stale_locations = hasattr(entry, "subentries")
+        filter_stale_locations = bool(active_subentry_ids)
         for subentry_id, location in runtime.locations.items():
             if filter_stale_locations and subentry_id not in active_subentry_ids:
                 stale_location_ids.append(subentry_id)

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -36,7 +36,12 @@ from .const import (
 )
 from .runtime import PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
-from .util import active_location_subentry_ids, redact_api_key, safe_parse_int
+from .util import (
+    active_location_subentry_ids,
+    has_legacy_location_data,
+    redact_api_key,
+    safe_parse_int,
+)
 
 # Redact potentially sensitive values from diagnostics. Diagnostics intentionally
 # expose only 1-decimal approximate coordinates in support examples so issues
@@ -282,7 +287,9 @@ async def async_get_config_entry_diagnostics(
     first_location_payload: dict[str, Any] | None = None
     if runtime is not None:
         active_subentry_ids = active_location_subentry_ids(entry)
-        filter_stale_locations = bool(active_subentry_ids)
+        filter_stale_locations = bool(
+            active_subentry_ids
+        ) or not has_legacy_location_data(entry)
         for subentry_id, location in runtime.locations.items():
             if filter_stale_locations and subentry_id not in active_subentry_ids:
                 stale_location_ids.append(subentry_id)

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -36,7 +36,7 @@ from .const import (
 )
 from .runtime import PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
-from .util import redact_api_key, safe_parse_int
+from .util import active_location_subentry_ids, redact_api_key, safe_parse_int
 
 # Redact potentially sensitive values from diagnostics. Diagnostics intentionally
 # expose only 1-decimal approximate coordinates in support examples so issues
@@ -278,9 +278,15 @@ async def async_get_config_entry_diagnostics(
     days_effective = _effective_days(options, data)
     lang = options.get(CONF_LANGUAGE_CODE, data.get(CONF_LANGUAGE_CODE))
     locations: dict[str, Any] = {}
+    stale_location_ids: list[str] = []
     first_location_payload: dict[str, Any] | None = None
     if runtime is not None:
+        active_subentry_ids = active_location_subentry_ids(entry)
+        filter_stale_locations = hasattr(entry, "subentries")
         for subentry_id, location in runtime.locations.items():
+            if filter_stale_locations and subentry_id not in active_subentry_ids:
+                stale_location_ids.append(subentry_id)
+                continue
             coordinator = location.coordinator
             lat = _coordinate_from_coordinator_or_data(coordinator, data, CONF_LATITUDE)
             lon = _coordinate_from_coordinator_or_data(
@@ -325,6 +331,10 @@ async def async_get_config_entry_diagnostics(
             },
         },
         "locations": locations,
+        "runtime_summary": {
+            "stale_location_count": len(stale_location_ids),
+            "stale_location_ids": sorted(stale_location_ids),
+        },
         "registry_summary": _registry_summary(hass, entry),
     }
     if first_location_payload is not None:

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0a2"
+    "version": "3.0.0a3"
 }

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -8,7 +8,12 @@ import re
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
-from .const import FORECAST_SENSORS_CHOICES, SUBENTRY_TYPE_LOCATION
+from .const import (
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    FORECAST_SENSORS_CHOICES,
+    SUBENTRY_TYPE_LOCATION,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from aiohttp import ClientResponse
@@ -27,6 +32,17 @@ def active_location_subentry_ids(entry: Any) -> set[str]:
         if isinstance(subentry_id, str) and subentry_id:
             active_ids.add(subentry_id)
     return active_ids
+
+
+def has_legacy_location_data(entry: Any) -> bool:
+    """Return True when entry data contains a valid legacy fallback location."""
+    data = getattr(entry, "data", {}) or {}
+    if CONF_LATITUDE not in data or CONF_LONGITUDE not in data:
+        return False
+    return (
+        validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+        is not None
+    )
 
 
 async def extract_error_message(resp: ClientResponse, default: str = "") -> str:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -8,12 +8,25 @@ import re
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
-from .const import FORECAST_SENSORS_CHOICES
+from .const import FORECAST_SENSORS_CHOICES, SUBENTRY_TYPE_LOCATION
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from aiohttp import ClientResponse
 else:  # pragma: no cover - runtime fallback for test environments without aiohttp
     ClientResponse = Any
+
+
+def active_location_subentry_ids(entry: Any) -> set[str]:
+    """Return active location subentry ids for a config entry."""
+    subentries = getattr(entry, "subentries", {}) or {}
+    active_ids: set[str] = set()
+    for subentry in subentries.values():
+        if getattr(subentry, "subentry_type", None) != SUBENTRY_TYPE_LOCATION:
+            continue
+        subentry_id = getattr(subentry, "subentry_id", None)
+        if isinstance(subentry_id, str) and subentry_id:
+            active_ids.add(subentry_id)
+    return active_ids
 
 
 async def extract_error_message(resp: ClientResponse, default: str = "") -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0a2"
+version = "3.0.0a3"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -251,6 +251,72 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_summarizes_stale_runtime_locations(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should exclude deleted runtime locations and summarize them."""
+
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
+    }
+    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    entry.subentries = {
+        "casa": SimpleNamespace(subentry_id="casa", subentry_type="location"),
+        "guineta": SimpleNamespace(subentry_id="guineta", subentry_type="location"),
+    }
+
+    def _coordinator(subentry_id: str, lat: float, lon: float) -> SimpleNamespace:
+        return SimpleNamespace(
+            entry_id="entry",
+            subentry_id=subentry_id,
+            forecast_days=2,
+            language="en",
+            create_d1=True,
+            create_d2=False,
+            last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+            lat=lat,
+            lon=lon,
+            entry_title=subentry_id,
+            data={},
+        )
+
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "casa": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="casa",
+                coordinator=_coordinator("casa", 12.345678, -98.765432),
+            ),
+            "trabajo": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="trabajo",
+                coordinator=_coordinator("trabajo", 23.456789, -87.654321),
+            ),
+            "guineta": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="guineta",
+                coordinator=_coordinator("guineta", 34.567891, -76.543219),
+            ),
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert set(diagnostics["locations"]) == {"casa", "guineta"}
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 1,
+        "stale_location_ids": ["trabajo"],
+    }
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+    assert "23.456789" not in serialized
+    assert "-87.654321" not in serialized
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("raw_days", "expected_days"),
     [

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -251,6 +251,53 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_includes_fallback_location_without_subentries(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should keep fallback runtime locations when no subentries exist."""
+
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LATITUDE: 12.345678,
+        diagnostics_modules.CONF_LONGITUDE: -98.765432,
+    }
+    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="entry",
+        forecast_days=2,
+        language=None,
+        create_d1=True,
+        create_d2=False,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=12.345678,
+        lon=-98.765432,
+        entry_title="Home",
+        data={},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            entry.entry_id: diagnostics_modules.PollenLocationRuntime(
+                subentry_id=entry.entry_id, coordinator=coordinator
+            )
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert set(diagnostics["locations"]) == {"entry"}
+    assert diagnostics["runtime_summary"]["stale_location_count"] == 0
+    assert diagnostics["runtime_summary"]["stale_location_ids"] == []
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_summarizes_stale_runtime_locations(
     diagnostics_modules: DiagnosticsModules,
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -180,6 +180,14 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
     }
     options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
+    entry.subentries = {
+        "subentry-1": SimpleNamespace(
+            subentry_id="subentry-1", subentry_type="location"
+        ),
+        "subentry-2": SimpleNamespace(
+            subentry_id="subentry-2", subentry_type="location"
+        ),
+    }
 
     first_coordinator = SimpleNamespace(
         entry_id="entry",
@@ -291,6 +299,52 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
     assert set(diagnostics["locations"]) == {"entry"}
     assert diagnostics["runtime_summary"]["stale_location_count"] == 0
     assert diagnostics["runtime_summary"]["stale_location_ids"] == []
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_summarizes_runtime_locations_when_parent_has_no_locations(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should summarize stale v3 runtime locations after the last deletion."""
+
+    data = {diagnostics_modules.CONF_API_KEY: "secret-token"}
+    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    entry.subentries = {}
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="deleted-location",
+        forecast_days=2,
+        language=None,
+        create_d1=True,
+        create_d2=False,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=12.345678,
+        lon=-98.765432,
+        entry_title="Deleted",
+        data={},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "deleted-location": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="deleted-location", coordinator=coordinator
+            )
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert diagnostics["locations"] == {}
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 1,
+        "stale_location_ids": ["deleted-location"],
+    }
     serialized = json.dumps(diagnostics, sort_keys=True)
     assert "secret-token" not in serialized
     assert "12.345678" not in serialized
@@ -420,9 +474,13 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
     options = {diagnostics_modules.CONF_FORECAST_DAYS: 2}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
+    entry.subentries = {
+        "entry": SimpleNamespace(subentry_id="entry", subentry_type="location")
+    }
 
     coordinator = SimpleNamespace(
         entry_id="entry",
+        subentry_id="entry",
         forecast_days=2,
         language="en",
         create_d1=True,
@@ -559,8 +617,12 @@ async def test_diagnostics_daily_summary_uses_empty_states_without_data(
     """Diagnostics daily summary should be present even without coordinator data."""
 
     entry = _ConfigEntry(data={}, options={}, entry_id="entry", title="Home")
+    entry.subentries = {
+        "entry": SimpleNamespace(subentry_id="entry", subentry_type="location")
+    }
     coordinator = SimpleNamespace(
         entry_id="entry",
+        subentry_id="entry",
         forecast_days=1,
         language=None,
         create_d1=False,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1239,6 +1239,47 @@ def test_force_update_refreshes_location_subentries_sequentially(
     assert order == ["loc-1:start", "loc-1:end", "loc-2:start", "loc-2:end"]
 
 
+def test_force_update_refreshes_fallback_location_without_subentries(
+    integration_modules: _InitModules, caplog
+) -> None:
+    """force_update should still refresh legacy fallback runtime locations."""
+    integration = integration_modules.integration
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    coordinator = _Coordinator()
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-legacy",
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+        },
+        subentries={},
+    )
+    entry.runtime_data = types.SimpleNamespace(
+        locations={
+            entry.entry_id: types.SimpleNamespace(
+                subentry_id=entry.entry_id, coordinator=coordinator
+            )
+        }
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    with caplog.at_level("DEBUG"):
+        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert coordinator.calls == 1
+    assert "Skipping stale Pollen Levels runtime location" not in caplog.text
+
+
 def test_force_update_skips_stale_location_subentries(
     integration_modules: _InitModules, caplog
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1280,6 +1280,46 @@ def test_force_update_refreshes_fallback_location_without_subentries(
     assert "Skipping stale Pollen Levels runtime location" not in caplog.text
 
 
+def test_force_update_skips_runtime_locations_when_parent_has_no_locations(
+    integration_modules: _InitModules, caplog
+) -> None:
+    """force_update should skip stale v3 runtime locations after deleting the last subentry."""
+    integration = integration_modules.integration
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    coordinator = _Coordinator()
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-parent",
+        data={integration.CONF_API_KEY: "key"},
+        subentries={},
+    )
+    entry.runtime_data = types.SimpleNamespace(
+        locations={
+            "deleted-location": types.SimpleNamespace(
+                subentry_id="deleted-location", coordinator=coordinator
+            )
+        }
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    with caplog.at_level("DEBUG"):
+        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert coordinator.calls == 0
+    assert (
+        "Skipping stale Pollen Levels runtime location deleted-location "
+        "for entry entry-parent"
+    ) in caplog.text
+
+
 def test_force_update_skips_stale_location_subentries(
     integration_modules: _InitModules, caplog
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -327,6 +327,20 @@ class _FakeEntry:
         self.runtime_data = None
 
 
+def _location_subentries(
+    integration: types.ModuleType, *subentry_ids: str
+) -> dict[str, Any]:
+    """Return active location subentries keyed by subentry id."""
+    return {
+        subentry_id: integration.ConfigSubentry(
+            data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+            subentry_id=subentry_id,
+            title=subentry_id,
+        )
+        for subentry_id in subentry_ids
+    }
+
+
 class _FakeHass:
     def __init__(
         self,
@@ -1156,6 +1170,7 @@ def test_force_update_refreshes_all_location_subentries(
         integration,
         entry_id="entry-parent",
         data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "loc-1", "loc-2"),
     )
     entry.runtime_data = types.SimpleNamespace(
         locations={
@@ -1203,6 +1218,7 @@ def test_force_update_refreshes_location_subentries_sequentially(
         integration,
         entry_id="entry-parent",
         data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "loc-1", "loc-2"),
     )
     entry.runtime_data = types.SimpleNamespace(
         locations={
@@ -1221,6 +1237,54 @@ def test_force_update_refreshes_location_subentries_sequentially(
 
     assert max_active == 1
     assert order == ["loc-1:start", "loc-1:end", "loc-2:start", "loc-2:end"]
+
+
+def test_force_update_skips_stale_location_subentries(
+    integration_modules: _InitModules, caplog
+) -> None:
+    """force_update should not refresh runtime locations removed from entry.subentries."""
+    integration = integration_modules.integration
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    casa = _Coordinator()
+    trabajo = _Coordinator()
+    guineta = _Coordinator()
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-parent",
+        data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "casa", "guineta"),
+    )
+    entry.runtime_data = types.SimpleNamespace(
+        locations={
+            "casa": types.SimpleNamespace(subentry_id="casa", coordinator=casa),
+            "trabajo": types.SimpleNamespace(
+                subentry_id="trabajo", coordinator=trabajo
+            ),
+            "guineta": types.SimpleNamespace(
+                subentry_id="guineta", coordinator=guineta
+            ),
+        }
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    with caplog.at_level("DEBUG"):
+        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert casa.calls == 1
+    assert guineta.calls == 1
+    assert trabajo.calls == 0
+    assert (
+        "Skipping stale Pollen Levels runtime location trabajo for entry entry-parent"
+        in caplog.text
+    )
 
 
 def test_force_update_continues_after_one_location_failure(
@@ -1251,6 +1315,7 @@ def test_force_update_continues_after_one_location_failure(
         integration,
         entry_id="entry-parent",
         data={integration.CONF_API_KEY: "secret-123"},
+        subentries=_location_subentries(integration, "loc-bad", "loc-good"),
     )
     entry.runtime_data = types.SimpleNamespace(
         locations={
@@ -1297,6 +1362,7 @@ def test_force_update_handles_location_cancelled_error(
         integration,
         entry_id="entry-parent",
         data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "loc-cancel", "loc-good"),
     )
     entry.runtime_data = types.SimpleNamespace(
         locations={


### PR DESCRIPTION
### Motivation
- Prevent manual refresh from touching runtime location coordinators that were removed from a parent entry but still present in the in-memory `runtime_data.locations`, avoiding confusing refreshes before the parent entry is reloaded. 
- Make diagnostics aware of stale runtime locations so support can see they exist at runtime without mixing them into the active-location diagnostics block.

### Description
- Add `active_location_subentry_ids(entry)` helper in `custom_components/pollenlevels/util.py` to return currently active location `subentry_id`s from `entry.subentries`.
- Update the `pollenlevels.force_update` handler in `custom_components/pollenlevels/__init__.py` to skip runtime locations whose `subentry_id` is not an active location subentry and log a debug message when skipping: `"Skipping stale Pollen Levels runtime location <subentry_id> for entry <entry_id>"`.
- Change diagnostics in `custom_components/pollenlevels/diagnostics.py` to detect runtime locations removed from `entry.subentries`, exclude them from the main `locations` block, and report a `runtime_summary` with `stale_location_count` and `stale_location_ids`.
- Add regression tests: `tests/test_init.py` adds `test_force_update_skips_stale_location_subentries` to assert `force_update` refreshes only active locations; `tests/test_diagnostics.py` adds `test_diagnostics_summarizes_stale_runtime_locations` to assert stale runtime locations are summarized and redacted correctly.
- Bump package/manifest version to `3.0.0a3` and add a changelog entry describing the fix.

### Testing
- Ran static/format checks: `python -m compileall -q custom_components tests`, `python -m ruff check .`, and `python -m black --check .`, all succeeded.
- Ran unit tests: `python -m pytest tests/test_init.py -q`, `python -m pytest tests/test_diagnostics.py -q`, and the full suite `python -m pytest -q`; all tests passed.
- Confirmed the new tests verify the required behavior: the stale location coordinator is not refreshed, the debug skip message is emitted, and diagnostics report the stale runtime summary while redacting sensitive data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f4cd9260c8324a6bcd0c6d0c0f642)