### PR TITLE
Abort v3 migration for invalid legacy coordinates

### DIFF
--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -26,7 +26,7 @@ from .const import (
     DOMAIN,
     SUBENTRY_TYPE_LOCATION,
 )
-from .util import api_key_unique_id, normalize_sensor_mode
+from .util import api_key_unique_id, normalize_sensor_mode, validate_location_pair
 
 _LOGGER = logging.getLogger(__name__)
 LEGACY_HTTP_REFERER_KEY = "http_referer"
@@ -74,6 +74,46 @@ def _location_unique_id(lat: Any, lon: Any) -> str | None:
     if not _coordinates_are_valid(lat_float, lon_float):
         return None
     return f"{lat_float:.4f}_{lon_float:.4f}"
+
+
+def _has_invalid_legacy_coordinates(entry: ConfigEntry) -> bool:
+    """Return whether legacy entry data contains unusable stored coordinates."""
+    data = entry.data or {}
+    return (
+        _has_legacy_coordinates(entry)
+        and validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+        is None
+    )
+
+
+def _has_legacy_coordinates(entry: ConfigEntry) -> bool:
+    """Return whether legacy entry data contains a stored coordinate pair."""
+    data = entry.data or {}
+    return CONF_LATITUDE in data and CONF_LONGITUDE in data
+
+
+def _log_invalid_legacy_coordinates(entry: ConfigEntry) -> None:
+    """Log an actionable migration failure for corrupt legacy coordinates."""
+    _LOGGER.error(
+        "Cannot migrate Pollen Levels entry %s because it contains invalid stored "
+        "coordinates. The entry was left unchanged. Remove and recreate this "
+        "location or fix the configuration before retrying the migration.",
+        entry.entry_id,
+    )
+
+
+def _invalid_legacy_coordinate_entry(
+    entries: list[ConfigEntry],
+) -> ConfigEntry | None:
+    """Return the first entry with corrupt legacy coordinates, if any."""
+    return next(
+        (
+            candidate
+            for candidate in entries
+            if _has_invalid_legacy_coordinates(candidate)
+        ),
+        None,
+    )
 
 
 def _entry_version(entry: ConfigEntry) -> int:
@@ -139,6 +179,11 @@ def _location_from_legacy_entry(entry: ConfigEntry) -> _MigrationLocation | None
     """Return the location stored directly on a legacy config entry."""
     data = dict(entry.data or {})
     if CONF_LATITUDE not in data or CONF_LONGITUDE not in data:
