### PR TITLE
Prepare 3.0.0a4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [3.0.0a4] - 2026-06-05
+### Fixed
+- Hardened Google Pollen `dailyInfo` validation during config flow.
+- Prevented invalid or partial legacy coordinates from being migrated into v3
+  location subentries.
+- Aborted API-key group migration safely when any grouped legacy entry has
+  invalid coordinates.
+- Prevented partial parent setup when one configured location fails initial
+  refresh.
+- Kept parent entries without location subentries supported with an empty
+  runtime.
+
 ## [3.0.0a3] - 2026-06-02
 ### Fixed
 - Skipped stale runtime location coordinators after a location subentry is

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0a3"
+    "version": "3.0.0a4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0a3"
+version = "3.0.0a4"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
## Summary
- Bump integration and package version to 3.0.0a4.
- Add the 3.0.0a4 changelog entry for the pre-beta robustness fixes.

## Validation
- python -m compileall -q custom_components tests
- python -m ruff check .
- python -m black --check .
- python -m pytest -q

Note: pytest passed with one cache warning because the environment could not create .pytest_cache.