### PR TITLE
docs: update v3 migration diagnostics guidance

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -106,12 +106,12 @@ FAQ: https://developers.google.com/maps/documentation/pollen/faq
 
 ---
 
-## 12. What happens to my entries when upgrading to 3.0.0a1?
-Pollen Levels 3.0.0a1 migrates configuration to Home Assistant config
-subentries. This is an alpha release for the v3 migration. Legacy 2.x entries
-that share the same Google API key are grouped under one parent API-key entry,
-and each migrated location becomes one location subentry. The API key is stored
-once on the parent instead of duplicated across legacy entries.
+## 12. What happens to my entries when upgrading to the v3 pre-release?
+The v3 pre-release migrates Pollen Levels to Home Assistant config subentries.
+Legacy 2.x entries that share the same Google API key are grouped under one
+parent API-key entry, and each migrated location becomes one location subentry.
+The API key is stored once on the parent instead of duplicated across legacy
+entries.
 
 Duplicate legacy entries are marked as merged and removed after their
 locations, entities, and devices are moved to the parent entry. If Home
@@ -119,12 +119,25 @@ Assistant cannot move those registry links safely, the legacy entry is kept so
 the migration can be retried.
 
 Migrated location subentries keep the legacy entry ID internally so existing
-entity unique IDs, device identifiers, dashboards, and automations continue to
-match after the entries are consolidated.
+entity unique IDs, device identifiers, dashboards, history, and automations
+continue to match after the entries are consolidated.
 
 If grouped legacy entries used different update, language, or forecast options,
 the parent keeps the first entry's options and fills missing values from the
 remaining entries. You can adjust the shared options after upgrading.
+
+After upgrading, diagnostics can help validate the migration:
+
+- `registry_summary.entities.without_subentry` should normally be `0`.
+- `registry_summary.devices.without_subentry` should normally be `0`.
+- `registry_summary.devices.with_legacy_none_association` should normally be
+  `0`.
+- `runtime_summary.stale_location_count` should normally be `0` after reloading
+  the parent entry.
+
+If `runtime_summary.stale_location_count` is greater than `0` immediately after
+deleting a location subentry, reload the Pollen Levels parent entry from Home
+Assistant. This clears the stale runtime coordinator from memory.
 
 During parent API-key reauthentication or reconfiguration, the integration tries
 configured locations until one validates successfully. Authentication and quota

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - **We do not log request parameters** (coordinates). Debug logs only include non-sensitive metadata (e.g., forecast days and whether a language is set).  
 - Diagnostics include redacted daily, registry, and runtime summaries to help
   troubleshoot the integration without exposing API keys or exact coordinates.
-  Support coordinate examples are rounded to 1 decimal.
+  Approximate coordinates are rounded to 1 decimal for support purposes.
 - Avoid sharing full debug logs publicly; review them for sensitive information before posting.
 - Never share real Google API keys publicly, and do not paste full Google Pollen
   API URLs containing `key=...` into public issues. If a key was exposed,
@@ -146,7 +146,8 @@ Diagnostics include two support summaries for the v3 migration:
   `0`.
 - `runtime_summary` reports temporary runtime-only locations that can remain in
   memory after deleting a location subentry before the parent entry is reloaded.
-- `runtime_summary.stale_location_count = 0` is the normal state after reload.
+- `runtime_summary.stale_location_count` should normally be `0` after reloading
+  the parent entry.
 - If `runtime_summary.stale_location_count > 0` immediately after deleting a
   location, reload the Pollen Levels parent entry from Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - Your **API key** is stored by Home Assistant’s secure config entries.  
 - **We never log your API key.** As a safety net, if it ever appears in an error message, it is **redacted** as `***`.  
 - **We do not log request parameters** (coordinates). Debug logs only include non-sensitive metadata (e.g., forecast days and whether a language is set).  
-- Diagnostics include a redacted `daily_summary` snapshot to help troubleshoot
-  the daily summary sensors without exposing API keys or exact coordinates.
+- Diagnostics include redacted daily, registry, and runtime summaries to help
+  troubleshoot the integration without exposing API keys or exact coordinates.
+  Support coordinate examples are rounded to 1 decimal.
 - Avoid sharing full debug logs publicly; review them for sensitive information before posting.
 - Never share real Google API keys publicly, and do not paste full Google Pollen
   API URLs containing `key=...` into public issues. If a key was exposed,
@@ -93,9 +94,10 @@ Go to **Settings → Devices & Services → Pollen Levels → Configure**.
 
 ## Multiple locations and upgrades
 
-Version 3.0.0a1 starts the v3 alpha line and stores configuration as one parent
-API-key entry with one or more location subentries. Existing 2.x entries are
-consolidated by API key during migration:
+The v3 pre-release line migrates Pollen Levels to Home Assistant config
+subentries. Configuration is stored as one parent API-key entry with one or more
+location subentries. Existing 2.x entries are consolidated by API key during
+migration:
 
 - Legacy entries with the same Google API key are grouped under one parent
   entry, so the API key is stored once on the parent instead of duplicated.
@@ -105,7 +107,8 @@ consolidated by API key during migration:
   cannot move the entity or device registry links safely, the legacy entry is
   kept so the migration can be retried.
 - Migrated location subentries keep the legacy entry ID internally so existing
-  entity unique IDs, devices, dashboards, and automations continue to match.
+  entity unique IDs, devices, dashboards, history, and automations continue to
+  match.
 
 If legacy entries sharing a key used different update, language, or forecast
 options, the parent entry keeps the first entry's options and fills missing
@@ -128,8 +131,27 @@ location initializes. Any location skipped because of a non-auth startup error
 may need a manual reload of the Pollen Levels parent entry after the underlying
 problem is fixed.
 
-Create a Home Assistant backup before installing the v3 alpha. Downgrading to
-Pollen Levels 2.x after the subentry migration is not supported.
+Create a Home Assistant backup before installing the v3 pre-release.
+Downgrading to Pollen Levels 2.x after the subentry migration is not supported.
+
+### Diagnostics after the v3 migration
+
+Diagnostics include two support summaries for the v3 migration:
+
+- `registry_summary` shows how many entities and devices are associated with
+  each location subentry.
+- `registry_summary.entities.without_subentry` should normally be `0`.
+- `registry_summary.devices.without_subentry` should normally be `0`.
+- `registry_summary.devices.with_legacy_none_association` should normally be
+  `0`.
+- `runtime_summary` reports temporary runtime-only locations that can remain in
+  memory after deleting a location subentry before the parent entry is reloaded.
+- `runtime_summary.stale_location_count = 0` is the normal state after reload.
+- If `runtime_summary.stale_location_count > 0` immediately after deleting a
+  location, reload the Pollen Levels parent entry from Home Assistant.
+
+Diagnostics redact the API key and only include approximate coordinates rounded
+to 1 decimal for support purposes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Update README wording from the old `3.0.0a1` alpha reference to the broader v3 pre-release line.
- Document how v3 consolidates legacy entries by API key into parent entries with location subentries.
- Add guidance for interpreting `registry_summary` and `runtime_summary` diagnostics after migration.
- Update the FAQ v3 upgrade entry to avoid alpha-specific wording and include reload guidance for stale runtime locations.

## Scope

Documentation only.

No runtime code, translations, versioning, or release metadata are changed.

## Validation

- Markdown-only change; no tests run.
- Reviewed README and FAQ wording for v3 beta/pre-release readiness.