+        return None
+    if (
+        validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+        is None
+    ):
         return None
 
     subentry_data = {
@@ -322,6 +367,7 @@ def _migration_group_entries(
             continue
         if (
             candidate is entry
+            or _has_legacy_coordinates(candidate)
             or _has_migration_locations(candidate)
             or _has_location_subentries(candidate)
             or getattr(candidate, "unique_id", None) == target_unique_id
@@ -694,6 +740,15 @@ async def _async_migrate_grouped_entries(
     target_version: int,
 ) -> bool:
     """Migrate all legacy entries sharing one API key into one parent."""
+    if (invalid_entry := _invalid_legacy_coordinate_entry(group)) is not None:
+        _log_invalid_legacy_coordinates(invalid_entry)
+        _LOGGER.error(
+            "Aborted Pollen Levels API-key migration group because entry %s "
+            "contains invalid stored coordinates. The group was left unchanged.",
+            invalid_entry.entry_id,
+        )
+        return False
+
     parent = _select_migration_parent(group, entry, api_key)
     _LOGGER.info(
         "Selected parent entry %s for API-key migration group with %d entries",
@@ -889,6 +944,10 @@ async def async_handle_entry_migration(
                 return await _async_migrate_grouped_entries(
                     hass, entry, group, api_key, target_version
                 )
+
+        if _has_invalid_legacy_coordinates(entry):
+            _log_invalid_legacy_coordinates(entry)
+            return False
 
         existing_data = entry.data or {}
         existing_options = entry.options or {}

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -79,14 +79,24 @@ def _location_unique_id(lat: Any, lon: Any) -> str | None:
 def _has_invalid_legacy_coordinates(entry: ConfigEntry) -> bool:
     """Return whether legacy entry data contains unusable stored coordinates."""
     data = entry.data or {}
+    if not _has_any_legacy_coordinate_key(entry):
+        return False
+    if not _has_legacy_coordinate_pair(entry):
+        return True
+
     return (
-        _has_legacy_coordinates(entry)
-        and validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+        validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
         is None
     )
 
 
-def _has_legacy_coordinates(entry: ConfigEntry) -> bool:
+def _has_any_legacy_coordinate_key(entry: ConfigEntry) -> bool:
+    """Return whether legacy entry data contains any stored coordinate key."""
+    data = entry.data or {}
+    return CONF_LATITUDE in data or CONF_LONGITUDE in data
+
+
+def _has_legacy_coordinate_pair(entry: ConfigEntry) -> bool:
     """Return whether legacy entry data contains a stored coordinate pair."""
     data = entry.data or {}
     return CONF_LATITUDE in data and CONF_LONGITUDE in data
@@ -367,7 +377,7 @@ def _migration_group_entries(
             continue
         if (
             candidate is entry
-            or _has_legacy_coordinates(candidate)
+            or _has_any_legacy_coordinate_key(candidate)
             or _has_migration_locations(candidate)
             or _has_location_subentries(candidate)
             or getattr(candidate, "unique_id", None) == target_unique_id

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1933,6 +1933,77 @@ def test_migrate_legacy_entries_with_same_api_key_group_under_one_parent(
     assert hass.config_entries.removed_entries == ["legacy-office"]
 
 
+def test_migrate_group_with_invalid_legacy_coordinates_is_left_unchanged(
+    integration_modules: _InitModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Grouped migration should abort if any legacy entry has corrupt coordinates."""
+    integration = integration_modules.integration
+    parent_data = {
+        integration.CONF_API_KEY: "shared-secret",
+        integration.CONF_LATITUDE: 1.0,
+        integration.CONF_LONGITUDE: 2.0,
+        integration.CONF_UPDATE_INTERVAL: 12,
+    }
+    invalid_data = {
+        integration.CONF_API_KEY: "shared-secret",
+        integration.CONF_LATITUDE: "123.456789",
+        integration.CONF_LONGITUDE: "-222.987654",
+        integration.CONF_LANGUAGE_CODE: "en",
+    }
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        title="Home",
+        data=dict(parent_data),
+        options={},
+        version=3,
+        subentries={},
+        unique_id="1.0000_2.0000",
+    )
+    duplicate = _FakeEntry(
+        integration,
+        entry_id="legacy-corrupt",
+        title="Corrupt",
+        data=dict(invalid_data),
+        options={},
+        version=3,
+        subentries={},
+    )
+    hass = _FakeHass(entries=[parent, duplicate])
+
+    with caplog.at_level("ERROR"):
+        assert asyncio.run(integration.async_migrate_entry(hass, parent)) is False
+
+    assert parent.data == parent_data
+    assert parent.options == {}
+    assert parent.version == 3
+    assert parent.subentries == {}
+    assert duplicate.data == invalid_data
+    assert duplicate.options == {}
+    assert duplicate.version == 3
+    assert duplicate.subentries == {}
+    assert "merged_into_entry_id" not in parent.data
+    assert "merged_into_entry_id" not in duplicate.data
+    assert hass.config_entries.added_subentries == []
+    assert hass.config_entries.removed_entries == []
+    assert [entry.entry_id for entry in hass.config_entries.async_entries()] == [
+        "legacy-home",
+        "legacy-corrupt",
+    ]
+    assert (
+        "Cannot migrate Pollen Levels entry legacy-corrupt because it contains "
+        "invalid stored coordinates"
+    ) in caplog.text
+    assert (
+        "Aborted Pollen Levels API-key migration group because entry legacy-corrupt "
+        "contains invalid stored coordinates. The group was left unchanged."
+    ) in caplog.text
+    assert "shared-secret" not in caplog.text
+    assert "123.456789" not in caplog.text
+    assert "-222.987654" not in caplog.text
+
+
 def test_migrate_legacy_entry_into_existing_clean_v3_parent(
     integration_modules: _InitModules,
 ) -> None:
@@ -2062,6 +2133,51 @@ def test_migrate_entry_without_location_does_not_create_corrupt_subentry(
     assert entry.subentries == {}
     assert entry.version == integration.TARGET_ENTRY_VERSION
     assert hass.config_entries.added_subentries == []
+
+
+def test_migrate_entry_with_invalid_legacy_coordinates_is_left_unchanged(
+    integration_modules: _InitModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Legacy entries with corrupt coordinates should fail without side effects."""
+    integration = integration_modules.integration
+    original_data = {
+        integration.CONF_API_KEY: "secret-api-key",
+        integration.CONF_LATITUDE: "123.456789",
+        integration.CONF_LONGITUDE: "-222.987654",
+        integration.CONF_UPDATE_INTERVAL: 12,
+    }
+    entry = _FakeEntry(
+        integration,
+        entry_id="legacy-corrupt",
+        title="Corrupt Legacy",
+        data=dict(original_data),
+        options={},
+        version=3,
+        subentries={},
+        unique_id="legacy-corrupt-id",
+    )
+    hass = _FakeHass(entries=[entry])
+
+    with caplog.at_level("ERROR"):
+        assert asyncio.run(integration.async_migrate_entry(hass, entry)) is False
+
+    assert entry.data == original_data
+    assert entry.options == {}
+    assert entry.version == 3
+    assert entry.subentries == {}
+    assert hass.config_entries.added_subentries == []
+    assert hass.config_entries.removed_entries == []
+    assert "merged_into_entry_id" not in entry.data
+    assert (
+        "Cannot migrate Pollen Levels entry legacy-corrupt because it contains "
+        "invalid stored coordinates. The entry was left unchanged. Remove and "
+        "recreate this location or fix the configuration before retrying the "
+        "migration."
+    ) in caplog.text
+    assert "secret-api-key" not in caplog.text
+    assert "123.456789" not in caplog.text
+    assert "-222.987654" not in caplog.text
 
 
 def test_migrate_current_entry_updates_parent_unique_id_to_api_key_identity(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2004,6 +2004,75 @@ def test_migrate_group_with_invalid_legacy_coordinates_is_left_unchanged(
     assert "-222.987654" not in caplog.text
 
 
+def test_migrate_group_with_partial_legacy_coordinates_is_left_unchanged(
+    integration_modules: _InitModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Grouped migration should abort if a legacy entry has partial coordinates."""
+    integration = integration_modules.integration
+    parent_data = {
+        integration.CONF_API_KEY: "shared-secret",
+        integration.CONF_LATITUDE: 1.0,
+        integration.CONF_LONGITUDE: 2.0,
+        integration.CONF_UPDATE_INTERVAL: 12,
+    }
+    partial_data = {
+        integration.CONF_API_KEY: "shared-secret",
+        integration.CONF_LATITUDE: "45.123456",
+        integration.CONF_LANGUAGE_CODE: "en",
+    }
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        title="Home",
+        data=dict(parent_data),
+        options={},
+        version=3,
+        subentries={},
+        unique_id="1.0000_2.0000",
+    )
+    duplicate = _FakeEntry(
+        integration,
+        entry_id="legacy-partial",
+        title="Partial",
+        data=dict(partial_data),
+        options={},
+        version=3,
+        subentries={},
+    )
+    hass = _FakeHass(entries=[parent, duplicate])
+
+    with caplog.at_level("ERROR"):
+        assert asyncio.run(integration.async_migrate_entry(hass, parent)) is False
+
+    assert parent.data == parent_data
+    assert parent.options == {}
+    assert parent.version == 3
+    assert parent.subentries == {}
+    assert duplicate.data == partial_data
+    assert duplicate.options == {}
+    assert duplicate.version == 3
+    assert duplicate.subentries == {}
+    assert "merged_into_entry_id" not in parent.data
+    assert "merged_into_entry_id" not in duplicate.data
+    assert hass.config_entries.added_subentries == []
+    assert hass.config_entries.removed_entries == []
+    assert [entry.entry_id for entry in hass.config_entries.async_entries()] == [
+        "legacy-home",
+        "legacy-partial",
+    ]
+    assert (
+        "Cannot migrate Pollen Levels entry legacy-partial because it contains "
+        "invalid stored coordinates"
+    ) in caplog.text
+    assert (
+        "Aborted Pollen Levels API-key migration group because entry legacy-partial "
+        "contains invalid stored coordinates. The group was left unchanged."
+    ) in caplog.text
+    assert "shared-secret" not in caplog.text
+    assert "45.123456" not in caplog.text
+
+
 def test_migrate_legacy_entry_into_existing_clean_v3_parent(
     integration_modules: _InitModules,
 ) -> None:
@@ -2135,17 +2204,35 @@ def test_migrate_entry_without_location_does_not_create_corrupt_subentry(
     assert hass.config_entries.added_subentries == []
 
 
+@pytest.mark.parametrize(
+    ("coordinate_data", "precise_coordinate"),
+    [
+        (
+            {
+                "latitude": "123.456789",
+                "longitude": "-222.987654",
+            },
+            "123.456789",
+        ),
+        ({"latitude": "45.123456"}, "45.123456"),
+        ({"longitude": "-3.987654"}, "-3.987654"),
+    ],
+)
 def test_migrate_entry_with_invalid_legacy_coordinates_is_left_unchanged(
     integration_modules: _InitModules,
     caplog: pytest.LogCaptureFixture,
+    coordinate_data: dict[str, str],
+    precise_coordinate: str,
 ) -> None:
     """Legacy entries with corrupt coordinates should fail without side effects."""
     integration = integration_modules.integration
     original_data = {
         integration.CONF_API_KEY: "secret-api-key",
-        integration.CONF_LATITUDE: "123.456789",
-        integration.CONF_LONGITUDE: "-222.987654",
         integration.CONF_UPDATE_INTERVAL: 12,
+        **{
+            getattr(integration, f"CONF_{key.upper()}"): value
+            for key, value in coordinate_data.items()
+        },
     }
     entry = _FakeEntry(
         integration,
@@ -2176,8 +2263,7 @@ def test_migrate_entry_with_invalid_legacy_coordinates_is_left_unchanged(
         "migration."
     ) in caplog.text
     assert "secret-api-key" not in caplog.text
-    assert "123.456789" not in caplog.text
-    assert "-222.987654" not in caplog.text
+    assert precise_coordinate not in caplog.text
 
 
 def test_migrate_current_entry_updates_parent_unique_id_to_api_key_identity(


### PR DESCRIPTION
## Summary
- reject legacy entries with stored coordinate pairs that fail coordinate validation before building migration locations
- treat partial legacy coordinates (latitude-only or longitude-only) as corrupt and leave the entry unchanged
- abort whole API-key migration groups when any grouped entry has invalid or partial stored coordinates
- leave corrupt legacy entries unchanged without creating subentries, marking merged entries, removing entries, or clearing stored coordinates
- add tests for single-entry aborts, grouped aborts, partial-coordinate aborts, log redaction, and preserving valid migration behavior

## Verification
- python -m compileall -q custom_components tests
- python -m ruff check .
- python -m black --check .
- python -m pytest tests/test_init.py -q
- python -m pytest -q