### PR TITLE
Retry setup when any location subentry fails

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -297,11 +297,15 @@ async def async_setup_entry(
         latlon = validate_location_pair(raw_lat, raw_lon)
         if latlon is None:
             _LOGGER.warning(
-                "Invalid coordinates for entry %s subentry %s",
+                "Invalid coordinates for Pollen Levels entry %s subentry %s; "
+                "setup will be retried after the stored location is fixed",
                 entry.entry_id,
                 subentry_id,
             )
-            continue
+            entry.runtime_data = None
+            raise ConfigEntryNotReady(
+                "Pollen Levels location has invalid stored coordinates"
+            ) from None
         lat, lon = latlon
 
         coordinator = PollenDataUpdateCoordinator(
@@ -325,6 +329,8 @@ async def async_setup_entry(
             await coordinator.async_config_entry_first_refresh()
         except ConfigEntryAuthFailed:
             raise
+        except asyncio.CancelledError:
+            raise
         except ConfigEntryNotReady as err:
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
@@ -336,7 +342,10 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            continue
+            entry.runtime_data = None
+            raise ConfigEntryNotReady(
+                safe_message or "Pollen Levels location is not ready"
+            ) from None
         except Exception as err:
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
@@ -348,7 +357,10 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            continue
+            entry.runtime_data = None
+            raise ConfigEntryNotReady(
+                safe_message or "Pollen Levels location setup failed"
+            ) from None
 
         locations[subentry_id] = PollenLocationRuntime(
             subentry_id=subentry_id,

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -302,7 +302,6 @@ async def async_setup_entry(
                 entry.entry_id,
                 subentry_id,
             )
-            entry.runtime_data = None
             raise ConfigEntryNotReady(
                 "Pollen Levels location has invalid stored coordinates"
             ) from None
@@ -329,8 +328,6 @@ async def async_setup_entry(
             await coordinator.async_config_entry_first_refresh()
         except ConfigEntryAuthFailed:
             raise
-        except asyncio.CancelledError:
-            raise
         except ConfigEntryNotReady as err:
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
@@ -342,7 +339,6 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            entry.runtime_data = None
             raise ConfigEntryNotReady(
                 safe_message or "Pollen Levels location is not ready"
             ) from None
@@ -357,7 +353,6 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            entry.runtime_data = None
             raise ConfigEntryNotReady(
                 safe_message or "Pollen Levels location setup failed"
             ) from None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -629,12 +629,12 @@ def test_setup_entry_boundary_coordinates_are_allowed(
         assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
 
-def test_setup_entry_keeps_working_locations_when_one_subentry_fails(
+def test_setup_entry_raises_not_ready_when_one_subentry_fails(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A local refresh failure should not block other configured locations."""
+    """A local refresh failure should retry the whole parent entry."""
     integration = integration_modules.integration
 
     bad_subentry = integration.ConfigSubentry(
@@ -680,11 +680,12 @@ def test_setup_entry_keeps_working_locations_when_one_subentry_fails(
     monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
 
     with caplog.at_level("WARNING", logger=integration.__name__):
-        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+        with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
+            asyncio.run(integration.async_setup_entry(hass, entry))
 
-    assert entry.runtime_data is not None
-    assert set(entry.runtime_data.locations) == {"good-location"}
-    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    assert exc_info.value.__cause__ is None
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
     log_text = caplog.text
     assert "Initial data refresh failed for entry entry-1 subentry bad-location" in (
         log_text
@@ -692,6 +693,98 @@ def test_setup_entry_keeps_working_locations_when_one_subentry_fails(
     assert "secret-key" not in log_text
     assert "3.123456" not in log_text
     assert "-4.654321" not in log_text
+
+
+def test_setup_entry_raises_not_ready_when_subentry_coordinates_are_invalid(
+    integration_modules: _InitModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Invalid subentry coordinates should retry without partial runtime data."""
+    integration = integration_modules.integration
+
+    bad_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 91.123456,
+            integration.CONF_LONGITUDE: 2.654321,
+        },
+        subentry_id="bad-location",
+        title="Bad",
+    )
+    good_subentry = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="good-location",
+        title="Good",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "secret-key"},
+        subentries={
+            good_subentry.subentry_id: good_subentry,
+            bad_subentry.subentry_id: bad_subentry,
+        },
+    )
+    hass = _FakeHass()
+
+    with caplog.at_level("WARNING", logger=integration.__name__):
+        with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
+            asyncio.run(integration.async_setup_entry(hass, entry))
+
+    assert exc_info.value.__cause__ is None
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
+    log_text = caplog.text
+    assert (
+        "Invalid coordinates for Pollen Levels entry entry-1 subentry bad-location"
+        in (log_text)
+    )
+    assert "secret-key" not in log_text
+    assert "91.123456" not in log_text
+    assert "2.654321" not in log_text
+
+
+def test_setup_entry_raises_not_ready_when_later_subentry_is_not_ready(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later not-ready location should discard earlier successful setup work."""
+    integration = integration_modules.integration
+
+    first = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="first-location",
+    )
+    second = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 3.0, integration.CONF_LONGITUDE: 4.0},
+        subentry_id="second-location",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "key"},
+        subentries={first.subentry_id: first, second.subentry_id: second},
+    )
+    hass = _FakeHass()
+    refreshed: list[str] = []
+
+    class _PartiallyReadyCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+
+        async def async_config_entry_first_refresh(self):
+            refreshed.append(self.subentry_id)
+            if self.subentry_id == "second-location":
+                raise integration.ConfigEntryNotReady("retry later")
+
+    monkeypatch.setattr(
+        integration, "PollenDataUpdateCoordinator", _PartiallyReadyCoordinator
+    )
+
+    with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
+        asyncio.run(integration.async_setup_entry(hass, entry))
+
+    assert exc_info.value.__cause__ is None
+    assert refreshed == ["first-location", "second-location"]
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
 
 
 def test_setup_entry_raises_not_ready_when_all_subentries_fail(


### PR DESCRIPTION
## Summary
- make parent setup fail with ConfigEntryNotReady when any configured location subentry has invalid coordinates
- stop partial parent setup when any subentry first refresh raises ConfigEntryNotReady or an unexpected exception
- preserve ConfigEntryAuthFailed propagation and avoid catching cancellation
- keep runtime_data unset and skip platform forwarding on location setup failures
- update setup tests for all-or-retry location initialization and redacted logs

## Verification
- python -m compileall -q custom_components tests
- python -m ruff check .
- python -m black --check .
- python -m pytest tests/test_init.py -q
- python -m pytest -q