### PR TITLE
Validate useful daily info payloads

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -167,6 +167,19 @@ def _redact_validation_error(
     ).strip()
 
 
+def _has_usable_pollen_info_items(value: Any) -> bool:
+    """Return whether pollen info contains at least one usable coded item."""
+    if not isinstance(value, list):
+        return False
+
+    return any(
+        isinstance(item, dict)
+        and isinstance(code := item.get("code"), str)
+        and bool(code.strip())
+        for item in value
+    )
+
+
 def _daily_info_is_valid(data: Any) -> bool:
     """Return whether a validation response contains usable dailyInfo."""
     daily_info = data.get("dailyInfo") if isinstance(data, dict) else None
@@ -185,10 +198,10 @@ def _daily_info_is_valid(data: Any) -> bool:
         ):
             has_usable_entry = True
 
-        if isinstance(item.get("pollenTypeInfo"), list) and item["pollenTypeInfo"]:
+        if _has_usable_pollen_info_items(item.get("pollenTypeInfo")):
             has_usable_entry = True
 
-        if isinstance(item.get("plantInfo"), list) and item["plantInfo"]:
+        if _has_usable_pollen_info_items(item.get("plantInfo")):
             has_usable_entry = True
 
     return has_usable_entry

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -170,11 +170,28 @@ def _redact_validation_error(
 def _daily_info_is_valid(data: Any) -> bool:
     """Return whether a validation response contains usable dailyInfo."""
     daily_info = data.get("dailyInfo") if isinstance(data, dict) else None
-    return (
-        isinstance(daily_info, list)
-        and bool(daily_info)
-        and all(isinstance(item, dict) for item in daily_info)
-    )
+    if not isinstance(daily_info, list) or not daily_info:
+        return False
+
+    has_usable_entry = False
+    for item in daily_info:
+        if not isinstance(item, dict):
+            return False
+
+        date = item.get("date")
+        if isinstance(date, dict) and all(
+            safe_parse_int(date.get(part)) is not None
+            for part in ("year", "month", "day")
+        ):
+            has_usable_entry = True
+
+        if isinstance(item.get("pollenTypeInfo"), list) and item["pollenTypeInfo"]:
+            has_usable_entry = True
+
+        if isinstance(item.get("plantInfo"), list) and item["plantInfo"]:
+            has_usable_entry = True
+
+    return has_usable_entry
 
 
 async def _async_validate_api_location(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -696,7 +696,7 @@ def _patch_client_fetch(
         calls.append(kwargs)
         if error is not None:
             raise error
-        return result or {"dailyInfo": [{"day": "D0"}]}
+        return result or _valid_daily_info_payload()
 
     monkeypatch.setattr(
         config_flow_stubs.config_flow.GooglePollenApiClient,
@@ -704,6 +704,49 @@ def _patch_client_fetch(
         _fake_fetch,
     )
     return calls
+
+
+def _valid_daily_info_payload() -> dict[str, list[dict[str, dict[str, int]]]]:
+    return {"dailyInfo": [{"date": {"year": 2026, "month": 6, "day": 3}}]}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"dailyInfo": None},
+        {"dailyInfo": []},
+        {"dailyInfo": "invalid"},
+        {"dailyInfo": [{}]},
+        {"dailyInfo": [{"day": "D0"}]},
+        {"dailyInfo": [{"indexInfo": []}]},
+        {"dailyInfo": ["bad"]},
+    ],
+)
+def test_daily_info_is_valid_rejects_structurally_empty_payloads(
+    config_flow_stubs: ConfigFlowStubs,
+    payload: object,
+) -> None:
+    """Structurally empty validation responses should not pass the flow."""
+
+    assert not config_flow_stubs.config_flow._daily_info_is_valid(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _valid_daily_info_payload(),
+        {"dailyInfo": [{"pollenTypeInfo": [{"code": "GRASS"}]}]},
+        {"dailyInfo": [{"plantInfo": [{"code": "OLIVE"}]}]},
+    ],
+)
+def test_daily_info_is_valid_accepts_structurally_useful_payloads(
+    config_flow_stubs: ConfigFlowStubs,
+    payload: object,
+) -> None:
+    """Validation accepts forecast data that can seed setup sensors."""
+
+    assert config_flow_stubs.config_flow._daily_info_is_valid(payload)
 
 
 def _base_user_input(config_flow_stubs) -> dict:
