### PR TITLE
Prepare 3.0.0b1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [3.0.0b1] - 2026-06-05
+
+### Changed
+- Promoted the v3 config subentries migration from alpha to beta for wider
+  real-world validation.
+- Documented the beta upgrade path and clarified that downgrading to Pollen
+  Levels 2.x after the v3 subentry migration is not supported.
+- Aligned release metadata for the beta package.
+
+### Fixed
+- Hardened v3 migration against invalid legacy location subentries before setup
+  can reuse them.
+- Redacted API keys and exact coordinates from user-controlled diagnostics
+  titles across legacy, subentry, and runtime locations.
+- Clarified duplicate API-key errors during setup, reauthentication, and
+  reconfiguration.
+- Updated migration retry logs so partial migration preparation is not described
+  as fully unchanged.
+- Avoided logging user-controlled setup/config-flow text that may accidentally
+  contain secrets.
+- Corrected README wording about multi-location startup behavior during beta
+  validation.
+
 ## [3.0.0a4] - 2026-06-05
 ### Fixed
 - Hardened Google Pollen `dailyInfo` validation during config flow.

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ When reauthenticating or reconfiguring the parent API key, the integration tries
 the configured locations until one returns usable pollen data. Authentication
 and quota errors are treated as key-level failures.
 
-During startup, a parent entry can still load if at least one configured
-location initializes. Any location skipped because of a non-auth startup error
-may need a manual reload of the Pollen Levels parent entry after the underlying
-problem is fixed.
+During startup, the v3 beta avoids partial parent setup. If any configured
+location fails its initial non-auth refresh, Home Assistant will retry setup
+until the underlying issue is fixed or the affected location is removed or
+reconfigured. This keeps all location entities, devices, and diagnostics in a
+consistent state during the beta migration.
 
 Create a Home Assistant backup before installing the v3 pre-release.
 Downgrading to Pollen Levels 2.x after the subentry migration is not supported.

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -232,9 +232,8 @@ async def async_setup_entry(
 ) -> bool:
     """Forward config entry to sensor platform."""
     _LOGGER.debug(
-        "PollenLevels async_setup_entry for entry_id=%s title=%s",
+        "PollenLevels async_setup_entry for entry_id=%s",
         entry.entry_id,
-        entry.title,
     )
     if is_entry_merged(entry):
         _LOGGER.debug(

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -96,7 +96,7 @@ def is_valid_language_code(value: str) -> str:
     if not norm:
         raise vol.Invalid("empty")
     if not LANGUAGE_CODE_REGEX.match(norm):
-        _LOGGER.warning("Invalid language code format (BCP-47-like): %s", value)
+        _LOGGER.warning("Invalid language code format (BCP-47-like)")
         raise vol.Invalid("invalid_language")
     return norm
 
@@ -776,9 +776,8 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         except vol.Invalid as ve:
             _LOGGER.warning(
-                "Language code validation failed for '%s': %s",
-                user_input.get(CONF_LANGUAGE_CODE),
-                ve,
+                "Language code validation failed: %s",
+                _language_error_to_form_key(ve),
             )
             errors[CONF_LANGUAGE_CODE] = _language_error_to_form_key(ve)
             placeholders.pop("error_message", None)
@@ -1227,9 +1226,8 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
 
             except vol.Invalid as ve:
                 _LOGGER.warning(
-                    "Options language validation failed for '%s': %s",
-                    normalized_input.get(CONF_LANGUAGE_CODE),
-                    ve,
+                    "Options language validation failed: %s",
+                    _language_error_to_form_key(ve),
                 )
                 errors[CONF_LANGUAGE_CODE] = _language_error_to_form_key(ve)
             except Exception as err:  # defensive

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0a4"
+    "version": "3.0.0b1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0a4"
+version = "3.0.0b1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -539,6 +539,32 @@ def test_validate_input_invalid_language_key_mapping(
     assert normalized is None
 
 
+def test_validate_input_invalid_language_code_not_logged_raw(
+    config_flow_stubs: ConfigFlowStubs, caplog
+) -> None:
+    """Invalid language code should not log the raw user-provided value."""
+    flow = config_flow_stubs.PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    with caplog.at_level("WARNING", logger=config_flow_stubs.config_flow.__name__):
+        errors, normalized = asyncio.run(
+            flow._async_validate_input(
+                {
+                    config_flow_stubs.CONF_API_KEY: "test-key",
+                    config_flow_stubs.CONF_LOCATION: {
+                        config_flow_stubs.CONF_LATITUDE: "1",
+                        config_flow_stubs.CONF_LONGITUDE: "2",
+                    },
+                    config_flow_stubs.CONF_LANGUAGE_CODE: "bad code",
+                },
+                check_unique_id=False,
+            )
+        )
+
+    assert "bad code" not in caplog.text
+    assert errors == {config_flow_stubs.CONF_LANGUAGE_CODE: "invalid_language_format"}
+
+
 def test_validate_input_empty_api_key(
     config_flow_stubs: ConfigFlowStubs, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -495,6 +495,30 @@ def test_setup_entry_without_location_subentries_loads_empty_runtime(
     assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
 
 
+def test_setup_entry_debug_log_does_not_include_entry_title(
+    integration_modules: _InitModules, caplog
+) -> None:
+    """async_setup_entry debug log should include entry_id but not entry.title."""
+    integration = integration_modules.integration
+
+    hass = _FakeHass()
+    entry = _FakeEntry(
+        integration,
+        entry_id="test-entry",
+        title="secret-api-key-abc-123",
+        data={integration.CONF_API_KEY: "actual-key"},
+        subentries={},
+    )
+
+    with caplog.at_level("DEBUG"):
+        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+
+    log_text = caplog.text
+    assert "entry_id=test-entry" in log_text
+    assert "secret-api-key-abc-123" not in log_text
+    assert "actual-key" not in log_text
+
+
 def test_setup_entry_invalid_coordinates_raise_not_ready(
     integration_modules: _InitModules,
 ) -> None:

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -253,6 +253,30 @@ def test_options_flow_invalid_language_sets_error(
     }
 
 
+def test_options_flow_invalid_language_code_not_logged_raw(
+    options_flow_env: OptionsFlowEnv, caplog
+) -> None:
+    """Invalid language in options should not log the raw user-provided value."""
+    flow = _flow(options_flow_env)
+
+    with caplog.at_level("WARNING", logger=options_flow_env.config_flow.__name__):
+        result = asyncio.run(
+            flow.async_step_init(
+                {
+                    options_flow_env.CONF_LANGUAGE_CODE: "bad code",
+                    options_flow_env.CONF_FORECAST_DAYS: 2,
+                    options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
+                    options_flow_env.CONF_UPDATE_INTERVAL: 6,
+                }
+            )
+        )
+
+    assert "bad code" not in caplog.text
+    assert result["errors"] == {
+        options_flow_env.CONF_LANGUAGE_CODE: "invalid_language_format"
+    }
+
+
 def test_options_flow_forecast_days_below_min_sets_error(
     options_flow_env: OptionsFlowEnv,
 ) -> None:


### PR DESCRIPTION
## Summary

Bump version to 3.0.0b1 and apply final beta1 release-prep changes.

### Changes
- **Version:** manifest.json & pyproject.toml → 3.0.0b1
- **CHANGELOG.md:** Added 3.0.0b1 entry with Changed/Fixed sections
- **README.md:** Updated multi-location startup paragraph for beta behavior
- **Privacy hardening:** Removed `entry.title` from `async_setup_entry` debug log; removed raw invalid language values from config_flow warnings
- **Tests:** Added caplog tests verifying entry title and invalid language values are not logged

### Validation
- `ruff check .` — passed
- `black --check .` — passed
- `pytest` requires Python 3.14+ (pre-existing syntax compatibility)