### PR TITLE
Fix beta1 audit findings

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -812,7 +812,11 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     getattr(self.hass, "config_entries", None),
                     "async_entry_for_domain_unique_id",
                 ):
-                    self._abort_if_unique_id_configured()
+                    existing_entry = _entry_for_parent_unique_id(
+                        self.hass, _api_key_unique_id(normalized[CONF_API_KEY])
+                    )
+                    if existing_entry is not None:
+                        return self.async_abort(reason="api_key_already_configured")
                 entry_name = str(user_input.get(CONF_NAME, "")).strip()
                 title = entry_name or DEFAULT_ENTRY_TITLE
                 subentry = _location_subentry_data(
@@ -892,7 +896,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if existing_entry is not None and getattr(
                         existing_entry, "entry_id", None
                     ) != getattr(entry, "entry_id", None):
-                        errors = {"base": "already_configured"}
+                        errors = {"base": "api_key_already_configured"}
                         display_errors = errors
                         display_placeholders = candidate_placeholders
                         break

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -301,25 +301,13 @@ async def async_get_config_entry_diagnostics(
     coordinate_pairs: list[tuple[Any, Any]] = []
     api_key = data.get(CONF_API_KEY)
     api_key_text = api_key if isinstance(api_key, str) else None
+    if CONF_LATITUDE in data or CONF_LONGITUDE in data:
+        coordinate_pairs.append((data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE)))
     if runtime is not None:
         active_subentry_ids = active_location_subentry_ids(entry)
         filter_stale_locations = bool(
             active_subentry_ids
         ) or not has_legacy_location_data(entry)
-        for subentry_id, location in runtime.locations.items():
-            if filter_stale_locations and subentry_id not in active_subentry_ids:
-                continue
-            coordinator = location.coordinator
-            coordinate_pairs.append(
-                (
-                    _coordinate_from_coordinator_or_data(
-                        coordinator, data, CONF_LATITUDE
-                    ),
-                    _coordinate_from_coordinator_or_data(
-                        coordinator, data, CONF_LONGITUDE
-                    ),
-                )
-            )
         for subentry_id, location in runtime.locations.items():
             if filter_stale_locations and subentry_id not in active_subentry_ids:
                 stale_location_ids.append(subentry_id)
@@ -329,6 +317,8 @@ async def async_get_config_entry_diagnostics(
             lon = _coordinate_from_coordinator_or_data(
                 coordinator, data, CONF_LONGITUDE
             )
+            if lat is not None or lon is not None:
+                coordinate_pairs.append((lat, lon))
             request_params_example: dict[str, Any] = {
                 "key": redact_api_key(api_key, api_key_text) or "***",
                 "location.latitude": _rounded(lat),

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -102,6 +102,20 @@ def _redact_diagnostics_text(
     return redacted
 
 
+def _coordinate_pairs_from_location_subentries(
+    entry: ConfigEntry,
+) -> list[tuple[Any, Any]]:
+    """Return stored coordinate pairs from active location subentries."""
+    subentries = getattr(entry, "subentries", {}) or {}
+    coordinate_pairs: list[tuple[Any, Any]] = []
+    for subentry_id in active_location_subentry_ids(entry):
+        subentry = subentries.get(subentry_id)
+        data = dict(getattr(subentry, "data", {}) or {})
+        if CONF_LATITUDE in data or CONF_LONGITUDE in data:
+            coordinate_pairs.append((data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE)))
+    return coordinate_pairs
+
+
 def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
     """Return diagnostics for one location coordinator."""
     coord_info = {
@@ -303,6 +317,7 @@ async def async_get_config_entry_diagnostics(
     api_key_text = api_key if isinstance(api_key, str) else None
     if CONF_LATITUDE in data or CONF_LONGITUDE in data:
         coordinate_pairs.append((data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE)))
+    coordinate_pairs.extend(_coordinate_pairs_from_location_subentries(entry))
     if runtime is not None:
         active_subentry_ids = active_location_subentry_ids(entry)
         filter_stale_locations = bool(

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -323,17 +323,28 @@ async def async_get_config_entry_diagnostics(
         filter_stale_locations = bool(
             active_subentry_ids
         ) or not has_legacy_location_data(entry)
+        # Pre-collect all runtime coordinate pairs before redacting any titles.
+        # This ensures a user-controlled title for one location can have all
+        # configured location coordinates redacted.
+        runtime_coords: dict[str, tuple[Any, Any]] = {}
         for subentry_id, location in runtime.locations.items():
             if filter_stale_locations and subentry_id not in active_subentry_ids:
-                stale_location_ids.append(subentry_id)
                 continue
             coordinator = location.coordinator
             lat = _coordinate_from_coordinator_or_data(coordinator, data, CONF_LATITUDE)
             lon = _coordinate_from_coordinator_or_data(
                 coordinator, data, CONF_LONGITUDE
             )
+            runtime_coords[subentry_id] = (lat, lon)
             if lat is not None or lon is not None:
                 coordinate_pairs.append((lat, lon))
+
+        for subentry_id, location in runtime.locations.items():
+            if filter_stale_locations and subentry_id not in active_subentry_ids:
+                stale_location_ids.append(subentry_id)
+                continue
+            coordinator = location.coordinator
+            lat, lon = runtime_coords.get(subentry_id, (None, None))
             request_params_example: dict[str, Any] = {
                 "key": redact_api_key(api_key, api_key_text) or "***",
                 "location.latitude": _rounded(lat),

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -40,6 +40,7 @@ from .util import (
     active_location_subentry_ids,
     has_legacy_location_data,
     redact_api_key,
+    redact_sensitive_values,
     safe_parse_int,
 )
 
@@ -87,6 +88,18 @@ def _effective_days(options: dict[str, Any], data: dict[str, Any]) -> int:
     parsed_days = safe_parse_int(days_raw)
     days_effective = DEFAULT_FORECAST_DAYS if parsed_days is None else parsed_days
     return max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, days_effective))
+
+
+def _redact_diagnostics_text(
+    value: Any,
+    api_key: str | None,
+    coordinate_pairs: list[tuple[Any, Any]],
+) -> str:
+    """Redact secrets from user-controlled diagnostics text."""
+    redacted = redact_sensitive_values(value, api_key=api_key)
+    for lat, lon in coordinate_pairs:
+        redacted = redact_sensitive_values(redacted, latitude=lat, longitude=lon)
+    return redacted
 
 
 def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
@@ -285,11 +298,28 @@ async def async_get_config_entry_diagnostics(
     locations: dict[str, Any] = {}
     stale_location_ids: list[str] = []
     first_location_payload: dict[str, Any] | None = None
+    coordinate_pairs: list[tuple[Any, Any]] = []
+    api_key = data.get(CONF_API_KEY)
+    api_key_text = api_key if isinstance(api_key, str) else None
     if runtime is not None:
         active_subentry_ids = active_location_subentry_ids(entry)
         filter_stale_locations = bool(
             active_subentry_ids
         ) or not has_legacy_location_data(entry)
+        for subentry_id, location in runtime.locations.items():
+            if filter_stale_locations and subentry_id not in active_subentry_ids:
+                continue
+            coordinator = location.coordinator
+            coordinate_pairs.append(
+                (
+                    _coordinate_from_coordinator_or_data(
+                        coordinator, data, CONF_LATITUDE
+                    ),
+                    _coordinate_from_coordinator_or_data(
+                        coordinator, data, CONF_LONGITUDE
+                    ),
+                )
+            )
         for subentry_id, location in runtime.locations.items():
             if filter_stale_locations and subentry_id not in active_subentry_ids:
                 stale_location_ids.append(subentry_id)
@@ -300,8 +330,7 @@ async def async_get_config_entry_diagnostics(
                 coordinator, data, CONF_LONGITUDE
             )
             request_params_example: dict[str, Any] = {
-                "key": redact_api_key(data.get(CONF_API_KEY), data.get(CONF_API_KEY))
-                or "***",
+                "key": redact_api_key(api_key, api_key_text) or "***",
                 "location.latitude": _rounded(lat),
                 "location.longitude": _rounded(lon),
                 "days": days_effective,
@@ -309,8 +338,10 @@ async def async_get_config_entry_diagnostics(
             if lang:
                 request_params_example["languageCode"] = lang
             location_payload = _coordinator_diagnostics(coordinator)
-            location_payload["title"] = getattr(
-                coordinator, "entry_title", DEFAULT_ENTRY_TITLE
+            location_payload["title"] = _redact_diagnostics_text(
+                getattr(coordinator, "entry_title", DEFAULT_ENTRY_TITLE),
+                api_key_text,
+                coordinate_pairs,
             )
             location_payload["approximate_location"] = {
                 "label": "approximate_location (rounded)",
@@ -326,7 +357,11 @@ async def async_get_config_entry_diagnostics(
     diag: dict[str, Any] = {
         "entry": {
             "entry_id": entry.entry_id,
-            "title": entry.title,
+            "title": _redact_diagnostics_text(
+                entry.title,
+                api_key_text,
+                coordinate_pairs,
+            ),
             "options": {
                 CONF_UPDATE_INTERVAL: options.get(CONF_UPDATE_INTERVAL),
                 CONF_LANGUAGE_CODE: options.get(CONF_LANGUAGE_CODE),

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -112,6 +112,17 @@ def _log_invalid_legacy_coordinates(entry: ConfigEntry) -> None:
     )
 
 
+def _log_unmigratable_location_subentries(entry: ConfigEntry) -> None:
+    """Log an actionable migration failure for corrupt location subentries."""
+    _LOGGER.error(
+        "Cannot migrate Pollen Levels entry %s because it has location subentries "
+        "with invalid stored migration data. The entry was left unchanged. Remove "
+        "and recreate the affected location or fix the configuration before "
+        "retrying the migration.",
+        entry.entry_id,
+    )
+
+
 def _invalid_legacy_coordinate_entry(
     entries: list[ConfigEntry],
 ) -> ConfigEntry | None:
@@ -225,6 +236,11 @@ def _location_from_subentry(
         return None
     if CONF_LATITUDE not in data or CONF_LONGITUDE not in data:
         return None
+    if (
+        validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+        is None
+    ):
+        return None
 
     subentry_data = {
         CONF_LATITUDE: data.get(CONF_LATITUDE),
@@ -274,6 +290,25 @@ def _has_location_subentries(entry: ConfigEntry) -> bool:
     )
 
 
+def _has_invalid_legacy_location_subentry(entry: ConfigEntry) -> bool:
+    """Return whether a legacy location subentry has unusable coordinates."""
+    for subentry in (getattr(entry, "subentries", {}) or {}).values():
+        if getattr(subentry, "subentry_type", None) != SUBENTRY_TYPE_LOCATION:
+            continue
+        data = dict(getattr(subentry, "data", {}) or {})
+        legacy_entry_id = data.get(CONF_LEGACY_ENTRY_ID)
+        if not isinstance(legacy_entry_id, str) or not legacy_entry_id:
+            continue
+        if CONF_LATITUDE not in data or CONF_LONGITUDE not in data:
+            return True
+        if (
+            validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+            is None
+        ):
+            return True
+    return False
+
+
 def _has_unmigratable_location_subentries(entry: ConfigEntry) -> bool:
     """Return whether location subentries cannot be safely auto-merged."""
     for subentry in (getattr(entry, "subentries", {}) or {}).values():
@@ -290,6 +325,11 @@ def _has_unmigratable_location_subentries(entry: ConfigEntry) -> bool:
         if not looks_like_location:
             continue
         if CONF_LATITUDE not in data or CONF_LONGITUDE not in data:
+            return True
+        if (
+            validate_location_pair(data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE))
+            is None
+        ):
             return True
         legacy_entry_id = data.get(CONF_LEGACY_ENTRY_ID)
         if not isinstance(legacy_entry_id, str) or not legacy_entry_id:
@@ -767,15 +807,12 @@ async def _async_migrate_grouped_entries(
     )
     for source in group:
         if source is parent:
+            if _has_invalid_legacy_location_subentry(source):
+                _log_unmigratable_location_subentries(source)
+                return False
             continue
         if _has_unmigratable_location_subentries(source):
-            _LOGGER.error(
-                "Cannot merge Pollen Levels entry %s into parent %s because it "
-                "has location subentries that cannot be safely mapped to "
-                "migration targets",
-                source.entry_id,
-                parent.entry_id,
-            )
+            _log_unmigratable_location_subentries(source)
             return False
 
     parent_options = _clean_parent_options(parent)
@@ -856,7 +893,7 @@ async def _async_migrate_grouped_entries(
             )
         if not entity_registry_migrated or not device_registry_migrated:
             _LOGGER.warning(
-                "Registry migration incomplete; keeping entries unchanged for retry"
+                "Registry migration incomplete; migration state will be reused on retry"
             )
             return False
 
@@ -928,7 +965,7 @@ def _repair_existing_parent_registry_links(
         )
     if not entity_registry_migrated or not device_registry_migrated:
         _LOGGER.warning(
-            "Registry migration incomplete; keeping entries unchanged for retry"
+            "Registry migration incomplete; migration state will be reused on retry"
         )
         return False
     return True
@@ -957,6 +994,9 @@ async def async_handle_entry_migration(
 
         if _has_invalid_legacy_coordinates(entry):
             _log_invalid_legacy_coordinates(entry)
+            return False
+        if _has_invalid_legacy_location_subentry(entry):
+            _log_unmigratable_location_subentries(entry)
             return False
 
         existing_data = entry.data or {}
@@ -1041,7 +1081,7 @@ async def async_handle_entry_migration(
                 )
             if not entity_registry_migrated or not device_registry_migrated:
                 _LOGGER.warning(
-                    "Registry migration incomplete; keeping entries unchanged for retry"
+                    "Registry migration incomplete; migration state will be reused on retry"
                 )
                 return False
 

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "L’interval d’actualització ha d’estar entre 1 i 24 hores.",
       "invalid_forecast_days": "Els dies de previsió han d’estar entre 1 i 5.",
       "already_configured": "Aquesta ubicació ja està configurada.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Aquesta clau API ja està configurada."
     },
     "abort": {
       "already_configured": "Aquesta ubicació ja està configurada.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Aquesta clau API ja està configurada.",
       "reauth_successful": "La reautenticació s'ha completat correctament.",
       "reauth_failed": "La reautenticació ha fallat. Torna-ho a provar.",
       "reconfigure_successful": "La reconfiguració s'ha completat correctament.",

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -40,10 +40,12 @@
       "unknown": "Error desconegut",
       "invalid_update_interval": "L’interval d’actualització ha d’estar entre 1 i 24 hores.",
       "invalid_forecast_days": "Els dies de previsió han d’estar entre 1 i 5.",
-      "already_configured": "Aquesta ubicació ja està configurada."
+      "already_configured": "Aquesta ubicació ja està configurada.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Aquesta ubicació ja està configurada.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "La reautenticació s'ha completat correctament.",
       "reauth_failed": "La reautenticació ha fallat. Torna-ho a provar.",
       "reconfigure_successful": "La reconfiguració s'ha completat correctament.",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -40,10 +40,12 @@
       "unknown": "Neznámá chyba",
       "invalid_update_interval": "Interval aktualizace musí být mezi 1 a 24 hodinami.",
       "invalid_forecast_days": "Dny předpovědi musí být v rozmezí 1–5.",
-      "already_configured": "Toto umístění je již nakonfigurováno."
+      "already_configured": "Toto umístění je již nakonfigurováno.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Toto umístění je již nakonfigurováno.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Opětovné ověření proběhlo úspěšně.",
       "reauth_failed": "Opětovné ověření se nezdařilo. Zkuste to znovu.",
       "reconfigure_successful": "Překonfigurování bylo úspěšně dokončeno.",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Interval aktualizace musí být mezi 1 a 24 hodinami.",
       "invalid_forecast_days": "Dny předpovědi musí být v rozmezí 1–5.",
       "already_configured": "Toto umístění je již nakonfigurováno.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Tento klíč API je již nakonfigurován."
     },
     "abort": {
       "already_configured": "Toto umístění je již nakonfigurováno.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Tento klíč API je již nakonfigurován.",
       "reauth_successful": "Opětovné ověření proběhlo úspěšně.",
       "reauth_failed": "Opětovné ověření se nezdařilo. Zkuste to znovu.",
       "reconfigure_successful": "Překonfigurování bylo úspěšně dokončeno.",

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -40,10 +40,12 @@
       "unknown": "Ukendt fejl",
       "invalid_update_interval": "Opdateringsintervallet skal være mellem 1 og 24 timer.",
       "invalid_forecast_days": "Prognosedage skal være mellem 1 og 5.",
-      "already_configured": "Denne placering er allerede konfigureret."
+      "already_configured": "Denne placering er allerede konfigureret.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Denne placering er allerede konfigureret.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Genautentificering fuldført.",
       "reauth_failed": "Genautentificering mislykkedes. Prøv igen.",
       "reconfigure_successful": "Omkonfiguration blev fuldført.",

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Opdateringsintervallet skal være mellem 1 og 24 timer.",
       "invalid_forecast_days": "Prognosedage skal være mellem 1 og 5.",
       "already_configured": "Denne placering er allerede konfigureret.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Denne API-nøgle er allerede konfigureret."
     },
     "abort": {
       "already_configured": "Denne placering er allerede konfigureret.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Denne API-nøgle er allerede konfigureret.",
       "reauth_successful": "Genautentificering fuldført.",
       "reauth_failed": "Genautentificering mislykkedes. Prøv igen.",
       "reconfigure_successful": "Omkonfiguration blev fuldført.",

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -40,10 +40,12 @@
       "unknown": "Unbekannter Fehler",
       "invalid_update_interval": "Das Aktualisierungsintervall muss zwischen 1 und 24 Stunden liegen.",
       "invalid_forecast_days": "Vorhersagetage müssen zwischen 1 und 5 liegen.",
-      "already_configured": "Dieser Standort ist bereits konfiguriert."
+      "already_configured": "Dieser Standort ist bereits konfiguriert.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Dieser Standort ist bereits konfiguriert.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich.",
       "reauth_failed": "Die erneute Authentifizierung ist fehlgeschlagen. Bitte versuche es erneut.",
       "reconfigure_successful": "Die Neukonfiguration wurde erfolgreich abgeschlossen.",

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Das Aktualisierungsintervall muss zwischen 1 und 24 Stunden liegen.",
       "invalid_forecast_days": "Vorhersagetage müssen zwischen 1 und 5 liegen.",
       "already_configured": "Dieser Standort ist bereits konfiguriert.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Dieser API-Schlüssel ist bereits konfiguriert."
     },
     "abort": {
       "already_configured": "Dieser Standort ist bereits konfiguriert.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Dieser API-Schlüssel ist bereits konfiguriert.",
       "reauth_successful": "Die erneute Authentifizierung war erfolgreich.",
       "reauth_failed": "Die erneute Authentifizierung ist fehlgeschlagen. Bitte versuche es erneut.",
       "reconfigure_successful": "Die Neukonfiguration wurde erfolgreich abgeschlossen.",

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -31,7 +31,8 @@
     },
     "error": {
       "invalid_auth": "Invalid API key\n\n{error_message}",
-      "already_configured": "This API key or location is already configured.",
+      "already_configured": "This location is already configured.",
+      "api_key_already_configured": "This API key is already configured.",
       "cannot_connect": "Unable to connect to the pollen service.\n\n{error_message}",
       "quota_exceeded": "Quota exceeded\n\n{error_message}",
       "invalid_language_format": "Use a canonical BCP-47 code such as \"en\" or \"es-ES\".",
@@ -43,7 +44,8 @@
       "invalid_forecast_days": "Forecast days must be between 1 and 5."
     },
     "abort": {
-      "already_configured": "This API key or location is already configured.",
+      "already_configured": "This location is already configured.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Re-authentication completed successfully.",
       "reauth_failed": "Re-authentication failed. Please try again.",
       "reconfigure_successful": "Reconfiguration completed successfully.",
@@ -76,7 +78,7 @@
         }
       },
       "error": {
-        "already_configured": "This API key or location is already configured.",
+        "already_configured": "This location is already configured.",
         "invalid_coordinates": "Please select a valid location on the map.",
         "unknown": "Unknown error",
         "invalid_auth": "Invalid API key\n\n{error_message}",

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -31,7 +31,7 @@
     },
     "error": {
       "invalid_auth": "Invalid API key\n\n{error_message}",
-      "already_configured": "This location is already configured.",
+      "already_configured": "This API key or location is already configured.",
       "cannot_connect": "Unable to connect to the pollen service.\n\n{error_message}",
       "quota_exceeded": "Quota exceeded\n\n{error_message}",
       "invalid_language_format": "Use a canonical BCP-47 code such as \"en\" or \"es-ES\".",
@@ -43,7 +43,7 @@
       "invalid_forecast_days": "Forecast days must be between 1 and 5."
     },
     "abort": {
-      "already_configured": "This location is already configured.",
+      "already_configured": "This API key or location is already configured.",
       "reauth_successful": "Re-authentication completed successfully.",
       "reauth_failed": "Re-authentication failed. Please try again.",
       "reconfigure_successful": "Reconfiguration completed successfully.",
@@ -76,7 +76,7 @@
         }
       },
       "error": {
-        "already_configured": "This location is already configured.",
+        "already_configured": "This API key or location is already configured.",
         "invalid_coordinates": "Please select a valid location on the map.",
         "unknown": "Unknown error",
         "invalid_auth": "Invalid API key\n\n{error_message}",

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "El intervalo de actualización debe estar entre 1 y 24 horas.",
       "invalid_forecast_days": "Los días de previsión deben estar entre 1 y 5.",
       "already_configured": "Esta ubicación ya está configurada.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Esta clave API ya está configurada."
     },
     "abort": {
       "already_configured": "Esta ubicación ya está configurada.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Esta clave API ya está configurada.",
       "reauth_successful": "La reautenticación se completó correctamente.",
       "reauth_failed": "La reautenticación falló. Inténtalo de nuevo.",
       "reconfigure_successful": "La reconfiguración se completó correctamente.",

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -40,10 +40,12 @@
       "unknown": "Error desconocido",
       "invalid_update_interval": "El intervalo de actualización debe estar entre 1 y 24 horas.",
       "invalid_forecast_days": "Los días de previsión deben estar entre 1 y 5.",
-      "already_configured": "Esta ubicación ya está configurada."
+      "already_configured": "Esta ubicación ya está configurada.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Esta ubicación ya está configurada.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "La reautenticación se completó correctamente.",
       "reauth_failed": "La reautenticación falló. Inténtalo de nuevo.",
       "reconfigure_successful": "La reconfiguración se completó correctamente.",

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -40,10 +40,12 @@
       "unknown": "Tuntematon virhe",
       "invalid_update_interval": "Päivitysvälin on oltava 1–24 tuntia.",
       "invalid_forecast_days": "Ennustepäivien on oltava välillä 1–5.",
-      "already_configured": "Tämä sijainti on jo määritetty."
+      "already_configured": "Tämä sijainti on jo määritetty.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Tämä sijainti on jo määritetty.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Uudelleentodennus onnistui.",
       "reauth_failed": "Uudelleentodennus epäonnistui. Yritä uudelleen.",
       "reconfigure_successful": "Uudelleenmääritys onnistui.",

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Päivitysvälin on oltava 1–24 tuntia.",
       "invalid_forecast_days": "Ennustepäivien on oltava välillä 1–5.",
       "already_configured": "Tämä sijainti on jo määritetty.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Tämä API-avain on jo määritetty."
     },
     "abort": {
       "already_configured": "Tämä sijainti on jo määritetty.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Tämä API-avain on jo määritetty.",
       "reauth_successful": "Uudelleentodennus onnistui.",
       "reauth_failed": "Uudelleentodennus epäonnistui. Yritä uudelleen.",
       "reconfigure_successful": "Uudelleenmääritys onnistui.",

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "L’intervalle de mise à jour doit être compris entre 1 et 24 heures.",
       "invalid_forecast_days": "Les jours de prévision doivent être compris entre 1 et 5.",
       "already_configured": "Cet emplacement est déjà configuré.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Cette clé API est déjà configurée."
     },
     "abort": {
       "already_configured": "Cet emplacement est déjà configuré.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Cette clé API est déjà configurée.",
       "reauth_successful": "La réauthentification a réussi.",
       "reauth_failed": "La réauthentification a échoué. Veuillez réessayer.",
       "reconfigure_successful": "La reconfiguration est terminée avec succès.",

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -40,10 +40,12 @@
       "unknown": "Erreur inconnue",
       "invalid_update_interval": "L’intervalle de mise à jour doit être compris entre 1 et 24 heures.",
       "invalid_forecast_days": "Les jours de prévision doivent être compris entre 1 et 5.",
-      "already_configured": "Cet emplacement est déjà configuré."
+      "already_configured": "Cet emplacement est déjà configuré.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Cet emplacement est déjà configuré.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "La réauthentification a réussi.",
       "reauth_failed": "La réauthentification a échoué. Veuillez réessayer.",
       "reconfigure_successful": "La reconfiguration est terminée avec succès.",

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "A frissítési időköznek 1 és 24 óra között kell lennie.",
       "invalid_forecast_days": "Az előrejelzési napoknak 1 és 5 között kell lenniük.",
       "already_configured": "Ez a hely már be van állítva.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Ez az API-kulcs már be van állítva."
     },
     "abort": {
       "already_configured": "Ez a hely már konfigurálva van.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Ez az API-kulcs már be van állítva.",
       "reauth_successful": "Az újrahitelesítés sikerült.",
       "reauth_failed": "Az újrahitelesítés nem sikerült. Próbáld meg újra.",
       "reconfigure_successful": "Az újrakonfigurálás sikeresen befejeződött.",

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -40,10 +40,12 @@
       "unknown": "Ismeretlen hiba",
       "invalid_update_interval": "A frissítési időköznek 1 és 24 óra között kell lennie.",
       "invalid_forecast_days": "Az előrejelzési napoknak 1 és 5 között kell lenniük.",
-      "already_configured": "Ez a hely már be van állítva."
+      "already_configured": "Ez a hely már be van állítva.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Ez a hely már konfigurálva van.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Az újrahitelesítés sikerült.",
       "reauth_failed": "Az újrahitelesítés nem sikerült. Próbáld meg újra.",
       "reconfigure_successful": "Az újrakonfigurálás sikeresen befejeződött.",

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "L’intervallo di aggiornamento deve essere compreso tra 1 e 24 ore.",
       "invalid_forecast_days": "I giorni di previsione devono essere compresi tra 1 e 5.",
       "already_configured": "Questa posizione è già configurata.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Questa chiave API è già configurata."
     },
     "abort": {
       "already_configured": "Questa posizione è già configurata.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Questa chiave API è già configurata.",
       "reauth_successful": "La ri-autenticazione è stata completata con successo.",
       "reauth_failed": "La ri-autenticazione non è riuscita. Riprova.",
       "reconfigure_successful": "Riconfigurazione completata con successo.",

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -40,10 +40,12 @@
       "unknown": "Errore sconosciuto",
       "invalid_update_interval": "L’intervallo di aggiornamento deve essere compreso tra 1 e 24 ore.",
       "invalid_forecast_days": "I giorni di previsione devono essere compresi tra 1 e 5.",
-      "already_configured": "Questa posizione è già configurata."
+      "already_configured": "Questa posizione è già configurata.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Questa posizione è già configurata.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "La ri-autenticazione è stata completata con successo.",
       "reauth_failed": "La ri-autenticazione non è riuscita. Riprova.",
       "reconfigure_successful": "Riconfigurazione completata con successo.",

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -40,10 +40,12 @@
       "unknown": "Ukjent feil",
       "invalid_update_interval": "Oppdateringsintervallet må være mellom 1 og 24 timer.",
       "invalid_forecast_days": "Prognosedager må være mellom 1 og 5.",
-      "already_configured": "Denne plasseringen er allerede konfigurert."
+      "already_configured": "Denne plasseringen er allerede konfigurert.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Dette stedet er allerede konfigurert.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Ny autentisering fullført.",
       "reauth_failed": "Ny autentisering mislyktes. Prøv igjen.",
       "reconfigure_successful": "Omkonfigurering fullført.",

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Oppdateringsintervallet må være mellom 1 og 24 timer.",
       "invalid_forecast_days": "Prognosedager må være mellom 1 og 5.",
       "already_configured": "Denne plasseringen er allerede konfigurert.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Denne API-nøkkelen er allerede konfigurert."
     },
     "abort": {
       "already_configured": "Dette stedet er allerede konfigurert.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Denne API-nøkkelen er allerede konfigurert.",
       "reauth_successful": "Ny autentisering fullført.",
       "reauth_failed": "Ny autentisering mislyktes. Prøv igjen.",
       "reconfigure_successful": "Omkonfigurering fullført.",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -40,10 +40,12 @@
       "unknown": "Onbekende fout",
       "invalid_update_interval": "Het update-interval moet tussen 1 en 24 uur liggen.",
       "invalid_forecast_days": "Voorspellingsdagen moeten tussen 1 en 5 liggen.",
-      "already_configured": "Deze locatie is al geconfigureerd."
+      "already_configured": "Deze locatie is al geconfigureerd.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Deze locatie is al geconfigureerd.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Opnieuw autoriseren voltooid.",
       "reauth_failed": "Opnieuw autoriseren is mislukt. Probeer het opnieuw.",
       "reconfigure_successful": "Herconfiguratie is succesvol voltooid.",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Het update-interval moet tussen 1 en 24 uur liggen.",
       "invalid_forecast_days": "Voorspellingsdagen moeten tussen 1 en 5 liggen.",
       "already_configured": "Deze locatie is al geconfigureerd.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Deze API-sleutel is al geconfigureerd."
     },
     "abort": {
       "already_configured": "Deze locatie is al geconfigureerd.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Deze API-sleutel is al geconfigureerd.",
       "reauth_successful": "Opnieuw autoriseren voltooid.",
       "reauth_failed": "Opnieuw autoriseren is mislukt. Probeer het opnieuw.",
       "reconfigure_successful": "Herconfiguratie is succesvol voltooid.",

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Interwał aktualizacji musi wynosić od 1 do 24 godzin.",
       "invalid_forecast_days": "Dni prognozy muszą mieścić się w zakresie 1–5.",
       "already_configured": "Ta lokalizacja jest już skonfigurowana.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Ten klucz API jest już skonfigurowany."
     },
     "abort": {
       "already_configured": "Ta lokalizacja jest już skonfigurowana.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Ten klucz API jest już skonfigurowany.",
       "reauth_successful": "Ponowne uwierzytelnienie zakończone pomyślnie.",
       "reauth_failed": "Ponowne uwierzytelnienie nie powiodło się. Spróbuj ponownie.",
       "reconfigure_successful": "Ponowna konfiguracja została zakończona pomyślnie.",

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -40,10 +40,12 @@
       "unknown": "Nieznany błąd",
       "invalid_update_interval": "Interwał aktualizacji musi wynosić od 1 do 24 godzin.",
       "invalid_forecast_days": "Dni prognozy muszą mieścić się w zakresie 1–5.",
-      "already_configured": "Ta lokalizacja jest już skonfigurowana."
+      "already_configured": "Ta lokalizacja jest już skonfigurowana.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Ta lokalizacja jest już skonfigurowana.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Ponowne uwierzytelnienie zakończone pomyślnie.",
       "reauth_failed": "Ponowne uwierzytelnienie nie powiodło się. Spróbuj ponownie.",
       "reconfigure_successful": "Ponowna konfiguracja została zakończona pomyślnie.",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
       "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
       "already_configured": "Este local já está configurado.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Esta chave de API já está configurada."
     },
     "abort": {
       "already_configured": "Este local já está configurado.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Esta chave de API já está configurada.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
       "reauth_failed": "A reautenticação falhou. Tente novamente.",
       "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -40,10 +40,12 @@
       "unknown": "Erro desconhecido",
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
       "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
-      "already_configured": "Este local já está configurado."
+      "already_configured": "Este local já está configurado.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Este local já está configurado.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
       "reauth_failed": "A reautenticação falhou. Tente novamente.",
       "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
       "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
       "already_configured": "Esta localização já está configurada.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Esta chave de API já está configurada."
     },
     "abort": {
       "already_configured": "Esta localização já está configurada.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Esta chave de API já está configurada.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
       "reauth_failed": "A reautenticação falhou. Tente novamente.",
       "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -40,10 +40,12 @@
       "unknown": "Erro desconhecido",
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
       "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
-      "already_configured": "Esta localização já está configurada."
+      "already_configured": "Esta localização já está configurada.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Esta localização já está configurada.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Reautenticação concluída com sucesso.",
       "reauth_failed": "A reautenticação falhou. Tente novamente.",
       "reconfigure_successful": "A reconfiguração foi concluída com sucesso.",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Intervalul de actualizare trebuie să fie între 1 și 24 de ore.",
       "invalid_forecast_days": "Zilele de prognoză trebuie să fie între 1 și 5.",
       "already_configured": "Această locație este deja configurată.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Această cheie API este deja configurată."
     },
     "abort": {
       "already_configured": "Această locație este deja configurată.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Această cheie API este deja configurată.",
       "reauth_successful": "Reautentificarea s-a încheiat cu succes.",
       "reauth_failed": "Reautentificarea a eșuat. Încercați din nou.",
       "reconfigure_successful": "Reconfigurarea s-a finalizat cu succes.",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -40,10 +40,12 @@
       "unknown": "Eroare necunoscută",
       "invalid_update_interval": "Intervalul de actualizare trebuie să fie între 1 și 24 de ore.",
       "invalid_forecast_days": "Zilele de prognoză trebuie să fie între 1 și 5.",
-      "already_configured": "Această locație este deja configurată."
+      "already_configured": "Această locație este deja configurată.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Această locație este deja configurată.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Reautentificarea s-a încheiat cu succes.",
       "reauth_failed": "Reautentificarea a eșuat. Încercați din nou.",
       "reconfigure_successful": "Reconfigurarea s-a finalizat cu succes.",

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Интервал обновления должен быть от 1 до 24 часов.",
       "invalid_forecast_days": "Дни прогноза должны быть от 1 до 5.",
       "already_configured": "Это местоположение уже настроено.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Этот API-ключ уже настроен."
     },
     "abort": {
       "already_configured": "Это местоположение уже настроено.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Этот API-ключ уже настроен.",
       "reauth_successful": "Повторная аутентификация выполнена успешно.",
       "reauth_failed": "Повторная аутентификация не удалась. Повторите попытку.",
       "reconfigure_successful": "Перенастройка успешно завершена.",

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -40,10 +40,12 @@
       "unknown": "Неизвестная ошибка",
       "invalid_update_interval": "Интервал обновления должен быть от 1 до 24 часов.",
       "invalid_forecast_days": "Дни прогноза должны быть от 1 до 5.",
-      "already_configured": "Это местоположение уже настроено."
+      "already_configured": "Это местоположение уже настроено.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Это местоположение уже настроено.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Повторная аутентификация выполнена успешно.",
       "reauth_failed": "Повторная аутентификация не удалась. Повторите попытку.",
       "reconfigure_successful": "Перенастройка успешно завершена.",

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -40,10 +40,12 @@
       "unknown": "Okänt fel",
       "invalid_update_interval": "Uppdateringsintervallet måste vara mellan 1 och 24 timmar.",
       "invalid_forecast_days": "Prognosdagar måste vara mellan 1 och 5.",
-      "already_configured": "Den här platsen är redan konfigurerad."
+      "already_configured": "Den här platsen är redan konfigurerad.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Den här platsen är redan konfigurerad.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Återautentiseringen lyckades.",
       "reauth_failed": "Återautentiseringen misslyckades. Försök igen.",
       "reconfigure_successful": "Omkonfigureringen slutfördes.",

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Uppdateringsintervallet måste vara mellan 1 och 24 timmar.",
       "invalid_forecast_days": "Prognosdagar måste vara mellan 1 och 5.",
       "already_configured": "Den här platsen är redan konfigurerad.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Den här API-nyckeln är redan konfigurerad."
     },
     "abort": {
       "already_configured": "Den här platsen är redan konfigurerad.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Den här API-nyckeln är redan konfigurerad.",
       "reauth_successful": "Återautentiseringen lyckades.",
       "reauth_failed": "Återautentiseringen misslyckades. Försök igen.",
       "reconfigure_successful": "Omkonfigureringen slutfördes.",

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "Інтервал оновлення має бути між 1 і 24 годинами.",
       "invalid_forecast_days": "Дні прогнозу мають бути від 1 до 5.",
       "already_configured": "Це місце вже налаштовано.",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "Цей API-ключ уже налаштовано."
     },
     "abort": {
       "already_configured": "Це розташування вже налаштовано.",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "Цей API-ключ уже налаштовано.",
       "reauth_successful": "Повторна автентифікація виконана успішно.",
       "reauth_failed": "Повторна автентифікація не вдалася. Спробуйте ще раз.",
       "reconfigure_successful": "Переналаштування успішно завершено.",

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -40,10 +40,12 @@
       "unknown": "Невідома помилка",
       "invalid_update_interval": "Інтервал оновлення має бути між 1 і 24 годинами.",
       "invalid_forecast_days": "Дні прогнозу мають бути від 1 до 5.",
-      "already_configured": "Це місце вже налаштовано."
+      "already_configured": "Це місце вже налаштовано.",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "Це розташування вже налаштовано.",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "Повторна автентифікація виконана успішно.",
       "reauth_failed": "Повторна автентифікація не вдалася. Спробуйте ще раз.",
       "reconfigure_successful": "Переналаштування успішно завершено.",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "更新间隔必须在 1 到 24 小时之间。",
       "invalid_forecast_days": "预测天数必须在 1 到 5 之间。",
       "already_configured": "此位置已配置。",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "此 API 密钥已配置。"
     },
     "abort": {
       "already_configured": "该位置已配置。",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "此 API 密钥已配置。",
       "reauth_successful": "重新验证已成功完成。",
       "reauth_failed": "重新验证失败。请重试。",
       "reconfigure_successful": "重新配置已成功完成。",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -40,10 +40,12 @@
       "unknown": "未知错误",
       "invalid_update_interval": "更新间隔必须在 1 到 24 小时之间。",
       "invalid_forecast_days": "预测天数必须在 1 到 5 之间。",
-      "already_configured": "此位置已配置。"
+      "already_configured": "此位置已配置。",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "该位置已配置。",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "重新验证已成功完成。",
       "reauth_failed": "重新验证失败。请重试。",
       "reconfigure_successful": "重新配置已成功完成。",

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -41,11 +41,11 @@
       "invalid_update_interval": "更新間隔必須在 1 到 24 小時之間。",
       "invalid_forecast_days": "預測天數必須在 1 到 5 之間。",
       "already_configured": "此位置已設定。",
-      "api_key_already_configured": "This API key is already configured."
+      "api_key_already_configured": "此 API 金鑰已設定。"
     },
     "abort": {
       "already_configured": "此位置已設定。",
-      "api_key_already_configured": "This API key is already configured.",
+      "api_key_already_configured": "此 API 金鑰已設定。",
       "reauth_successful": "重新驗證已成功完成。",
       "reauth_failed": "重新驗證失敗。請再試一次。",
       "reconfigure_successful": "重新設定已成功完成。",

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -40,10 +40,12 @@
       "unknown": "未知錯誤",
       "invalid_update_interval": "更新間隔必須在 1 到 24 小時之間。",
       "invalid_forecast_days": "預測天數必須在 1 到 5 之間。",
-      "already_configured": "此位置已設定。"
+      "already_configured": "此位置已設定。",
+      "api_key_already_configured": "This API key is already configured."
     },
     "abort": {
       "already_configured": "此位置已設定。",
+      "api_key_already_configured": "This API key is already configured.",
       "reauth_successful": "重新驗證已成功完成。",
       "reauth_failed": "重新驗證失敗。請再試一次。",
       "reconfigure_successful": "重新設定已成功完成。",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2250,7 +2250,7 @@ def test_api_key_confirm_rejects_duplicate_parent_unique_id(
 
     assert result == {
         "step_id": step_method_name.removeprefix("async_step_"),
-        "errors": {"base": "already_configured"},
+        "errors": {"base": "api_key_already_configured"},
     }
     assert recorder.updated is None
     assert recorder.reloaded is None
@@ -2837,9 +2837,9 @@ def test_async_step_user_checks_api_key_unique_id_for_existing_parent(
         },
     }
 
-    with pytest.raises(_AlreadyConfigured):
-        asyncio.run(flow.async_step_user(user_input))
+    result = asyncio.run(flow.async_step_user(user_input))
 
+    assert result == {"type": "abort", "reason": "api_key_already_configured"}
     assert flow.unique_ids == [
         config_flow_stubs.config_flow._api_key_unique_id("shared-key")
     ]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -259,6 +259,87 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_redacts_multi_location_titles(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Multi-location title redaction should cover all runtime coordinates.
+
+    The first coordinator's user-controlled title contains exact coordinates
+    of the second runtime location. Those must be redacted even though the
+    second location's payload has not been built yet.
+    """
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+    }
+    entry = _ConfigEntry(
+        data=data,
+        options={},
+        entry_id="entry",
+        title="Home secret-token 40.7128 -74.006",
+    )
+    entry.subentries = {
+        "casa": SimpleNamespace(subentry_id="casa", subentry_type="location"),
+        "trabajo": SimpleNamespace(subentry_id="trabajo", subentry_type="location"),
+    }
+
+    casa_coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="casa",
+        forecast_days=2,
+        language=None,
+        create_d1=True,
+        create_d2=False,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=12.345678,
+        lon=-98.765432,
+        entry_title="Casa secret-token 40.7128 -74.006",
+        data={"type_grass": {"source": "type", "code": "GRASS", "value": 2}},
+    )
+    trabajo_coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="trabajo",
+        forecast_days=2,
+        language=None,
+        create_d1=True,
+        create_d2=False,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=40.7128,
+        lon=-74.006,
+        entry_title="Trabajo",
+        data={"type_tree": {"source": "type", "code": "TREE", "value": 4}},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "casa": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="casa",
+                coordinator=casa_coordinator,
+                legacy_entry_id=None,
+            ),
+            "trabajo": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="trabajo",
+                coordinator=trabajo_coordinator,
+                legacy_entry_id=None,
+            ),
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert diagnostics["locations"]["casa"]["title"] == "Casa *** *** ***"
+    assert diagnostics["locations"]["trabajo"]["title"] == "Trabajo"
+    assert diagnostics["entry"]["title"] == "Home *** *** ***"
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+    assert "40.7128" not in serialized
+    assert "-74.006" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_includes_fallback_location_without_subentries(
     diagnostics_modules: DiagnosticsModules,
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -313,6 +313,34 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_redacts_legacy_title_without_runtime_data(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should redact legacy title secrets before runtime exists."""
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LATITUDE: 12.345678,
+        diagnostics_modules.CONF_LONGITUDE: -98.765432,
+    }
+    entry = _ConfigEntry(
+        data=data,
+        options={},
+        entry_id="entry",
+        title="Home secret-token 12.345678 -98.765432",
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert diagnostics["entry"]["title"] == "Home *** *** ***"
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_summarizes_runtime_locations_when_parent_has_no_locations(
     diagnostics_modules: DiagnosticsModules,
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -269,7 +269,12 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
         diagnostics_modules.CONF_LATITUDE: 12.345678,
         diagnostics_modules.CONF_LONGITUDE: -98.765432,
     }
-    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    entry = _ConfigEntry(
+        data=data,
+        options={},
+        entry_id="entry",
+        title="Home secret-token 12.345678",
+    )
     coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="entry",
@@ -280,7 +285,7 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=12.345678,
         lon=-98.765432,
-        entry_title="Home",
+        entry_title="Home secret-token -98.765432",
         data={},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
@@ -299,6 +304,8 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
     assert set(diagnostics["locations"]) == {"entry"}
     assert diagnostics["runtime_summary"]["stale_location_count"] == 0
     assert diagnostics["runtime_summary"]["stale_location_ids"] == []
+    assert diagnostics["entry"]["title"] == "Home *** ***"
+    assert diagnostics["locations"]["entry"]["title"] == "Home *** ***"
     serialized = json.dumps(diagnostics, sort_keys=True)
     assert "secret-token" not in serialized
     assert "12.345678" not in serialized

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -341,6 +341,40 @@ async def test_diagnostics_redacts_legacy_title_without_runtime_data(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_redacts_v3_subentry_title_without_runtime_data(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should redact v3 title coordinates before runtime exists."""
+    data = {diagnostics_modules.CONF_API_KEY: "secret-token"}
+    entry = _ConfigEntry(
+        data=data,
+        options={},
+        entry_id="entry",
+        title="Home secret-token 12.345678 -98.765432",
+    )
+    entry.subentries = {
+        "subentry-1": SimpleNamespace(
+            subentry_id="subentry-1",
+            subentry_type="location",
+            data={
+                diagnostics_modules.CONF_LATITUDE: 12.345678,
+                diagnostics_modules.CONF_LONGITUDE: -98.765432,
+            },
+        )
+    }
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert diagnostics["entry"]["title"] == "Home *** *** ***"
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_summarizes_runtime_locations_when_parent_has_no_locations(
     diagnostics_modules: DiagnosticsModules,
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2359,6 +2359,55 @@ def test_migrate_entry_with_invalid_legacy_coordinates_is_left_unchanged(
     assert precise_coordinate not in caplog.text
 
 
+def test_migrate_entry_with_invalid_legacy_subentry_is_left_unchanged(
+    integration_modules: _InitModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Alpha-state location subentries with corrupt coordinates should fail safely."""
+    integration = integration_modules.integration
+
+    existing_subentry = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: "123.456789",
+            integration.CONF_LONGITUDE: "-222.987654",
+            integration.CONF_LEGACY_ENTRY_ID: "legacy-corrupt",
+        },
+        subentry_id="existing-corrupt",
+        title="Corrupt Home",
+        unique_id=None,
+    )
+    entry = _FakeEntry(
+        integration,
+        entry_id="legacy-corrupt",
+        title="Corrupt Legacy",
+        data={integration.CONF_API_KEY: "secret-api-key"},
+        options={},
+        version=integration.TARGET_ENTRY_VERSION - 1,
+        subentries={existing_subentry.subentry_id: existing_subentry},
+        unique_id=integration.api_key_unique_id("secret-api-key"),
+    )
+    hass = _FakeHass(entries=[entry])
+
+    with caplog.at_level("ERROR"):
+        assert asyncio.run(integration.async_migrate_entry(hass, entry)) is False
+
+    assert entry.data == {integration.CONF_API_KEY: "secret-api-key"}
+    assert entry.options == {}
+    assert entry.version == integration.TARGET_ENTRY_VERSION - 1
+    assert entry.subentries == {existing_subentry.subentry_id: existing_subentry}
+    assert hass.config_entries.added_subentries == []
+    assert hass.config_entries.removed_entries == []
+    assert (
+        "Cannot migrate Pollen Levels entry legacy-corrupt because it has location "
+        "subentries with invalid stored migration data. The entry was left "
+        "unchanged. Remove and recreate the affected location or fix the "
+        "configuration before retrying the migration."
+    ) in caplog.text
+    assert "secret-api-key" not in caplog.text
+    assert "123.456789" not in caplog.text
+    assert "-222.987654" not in caplog.text
+
+
 def test_migrate_current_entry_updates_parent_unique_id_to_api_key_identity(
     integration_modules: _InitModules,
 ) -> None:
@@ -2874,7 +2923,7 @@ def test_migrate_grouped_entry_keeps_clean_v3_source_with_unmigratable_subentry(
     assert parent.subentries == {parent_subentry.subentry_id: parent_subentry}
     assert hass.config_entries.added_subentries == []
     assert hass.config_entries.removed_entries == []
-    assert "cannot be safely mapped to migration targets" in caplog.text
+    assert "location subentries with invalid stored migration data" in caplog.text
 
 
 def test_migrate_grouped_entry_keeps_source_with_corrupt_location_subentry(


### PR DESCRIPTION
## Summary
- Validate legacy location subentry coordinates during migration and leave corrupt alpha-state entries unchanged for retry/fix.
- Redact API keys and exact coordinates from user-controlled diagnostics titles.
- Clarify the shared `already_configured` English message and update migration retry logs to avoid implying no state was created.

## Tests
- `python -m compileall -q custom_components tests`
- `python -m ruff check --fix --select I`
- `python -m ruff check`
- `python -m black --check .`
- `python -m pytest -q` (412 passed; only the known `.pytest_cache` permission warning on the SMB workspace)