### PR TITLE
fix: accept plant payload keys during sensor setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## [3.0.0b3] - 2026-06-08
 
+### Changed
+
+- Extracted duplicated coordinator identity, device identifier, API key, and
+  location unique ID helpers into shared utilities without changing entity IDs,
+  device IDs, diagnostics, or migration behavior.
+
 ### Fixed
 
-- Propagated asyncio.CancelledError from the global pollenlevels.force_update
+- Propagated `asyncio.CancelledError` from the global `pollenlevels.force_update`
   action so Home Assistant shutdown, reload, and task cancellation are not
   swallowed.
 - Accepted current-day `plant_` pollen payload keys during sensor setup so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Propagated asyncio.CancelledError from the global pollenlevels.force_update
   action so Home Assistant shutdown, reload, and task cancellation are not
   swallowed.
+- Accepted current-day `plant_` pollen payload keys during sensor setup so
+  valid plant-only data is not treated as missing pollen data.
 
 ## [3.0.0b2] - 2026-06-07
 

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -247,7 +247,7 @@ async def async_setup_entry(
 
         data = coordinator.data or {}
         has_daily = ("date" in data) or any(
-            key.startswith(("type_", "plants_")) for key in data
+            key.startswith(("type_", "plant_", "plants_")) for key in data
         )
         if not has_daily:
             message = (

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2942,3 +2942,67 @@ async def test_device_info_trims_custom_title(
 
     placeholders = region_sensor.device_info["translation_placeholders"]
     assert placeholders["title"] == "My Location"
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_accepts_current_day_plant_prefix_without_date(
+    sensor_modules: SensorModules,
+) -> None:
+    """setup_entry should accept current-day plant_ keys without date, type_, or plants_."""
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: (
+                sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL
+            ),
+            sensor_modules.sensor.CONF_FORECAST_DAYS: (
+                sensor_modules.sensor.DEFAULT_FORECAST_DAYS
+            ),
+        },
+        entry_id="entry",
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "plant_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "value": 1,
+                "type": "TREE",
+            },
+        },
+        entry_id="entry",
+        entity_identity_id="entry",
+        entry_title="Home",
+        lat=1.0,
+        lon=2.0,
+        subentry_id="legacy",
+        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
+        create_d1=False,
+        create_d2=False,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "legacy": types.SimpleNamespace(
+                subentry_id="legacy",
+                coordinator=coordinator,
+            ),
+        },
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, **_kwargs):
+        captured.extend(entities)
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    codes = {
+        getattr(entity, "code", None)
+        for entity in captured
+        if isinstance(entity, sensor_modules.sensor.PollenSensor)
+    }
+    assert "plant_oak" in codes


### PR DESCRIPTION
Adds `"plant_"` to the has_daily guard tuple so sensor setup accepts current-day plant payload keys without requiring `date`, `type_` or `plants_` keys.