### PR TITLE
refactor: extract duplicated helpers into util.py

### DIFF
--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -14,7 +14,11 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .runtime import PollenLevelsConfigEntry
-from .util import stale_runtime_location_filter
+from .util import (
+    coordinator_device_id,
+    coordinator_identity_id,
+    stale_runtime_location_filter,
+)
 
 if TYPE_CHECKING:
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -23,19 +27,6 @@ if TYPE_CHECKING:
     from .runtime import PollenLocationRuntime
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:
-    """Return the stable identity used for entity unique IDs."""
-    return getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
-
-
-def _coordinator_device_id(coordinator: PollenDataUpdateCoordinator, group: str) -> str:
-    """Return the stable device identifier for a location/group pair."""
-    identity_id = getattr(coordinator, "device_identity_id", None) or (
-        getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
-    )
-    return f"{identity_id}_{group}"
 
 
 def _add_button_for_location(
@@ -91,10 +82,10 @@ class PollenLevelsUpdateButton(CoordinatorEntity, ButtonEntity):
     def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize update button entity."""
         super().__init__(coordinator)
-        identity_id = _coordinator_identity_id(coordinator)
+        identity_id = coordinator_identity_id(coordinator)
         self._attr_unique_id = f"{identity_id}_update_now"
         self._attr_device_info = {
-            "identifiers": {(DOMAIN, _coordinator_device_id(coordinator, "meta"))},
+            "identifiers": {(DOMAIN, coordinator_device_id(coordinator, "meta"))},
             "manufacturer": "Google",
             "model": "Pollen API",
             "translation_key": "info",

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -62,6 +62,8 @@ from .const import (
 )
 from .util import (
     api_key_unique_id,
+    entry_api_key,
+    format_location_unique_id,
     normalize_sensor_mode,
     redact_api_key,
     redact_sensitive_values,
@@ -431,11 +433,6 @@ def _api_key_unique_id(api_key: str) -> str:
     return api_key_unique_id(api_key)
 
 
-def _location_unique_id(lat: float, lon: float) -> str:
-    """Return the legacy coordinate unique ID format."""
-    return f"{lat:.4f}_{lon:.4f}"
-
-
 def _location_subentry_data(
     *,
     title: str,
@@ -454,7 +451,7 @@ def _location_subentry_data(
         "subentry_type": SUBENTRY_TYPE_LOCATION,
         "title": title,
         "data": data,
-        "unique_id": _location_unique_id(lat, lon),
+        "unique_id": format_location_unique_id(lat, lon),
     }
 
 
@@ -475,15 +472,6 @@ def _parent_entry_options(normalized: dict[str, Any]) -> dict[str, Any]:
         if key in normalized:
             options[key] = normalized[key]
     return options
-
-
-def _entry_api_key(entry: config_entries.ConfigEntry) -> str | None:
-    """Return a stripped parent API key or None when unavailable."""
-    raw_api_key = (entry.data or {}).get(CONF_API_KEY)
-    if not isinstance(raw_api_key, str):
-        return None
-    api_key = raw_api_key.strip()
-    return api_key or None
 
 
 def _entry_language_code(entry: config_entries.ConfigEntry) -> str | None:
@@ -988,11 +976,11 @@ class PollenLevelsLocationSubentryFlow(config_entries.ConfigSubentryFlow):
                 errors[CONF_LOCATION] = "invalid_coordinates"
             else:
                 lat, lon = latlon
-                unique_id = _location_unique_id(lat, lon)
+                unique_id = format_location_unique_id(lat, lon)
                 if _has_duplicate_location(entry, unique_id):
                     errors["base"] = "already_configured"
                 else:
-                    api_key = _entry_api_key(entry)
+                    api_key = entry_api_key(entry)
                     if api_key is None:
                         errors["base"] = "invalid_auth"
                         description_placeholders["error_message"] = "Invalid API key."
@@ -1050,13 +1038,13 @@ class PollenLevelsLocationSubentryFlow(config_entries.ConfigSubentryFlow):
                 errors[CONF_LOCATION] = "invalid_coordinates"
             else:
                 lat, lon = latlon
-                unique_id = _location_unique_id(lat, lon)
+                unique_id = format_location_unique_id(lat, lon)
                 if _has_duplicate_location(
                     entry, unique_id, current_subentry_id=subentry.subentry_id
                 ):
                     errors["base"] = "already_configured"
                 else:
-                    api_key = _entry_api_key(entry)
+                    api_key = entry_api_key(entry)
                     if api_key is None:
                         errors["base"] = "invalid_auth"
                         description_placeholders["error_message"] = "Invalid API key."

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -26,7 +26,12 @@ from .const import (
     DOMAIN,
     SUBENTRY_TYPE_LOCATION,
 )
-from .util import api_key_unique_id, normalize_sensor_mode, validate_location_pair
+from .util import (
+    api_key_unique_id,
+    entry_api_key,
+    normalize_sensor_mode,
+    validate_location_pair,
+)
 
 _LOGGER = logging.getLogger(__name__)
 LEGACY_HTTP_REFERER_KEY = "http_referer"
@@ -141,15 +146,6 @@ def _entry_version(entry: ConfigEntry) -> int:
     """Return a safe integer config-entry version."""
     current_version_raw = getattr(entry, "version", 1)
     return current_version_raw if isinstance(current_version_raw, int) else 1
-
-
-def _entry_api_key(entry: ConfigEntry) -> str | None:
-    """Return the normalized API key stored on an entry."""
-    api_key = (entry.data or {}).get(CONF_API_KEY)
-    if not isinstance(api_key, str):
-        return None
-    api_key = api_key.strip()
-    return api_key or None
 
 
 def is_entry_merged(entry: ConfigEntry) -> bool:
@@ -413,7 +409,7 @@ def _migration_group_entries(
     for candidate in entries:
         if is_entry_merged(candidate):
             continue
-        if _entry_api_key(candidate) != api_key:
+        if entry_api_key(candidate) != api_key:
             continue
         if (
             candidate is entry
@@ -984,7 +980,7 @@ async def async_handle_entry_migration(
             )
             return True
 
-        api_key = _entry_api_key(entry)
+        api_key = entry_api_key(entry)
         if api_key is not None:
             group = _migration_group_entries(hass, entry, api_key)
             if len(group) > 1:

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -53,7 +53,12 @@ from .const import (
 from .coordinator import PollenDataUpdateCoordinator
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
-from .util import safe_parse_int, stale_runtime_location_filter
+from .util import (
+    coordinator_device_id,
+    coordinator_identity_id,
+    safe_parse_int,
+    stale_runtime_location_filter,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -76,19 +81,6 @@ TYPE_ICONS = {
 # Plants reuse the same icon mapping by type.
 PLANT_TYPE_ICONS = TYPE_ICONS
 DEFAULT_ICON = "mdi:flower-pollen"
-
-
-def _coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:
-    """Return the stable identity used for entity unique IDs."""
-    return getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
-
-
-def _coordinator_device_id(coordinator: PollenDataUpdateCoordinator, group: str) -> str:
-    """Return the stable device identifier for a location/group pair."""
-    identity_id = getattr(coordinator, "device_identity_id", None) or (
-        getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
-    )
-    return f"{identity_id}_{group}"
 
 
 class ForecastSensorMode(StrEnum):
@@ -265,7 +257,7 @@ async def async_setup_entry(
             _LOGGER.warning(message)
             raise ConfigEntryNotReady(message)
 
-        identity_id = _coordinator_identity_id(coordinator)
+        identity_id = coordinator_identity_id(coordinator)
         await _cleanup_per_day_entities(
             hass,
             config_entry.entry_id,
@@ -332,7 +324,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         self.code = code
         # Pre-compute a stable unique_id; this never changes for the entity.
         self._attr_unique_id = (
-            f"{_coordinator_identity_id(self.coordinator)}_{self.code}"
+            f"{coordinator_identity_id(self.coordinator)}_{self.code}"
         )
 
     @property
@@ -460,7 +452,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
             else:
                 group = "meta"
 
-        device_id = _coordinator_device_id(self.coordinator, group)
+        device_id = coordinator_device_id(self.coordinator, group)
         translation_keys = {"type": "types", "plant": "plants", "meta": "info"}
         translation_key = translation_keys.get(group, "info")
         return {
@@ -484,7 +476,7 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.coordinator = coordinator
 
-        device_id = _coordinator_device_id(self.coordinator, group)
+        device_id = coordinator_device_id(self.coordinator, group)
         translation_keys = {"type": "types", "plant": "plants"}
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device_id)},
@@ -539,7 +531,7 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
         """Initialize the plants in season summary sensor."""
         super().__init__(coordinator, "plant")
         self._attr_unique_id = (
-            f"{_coordinator_identity_id(self.coordinator)}_plants_in_season_today"
+            f"{coordinator_identity_id(self.coordinator)}_plants_in_season_today"
         )
 
     @property
@@ -567,7 +559,7 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
         """Initialize the overall pollen risk summary sensor."""
         super().__init__(coordinator, "type")
         self._attr_unique_id = (
-            f"{_coordinator_identity_id(self.coordinator)}_overall_pollen_risk_today"
+            f"{coordinator_identity_id(self.coordinator)}_overall_pollen_risk_today"
         )
 
     @property
@@ -593,7 +585,7 @@ class TopPollenTypesTodaySensor(_BaseSummarySensor):
         """Initialize the top pollen types summary sensor."""
         super().__init__(coordinator, "type")
         self._attr_unique_id = (
-            f"{_coordinator_identity_id(self.coordinator)}_top_pollen_types_today"
+            f"{coordinator_identity_id(self.coordinator)}_top_pollen_types_today"
         )
 
     @property
@@ -620,7 +612,7 @@ class _BaseMetaSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.coordinator = coordinator
 
-        device_id = _coordinator_device_id(self.coordinator, "meta")
+        device_id = coordinator_device_id(self.coordinator, "meta")
         # Precompute device_info; location and identifiers are stable for the entry.
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device_id)},
@@ -653,7 +645,7 @@ class RegionSensor(_BaseMetaSensor):
     def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize region sensor with static attributes."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{_coordinator_identity_id(self.coordinator)}_region"
+        self._attr_unique_id = f"{coordinator_identity_id(self.coordinator)}_region"
         self._attr_icon = "mdi:earth"
 
     @property
@@ -675,7 +667,7 @@ class DateSensor(_BaseMetaSensor):
     def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:
         """Initialize date sensor with static attributes."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{_coordinator_identity_id(self.coordinator)}_date"
+        self._attr_unique_id = f"{coordinator_identity_id(self.coordinator)}_date"
         self._attr_icon = "mdi:calendar"
 
     @property
@@ -708,7 +700,7 @@ class LastUpdatedSensor(_BaseMetaSensor):
         """Initialize last updated sensor with static attributes."""
         super().__init__(coordinator)
         self._attr_unique_id = (
-            f"{_coordinator_identity_id(self.coordinator)}_last_updated"
+            f"{coordinator_identity_id(self.coordinator)}_last_updated"
         )
         self._attr_icon = "mdi:clock-check"
 

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from .const import (
+    CONF_API_KEY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     FORECAST_SENSORS_CHOICES,
@@ -17,8 +18,37 @@ from .const import (
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from aiohttp import ClientResponse
+
+    from .coordinator import PollenDataUpdateCoordinator
 else:  # pragma: no cover - runtime fallback for test environments without aiohttp
     ClientResponse = Any
+
+
+def coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:
+    """Return the stable identity used for entity unique IDs."""
+    return getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
+
+
+def coordinator_device_id(coordinator: PollenDataUpdateCoordinator, group: str) -> str:
+    """Return the stable device identifier for a location/group pair."""
+    identity_id = getattr(coordinator, "device_identity_id", None) or (
+        getattr(coordinator, "entity_identity_id", None) or coordinator.entry_id
+    )
+    return f"{identity_id}_{group}"
+
+
+def entry_api_key(entry: Any) -> str | None:
+    """Return a stripped parent API key or None when unavailable."""
+    raw_api_key = (entry.data or {}).get(CONF_API_KEY)
+    if not isinstance(raw_api_key, str):
+        return None
+    api_key = raw_api_key.strip()
+    return api_key or None
+
+
+def format_location_unique_id(lat: float, lon: float) -> str:
+    """Format a coordinate pair as a location unique ID."""
+    return f"{lat:.4f}_{lon:.4f}"
 
 
 def active_location_subentry_ids(entry: Any) -> set[str]:
@@ -299,7 +329,11 @@ _redact_api_key = redact_api_key
 
 __all__ = [
     "api_key_unique_id",
+    "coordinator_device_id",
+    "coordinator_identity_id",
+    "entry_api_key",
     "extract_error_message",
+    "format_location_unique_id",
     "normalize_sensor_mode",
     "parse_finite_float",
     "redact_api_key",

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -39,7 +39,8 @@ def coordinator_device_id(coordinator: PollenDataUpdateCoordinator, group: str) 
 
 def entry_api_key(entry: Any) -> str | None:
     """Return a stripped parent API key or None when unavailable."""
-    raw_api_key = (entry.data or {}).get(CONF_API_KEY)
+    data = getattr(entry, "data", {}) or {}
+    raw_api_key = data.get(CONF_API_KEY)
     if not isinstance(raw_api_key, str):
         return None
     api_key = raw_api_key.strip()


### PR DESCRIPTION
## Summary

Behavior-preserving refactor extracting 4 duplicated helpers into `util.py`.

### Helpers extracted

| Helper | Removed from | Now lives in |
|---|---|---|
| `coordinator_identity_id` | `sensor.py`, `button.py` | `util.py` |
| `coordinator_device_id` | `sensor.py`, `button.py` | `util.py` |
| `entry_api_key` | `config_flow.py`, `migration.py` | `util.py` |
| `format_location_unique_id` | `config_flow.py` | `util.py` |

### Not changed
- `migration.py._location_unique_id` — intentionally kept (validates `Any` inputs, returns `None`)
- Unique IDs, entity IDs, device identifiers, diagnostics shape, services, translations, manifest/pyproject version, README, CHANGELOG — none modified
- `_normalize_subentry_ids`, `_device_source_subentry_ids`, device_info factory, setup guards — left for future work

### Validation
- `ruff check --fix --select I .` — passed
- `ruff check .` — passed
- `black --check .` — passed
- `pytest` — 425 passed