### PR TITLE
docs: add v3.0.0b2 beta release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [3.0.0b2] - 2026-06-07
+
+### Changed
+
+- Reiterated that this is still a beta pre-release for the v3 config subentry
+  migration.
+- Reminded users to create a Home Assistant backup before upgrading from `2.x`.
+- Clarified that downgrading from `3.x` to `2.x` is not supported without
+  restoring a backup.
+
+### Fixed
+
+- Prevent deleted location subentries from temporarily recreating sensors or
+  update buttons from stale runtime data before the parent entry is reloaded.
+- Keep stale runtime location filtering consistent across sensor setup, update
+  button setup, and the `pollenlevels.force_update` service.
+
 ## [3.0.0b1] - 2026-06-05
 
 ### Changed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0b1"
+    "version": "3.0.0b2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0b1"
+version = "3.0.0b2"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
## Summary

- Add v3.0.0b2 beta release notes for stale runtime location filtering.
- Document that deleted location subentries should no longer recreate sensors or update buttons from stale runtime data.
- Reiterate that v3.0.0b2 remains a beta pre-release and that users should back up before upgrading from 2.x.

## Validation

- `git diff --check`