@@ -1007,7 +1050,7 @@ def test_validate_input_update_interval_float_string(
     calls = _patch_client_fetch(
         config_flow_stubs,
         monkeypatch,
-        result={"dailyInfo": [{"indexInfo": []}]},
+        result=_valid_daily_info_payload(),
     )
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()
@@ -1354,7 +1397,7 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
     assert placeholders.get("error_message")
 
     _patch_client_fetch(
-        config_flow_stubs, monkeypatch, result={"dailyInfo": [{"day": "D0"}]}
+        config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
     )
 
     errors, normalized = asyncio.run(
@@ -1420,7 +1463,7 @@ def test_validate_input_valid_forecast_mode_combinations_are_accepted(
     """User flow should accept forecast mode combinations that have enough days."""
 
     calls = _patch_client_fetch(
-        config_flow_stubs, monkeypatch, result={"dailyInfo": [{"day": "D0"}]}
+        config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
     )
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()
@@ -1952,7 +1995,7 @@ def test_validate_input_happy_path_sets_unique_id_and_normalizes(
     """Successful validation should normalize data and set unique ID."""
 
     calls = _patch_client_fetch(
-        config_flow_stubs, monkeypatch, result={"dailyInfo": [{"day": "D0"}]}
+        config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
     )
 
     class _TrackingFlow(config_flow_stubs.PollenLevelsConfigFlow):
@@ -2000,7 +2043,7 @@ def test_validate_input_unique_id_collapses_nearby_locations_legacy_compat(
     """Unique-id format should match legacy 4-decimal duplicate detection."""
 
     calls = _patch_client_fetch(
-        config_flow_stubs, monkeypatch, result={"dailyInfo": [{"day": "D0"}]}
+        config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
     )
 
     class _TrackingFlow(config_flow_stubs.PollenLevelsConfigFlow):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -721,6 +721,18 @@ def _valid_daily_info_payload() -> dict[str, list[dict[str, dict[str, int]]]]:
         {"dailyInfo": [{"day": "D0"}]},
         {"dailyInfo": [{"indexInfo": []}]},
         {"dailyInfo": ["bad"]},
+        {"dailyInfo": [{"pollenTypeInfo": []}]},
+        {"dailyInfo": [{"pollenTypeInfo": ["bad"]}]},
+        {"dailyInfo": [{"pollenTypeInfo": [{}]}]},
+        {"dailyInfo": [{"pollenTypeInfo": [{"displayName": "Grass"}]}]},
+        {"dailyInfo": [{"pollenTypeInfo": [{"code": ""}]}]},
+        {"dailyInfo": [{"pollenTypeInfo": [{"code": "   "}]}]},
+        {"dailyInfo": [{"plantInfo": []}]},
+        {"dailyInfo": [{"plantInfo": ["bad"]}]},
+        {"dailyInfo": [{"plantInfo": [{}]}]},
+        {"dailyInfo": [{"plantInfo": [{"displayName": "Olive"}]}]},
+        {"dailyInfo": [{"plantInfo": [{"code": ""}]}]},
+        {"dailyInfo": [{"plantInfo": [{"code": "   "}]}]},
     ],
 )
 def test_daily_info_is_valid_rejects_structurally_empty_payloads(
@@ -737,6 +749,7 @@ def test_daily_info_is_valid_rejects_structurally_empty_payloads(
     [
         _valid_daily_info_payload(),
         {"dailyInfo": [{"pollenTypeInfo": [{"code": "GRASS"}]}]},
+        {"dailyInfo": [{"pollenTypeInfo": [{}, {"code": "GRASS"}]}]},
         {"dailyInfo": [{"plantInfo": [{"code": "OLIVE"}]}]},
     ],
 )


### PR DESCRIPTION
## Summary
- require validation responses to include at least one usable dailyInfo entry
- require pollenTypeInfo and plantInfo entries to include a non-empty string code
- keep valid date-only dailyInfo payloads accepted
- add focused config flow tests for empty, malformed, valid, and mixed pollen info payloads

## Verification
- python -m compileall -q custom_components tests
- python -m ruff check .
- python -m black --check .
- python -m pytest tests/test_config_flow.py -q
- python -m pytest -q