### PR TITLE
[codex] Skip stale runtime locations in platforms

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -50,12 +50,11 @@ from .runtime import (
 )
 from .sensor import ForecastSensorMode
 from .util import (
-    active_location_subentry_ids,
     api_key_unique_id as api_key_unique_id,
-    has_legacy_location_data,
     normalize_sensor_mode,
     redact_sensitive_values,
     safe_parse_int,
+    stale_runtime_location_filter,
     validate_location_pair,
 )
 
@@ -196,10 +195,9 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
                 )
                 continue
 
-            active_subentry_ids = active_location_subentry_ids(entry)
-            filter_stale_locations = bool(
-                active_subentry_ids
-            ) or not has_legacy_location_data(entry)
+            active_subentry_ids, filter_stale_locations = stale_runtime_location_filter(
+                entry
+            )
             for location in locations.values():
                 subentry_id = location.subentry_id
                 if filter_stale_locations and subentry_id not in active_subentry_ids:

--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .runtime import PollenLevelsConfigEntry
+from .util import active_location_subentry_ids, has_legacy_location_data
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -67,7 +68,17 @@ async def async_setup_entry(
         _LOGGER.debug("No location subentries configured; no update buttons to add")
         return
 
+    active_subentry_ids = active_location_subentry_ids(config_entry)
+    filter_stale_locations = bool(active_subentry_ids) or not has_legacy_location_data(
+        config_entry
+    )
     for location in locations.values():
+        if filter_stale_locations and location.subentry_id not in active_subentry_ids:
+            _LOGGER.debug(
+                "Skipping stale Pollen Levels button runtime location %s",
+                location.subentry_id,
+            )
+            continue
         _add_button_for_location(async_add_entities, location)
 
 

--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .runtime import PollenLevelsConfigEntry
-from .util import active_location_subentry_ids, has_legacy_location_data
+from .util import stale_runtime_location_filter
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -68,8 +68,7 @@ async def async_setup_entry(
         _LOGGER.debug("No location subentries configured; no update buttons to add")
         return
 
-    active_subentry_ids = active_location_subentry_ids(config_entry)
-    filter_stale_locations = bool(active_subentry_ids) or not has_legacy_location_data(
+    active_subentry_ids, filter_stale_locations = stale_runtime_location_filter(
         config_entry
     )
     for location in locations.values():

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -564,6 +564,7 @@ def _entry_for_parent_unique_id(
 
 async def _async_reload_parent_after_subentry_create(hass: Any, entry_id: str) -> None:
     """Reload the parent after Home Assistant persists the created subentry."""
+    # Let Home Assistant finish attaching the newly-created subentry before reload.
     await asyncio.sleep(0)
     schedule_reload = getattr(hass.config_entries, "async_schedule_reload", None)
     if callable(schedule_reload):

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -53,7 +53,7 @@ from .const import (
 from .coordinator import PollenDataUpdateCoordinator
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
-from .util import active_location_subentry_ids, has_legacy_location_data, safe_parse_int
+from .util import safe_parse_int, stale_runtime_location_filter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -221,8 +221,7 @@ async def async_setup_entry(
         )
         return
 
-    active_subentry_ids = active_location_subentry_ids(config_entry)
-    filter_stale_locations = bool(active_subentry_ids) or not has_legacy_location_data(
+    active_subentry_ids, filter_stale_locations = stale_runtime_location_filter(
         config_entry
     )
     opts = config_entry.options or {}

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -53,7 +53,7 @@ from .const import (
 from .coordinator import PollenDataUpdateCoordinator
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
-from .util import safe_parse_int
+from .util import active_location_subentry_ids, has_legacy_location_data, safe_parse_int
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -221,8 +221,20 @@ async def async_setup_entry(
         )
         return
 
+    active_subentry_ids = active_location_subentry_ids(config_entry)
+    filter_stale_locations = bool(active_subentry_ids) or not has_legacy_location_data(
+        config_entry
+    )
     opts = config_entry.options or {}
     for location in runtime.locations.values():
+        if filter_stale_locations and location.subentry_id not in active_subentry_ids:
+            _LOGGER.debug(
+                "Skipping stale Pollen Levels sensor runtime location %s for entry %s",
+                location.subentry_id,
+                config_entry.entry_id,
+            )
+            continue
+
         coordinator = location.coordinator
         raw_days = opts.get(CONF_FORECAST_DAYS, coordinator.forecast_days)
         parsed = safe_parse_int(raw_days)

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -45,6 +45,15 @@ def has_legacy_location_data(entry: Any) -> bool:
     )
 
 
+def stale_runtime_location_filter(entry: Any) -> tuple[set[str], bool]:
+    """Return active location ids and whether stale runtime locations should skip."""
+    active_subentry_ids = active_location_subentry_ids(entry)
+    filter_stale_locations = bool(active_subentry_ids) or not has_legacy_location_data(
+        entry
+    )
+    return active_subentry_ids, filter_stale_locations
+
+
 async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
     """Extract and normalize an HTTP error message without secrets."""
 
@@ -296,6 +305,7 @@ __all__ = [
     "redact_api_key",
     "redact_sensitive_values",
     "safe_parse_int",
+    "stale_runtime_location_filter",
     "validate_latitude",
     "validate_location_pair",
     "validate_longitude",

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -291,3 +291,34 @@ async def test_setup_entry_without_locations_adds_no_button(
     )
 
     assert added == []
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_skips_stale_runtime_locations(
+    button_platform: SimpleNamespace,
+) -> None:
+    """Button setup should not recreate buttons for deleted location subentries."""
+
+    coordinator = _FakeCoordinator()
+    entry = types.SimpleNamespace(
+        data={},
+        subentries={},
+        runtime_data=types.SimpleNamespace(
+            locations={
+                "deleted-location": types.SimpleNamespace(
+                    subentry_id="deleted-location",
+                    coordinator=coordinator,
+                )
+            }
+        ),
+    )
+    added = []
+
+    def _add_entities(entities, **_kwargs):
+        added.extend(entities)
+
+    await button_platform.module.async_setup_entry(
+        button_platform.hass_class(), entry, _add_entities
+    )
+
+    assert added == []

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2959,6 +2959,14 @@ class _SubentryRecorder:
         self.reload_calls.append(entry_id)
 
 
+class _ReloadOnlySubentryRecorder:
+    def __init__(self) -> None:
+        self.reload_calls: list[str] = []
+
+    async def async_reload(self, entry_id: str) -> None:
+        self.reload_calls.append(entry_id)
+
+
 def _build_location_subentry_flow(config_flow_stubs: ConfigFlowStubs, entry):
     recorder = _SubentryRecorder(entry)
 
@@ -3026,8 +3034,11 @@ def test_location_subentry_user_step_creates_entry_without_premature_reload(
             }
         )
         assert recorder.reload_calls == []
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
+        assert len(recorder.created_tasks) == 1
+        assert recorder.created_tasks[0].get_name() == (
+            "reload Pollen Levels parent after location subentry create"
+        )
+        await recorder.created_tasks[0]
         return result
 
     result = asyncio.run(run_flow())
@@ -3049,6 +3060,23 @@ def test_location_subentry_user_step_creates_entry_without_premature_reload(
             "language_code": "es-ES",
         }
     ]
+
+
+def test_location_subentry_create_reload_helper_falls_back_to_async_reload(
+    config_flow_stubs: ConfigFlowStubs,
+) -> None:
+    """Subentry reload helper should use async_reload when schedule_reload is absent."""
+
+    recorder = _ReloadOnlySubentryRecorder()
+    hass = SimpleNamespace(config_entries=recorder)
+
+    asyncio.run(
+        config_flow_stubs.config_flow._async_reload_parent_after_subentry_create(
+            hass, "entry-id"
+        )
+    )
+
+    assert recorder.reload_calls == ["entry-id"]
 
 
 def test_location_subentry_user_step_rejects_invalid_api_payload(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2248,7 +2248,10 @@ def test_migrate_legacy_entry_into_existing_clean_v3_parent(
         "merged_into_entry_id": "clean-parent",
     }
     assert legacy.version == integration.TARGET_ENTRY_VERSION
-    assert hass.created_tasks
+    assert len(hass.created_tasks) == 1
+    assert hass.created_tasks[0].get_name() == (
+        "remove merged pollenlevels entry legacy-office"
+    )
 
 
 def test_migrate_legacy_entries_with_different_api_keys_stay_separate(
@@ -3940,7 +3943,10 @@ def test_migrate_current_duplicate_entry_is_marked_and_removed_later(
         "merged_into_entry_id": "legacy-home",
     }
     assert duplicate.version == integration.TARGET_ENTRY_VERSION
-    assert hass.created_tasks
+    assert len(hass.created_tasks) == 1
+    assert hass.created_tasks[0].get_name() == (
+        "remove merged pollenlevels entry legacy-office"
+    )
 
 
 def test_setup_entry_skips_entries_already_marked_as_merged(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2649,6 +2649,55 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_skips_stale_runtime_locations(
+    sensor_modules: SensorModules,
+) -> None:
+    """Sensor setup should not recreate entities for deleted location subentries."""
+
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={sensor_modules.sensor.CONF_API_KEY: "key"},
+        entry_id="entry",
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "date": {"source": "meta", "value": "2026-05-08"},
+            "type_grass": {
+                "source": "type",
+                "displayName": "Grass",
+                "value": 3,
+            },
+        },
+        entry_id="entry",
+        subentry_id="deleted-location",
+        entry_title="Deleted",
+        lat=1.0,
+        lon=2.0,
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
+        create_d1=False,
+        create_d2=False,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "deleted-location": types.SimpleNamespace(
+                subentry_id="deleted-location",
+                coordinator=coordinator,
+            )
+        },
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, **_kwargs):
+        captured.extend(entities)
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update(
     sensor_modules: SensorModules,
 ) -> None:


### PR DESCRIPTION
## Summary

- Skip stale runtime locations in sensor setup when the corresponding location subentry no longer exists.
- Apply the same stale-location filtering to update button setup and `force_update` through one shared helper.
- Add regression coverage so deleted location subentries do not recreate sensors or buttons from stale runtime data.
- Strengthen beta follow-up tests around subentry reload scheduling and migration cleanup task assertions.
- Document why subentry creation yields once before scheduling/reloading the parent entry.

## Backlog Review

Reviewed `pollenlevels_v3_post_beta_backlog.md` against this PR and the current `prototype/v3-subentries` base.

Applied for beta 2:

- P1 reload determinism: tests now await the exact created reload task instead of relying on repeated event-loop sleeps.
- P1 reload fallback: added coverage for the `async_reload()` fallback when `async_schedule_reload()` is unavailable.
- P2 migration task assertions: replaced broad `assert hass.created_tasks` checks with exact task count and task name assertions.
- Beta monitoring item: stale runtime locations after deleting a location are covered by this PR for sensors and buttons, with shared filter logic also used by `force_update`.

Already covered / no new change:

- Diagnostics registry summary coverage already exists in `tests/test_diagnostics.py`, including entity/device counts, missing subentry associations, legacy-none device association tracking, and redaction checks.
- Legacy duplicate fallback is a false positive: setup only uses legacy coordinates when no location subentries exist.
- Options flow/subentry separation is intentional: parent options and location subentry flows are tested separately.

Deferred intentionally:

- Coordinator update method refactor and constructor config object are medium-risk refactors better suited after beta behavior stabilizes.
- Logging traceback policy and minor lint/style cleanup remain opportunistic unless a real beta issue requires them.

## Validation

- `python -m black .`
- `python -m ruff check`
- `python -m pytest`