### PR TITLE
[codex] Harden v3 subentries setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   contain secrets.
 - Corrected README wording about multi-location startup behavior during beta
   validation.
+- Hardened v3 beta setup against duplicate API-key fallback detection, partial
+  legacy coordinates, missing button runtime data, and expected abort flow
+  handling.
 
 ## [3.0.0a4] - 2026-06-05
 ### Fixed

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -362,11 +362,6 @@ async def async_setup_entry(
             legacy_entry_id=legacy_entry_id,
         )
 
-    if location_configs and not locations:
-        raise ConfigEntryNotReady(
-            "No Pollen Levels locations could be initialized"
-        ) from None
-
     entry.runtime_data = PollenLevelsRuntimeData(client=client, locations=locations)
 
     try:

--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -55,7 +55,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Pollen Levels update buttons for all configured locations."""
-    runtime = config_entry.runtime_data
+    runtime = getattr(config_entry, "runtime_data", None)
     if runtime is None:
         raise ConfigEntryNotReady("Runtime data not ready")
     locations = getattr(runtime, "locations", None) or {}

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -516,7 +516,7 @@ def _location_data_for_validation(
     if locations:
         return locations
     data = dict(entry.data or {})
-    if CONF_LATITUDE in data or CONF_LONGITUDE in data:
+    if CONF_LATITUDE in data and CONF_LONGITUDE in data:
         return [data]
     return []
 
@@ -745,6 +745,8 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await self.async_set_unique_id(uid, raise_on_progress=False)
                 self._abort_if_unique_id_configured()
+            except config_entries.AbortFlow:
+                raise
             except Exception as err:  # defensive
                 _LOGGER.exception(
                     "Unique ID setup failed for coordinates (values redacted): %s",
@@ -807,15 +809,11 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _api_key_unique_id(normalized[CONF_API_KEY]),
                     raise_on_progress=False,
                 )
-                if hasattr(
-                    getattr(self.hass, "config_entries", None),
-                    "async_entry_for_domain_unique_id",
-                ):
-                    existing_entry = _entry_for_parent_unique_id(
-                        self.hass, _api_key_unique_id(normalized[CONF_API_KEY])
-                    )
-                    if existing_entry is not None:
-                        return self.async_abort(reason="api_key_already_configured")
+                existing_entry = _entry_for_parent_unique_id(
+                    self.hass, _api_key_unique_id(normalized[CONF_API_KEY])
+                )
+                if existing_entry is not None:
+                    return self.async_abort(reason="api_key_already_configured")
                 entry_name = str(user_input.get(CONF_NAME, "")).strip()
                 title = entry_name or DEFAULT_ENTRY_TITLE
                 subentry = _location_subentry_data(

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -246,6 +246,18 @@ async def test_setup_entry_raises_if_runtime_data_missing(
 
 
 @pytest.mark.asyncio
+async def test_setup_entry_raises_if_runtime_data_attribute_missing(
+    button_platform: SimpleNamespace,
+) -> None:
+    entry = types.SimpleNamespace()
+
+    with pytest.raises(button_platform.exceptions.ConfigEntryNotReady):
+        await button_platform.module.async_setup_entry(
+            button_platform.hass_class(), entry, lambda entities: None
+        )
+
+
+@pytest.mark.asyncio
 async def test_setup_entry_adds_one_button_entity(
     button_platform: SimpleNamespace,
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -90,6 +90,10 @@ class _StubOptionsFlowWithReload(_StubOptionsFlow):
     pass
 
 
+class _StubAbortFlow(Exception):
+    pass
+
+
 class _StubConfigSubentry:
     _next_id = 1
 
@@ -287,6 +291,7 @@ def _install_homeassistant_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     config_entries_mod.OptionsFlow = _StubOptionsFlow
     config_entries_mod.OptionsFlowWithReload = _StubOptionsFlowWithReload
     config_entries_mod.ConfigEntry = _StubConfigEntry
+    config_entries_mod.AbortFlow = _StubAbortFlow
     config_entries_mod.ConfigSubentry = _StubConfigSubentry
     config_entries_mod.ConfigSubentryFlow = _StubConfigSubentryFlow
     config_entries_mod.ConfigSubentryData = dict
@@ -797,6 +802,24 @@ def _base_user_input(config_flow_stubs) -> dict:
             config_flow_stubs.CONF_LONGITUDE: "2.0",
         },
     }
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"latitude": 1.0},
+        {"longitude": 2.0},
+    ],
+)
+def test_location_data_for_validation_ignores_partial_legacy_coordinates(
+    config_flow_stubs: ConfigFlowStubs,
+    data: dict[str, float],
+) -> None:
+    """Partial legacy coordinates should not be used for API-key validation."""
+
+    entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(data=data)
+
+    assert config_flow_stubs.config_flow._location_data_for_validation(entry) == []
 
 
 def _build_options_flow(
@@ -2869,6 +2892,58 @@ def test_async_step_user_checks_api_key_unique_id_for_existing_parent(
     assert flow.unique_ids == [
         config_flow_stubs.config_flow._api_key_unique_id("shared-key")
     ]
+
+
+def test_async_step_user_checks_api_key_unique_id_with_async_entries_fallback(
+    config_flow_stubs: ConfigFlowStubs,
+) -> None:
+    """New setup should detect duplicate API-key parents via async_entries fallback."""
+
+    class _TrackingFlow(config_flow_stubs.PollenLevelsConfigFlow):
+        def __init__(self) -> None:
+            super().__init__()
+            self.unique_ids: list[str] = []
+
+        async def async_set_unique_id(self, uid: str, raise_on_progress: bool = False):
+            self.unique_ids.append(uid)
+            return None
+
+    duplicate_unique_id = config_flow_stubs.config_flow._api_key_unique_id("shared-key")
+    flow = _TrackingFlow()
+    flow.hass = SimpleNamespace(
+        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
+        config_entries=SimpleNamespace(
+            async_entries=lambda _domain: [
+                SimpleNamespace(unique_id=duplicate_unique_id)
+            ]
+        ),
+    )
+
+    normalized = {
+        config_flow_stubs.CONF_API_KEY: "shared-key",
+        config_flow_stubs.CONF_LATITUDE: 1.0,
+        config_flow_stubs.CONF_LONGITUDE: 2.0,
+        config_flow_stubs.CONF_LANGUAGE_CODE: "en",
+    }
+
+    async def fake_validate(
+        user_input, *, check_unique_id, description_placeholders=None
+    ):
+        assert check_unique_id is False
+        return {}, normalized
+
+    flow._async_validate_input = fake_validate  # type: ignore[assignment]
+
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                config_flow_stubs.CONF_API_KEY: "shared-key",
+            }
+        )
+    )
+
+    assert result == {"type": "abort", "reason": "api_key_already_configured"}
+    assert flow.unique_ids == [duplicate_unique_id]
 
 
 class _SubentryRecorder:


### PR DESCRIPTION
## Summary

- Preserve duplicate API-key detection when Home Assistant lacks `async_entry_for_domain_unique_id` by always using the helper fallback.
- Re-raise `AbortFlow` during coordinate unique-id validation before defensive generic logging.
- Ignore partial legacy coordinates for API-key validation candidates.
- Treat missing button `runtime_data` as `ConfigEntryNotReady` and remove unreachable setup failure code.

## Impact

This keeps the v3 subentry setup behavior unchanged for normal installs while hardening older/edge Home Assistant API surfaces before `3.0.0b1`.

## Validation

- `python -m compileall -q custom_components tests`
- `python -m ruff check .`
- `python -m black --check .`
- `python -m pytest -q` (`422 passed`)