### PR TITLE
fix: expose overall pollen risk forecast attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [3.0.0b3] - 2026-06-08
+## [3.0.0b3] - 2026-06-09
+
+### Added
+
+- Exposed plant-style forecast attributes on the overall pollen risk summary
+  sensor so compatible Lovelace cards can render upcoming-day general pollen
+  risk values.
 
 ### Changed
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -19,6 +19,7 @@ from .const import (
     MAX_FORECAST_DAYS,
     MIN_FORECAST_DAYS,
 )
+from .forecast import attach_forecast_attributes
 from .util import redact_api_key, safe_parse_int
 
 if TYPE_CHECKING:
@@ -216,76 +217,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             return False
         return self._utcnow() - self.last_updated <= self._stale_data_ttl()
 
-    # ------------------------------
-    # DRY helper for forecast attrs
-    # ------------------------------
-    def _process_forecast_attributes(
-        self, base: dict[str, Any], forecast_list: list[dict[str, Any]]
-    ) -> dict[str, Any]:
-        """Attach common forecast attributes to a base sensor dict.
-
-        This keeps TYPE and PLANT processing consistent without duplicating code.
-
-        Adds:
-          - 'forecast' list
-          - Convenience: tomorrow_* / d2_*
-          - Derived: trend, expected_peak
-
-        Does NOT touch per-day TYPE sensor creation (kept elsewhere).
-        """
-        base["forecast"] = forecast_list
-        forecast_by_offset = {item.get("offset"): item for item in forecast_list}
-
-        def _set_convenience(prefix: str, off: int) -> None:
-            f = forecast_by_offset.get(off)
-            base[f"{prefix}_has_index"] = f.get("has_index") if f else False
-            base[f"{prefix}_value"] = (
-                f.get("value") if f and f.get("has_index") else None
-            )
-            base[f"{prefix}_category"] = (
-                f.get("category") if f and f.get("has_index") else None
-            )
-            base[f"{prefix}_description"] = (
-                f.get("description") if f and f.get("has_index") else None
-            )
-            base[f"{prefix}_color_hex"] = (
-                f.get("color_hex") if f and f.get("has_index") else None
-            )
-
-        _set_convenience("tomorrow", 1)
-        _set_convenience("d2", 2)
-
-        # Trend (today vs tomorrow)
-        now_val = base.get("value")
-        tomorrow_val = base.get("tomorrow_value")
-        if isinstance(now_val, (int, float)) and isinstance(tomorrow_val, (int, float)):
-            if tomorrow_val > now_val:
-                base["trend"] = "up"
-            elif tomorrow_val < now_val:
-                base["trend"] = "down"
-            else:
-                base["trend"] = "flat"
-        else:
-            base["trend"] = None
-
-        # Expected peak (excluding today)
-        peak = None
-        for f in forecast_list:
-            if f.get("has_index") and isinstance(f.get("value"), (int, float)):
-                if peak is None or f["value"] > peak["value"]:
-                    peak = f
-        base["expected_peak"] = (
-            {
-                "offset": peak["offset"],
-                "date": peak["date"],
-                "value": peak["value"],
-                "category": peak["category"],
-            }
-            if peak
-            else None
-        )
-        return base
-
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch pollen data and extract sensors for current day and forecast."""
         try:
@@ -465,7 +396,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                 daily, type_by_day_code, tcode, self.forecast_days
             )
             # Attach common forecast attributes (convenience, trend, expected_peak)
-            base = self._process_forecast_attributes(base, forecast_list)
+            base = attach_forecast_attributes(base, forecast_list)
             new_data[type_key] = base
 
             # Optional per-day sensors (only if requested and day exists)
@@ -530,7 +461,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             )
 
             # Attach common forecast attributes (convenience, trend, expected_peak)
-            base = self._process_forecast_attributes(base, forecast_list)
+            base = attach_forecast_attributes(base, forecast_list)
             new_data[key] = base
 
         self.data = new_data

--- a/custom_components/pollenlevels/forecast.py
+++ b/custom_components/pollenlevels/forecast.py
@@ -13,6 +13,7 @@ from typing import Any
 def attach_forecast_attributes(
     base: dict[str, Any],
     forecast_list: list[dict[str, Any]],
+    current_value: Any = None,
 ) -> dict[str, Any]:
     """Attach common forecast attributes to *base* in-place and return it.
 
@@ -47,7 +48,7 @@ def attach_forecast_attributes(
     _set_convenience("d2", 2)
 
     # Trend (today vs tomorrow)
-    now_val = base.get("value")
+    now_val = current_value if current_value is not None else base.get("value")
     tomorrow_val = base.get("tomorrow_value")
     if isinstance(now_val, (int, float)) and isinstance(tomorrow_val, (int, float)):
         if tomorrow_val > now_val:

--- a/custom_components/pollenlevels/forecast.py
+++ b/custom_components/pollenlevels/forecast.py
@@ -1,0 +1,78 @@
+"""Shared forecast attribute helper for pollen sensors.
+
+This module provides the pure ``attach_forecast_attributes`` function used
+by both the coordinator (TYPE and PLANT sensors) and the daily summary
+(overall_pollen_risk_today sensor).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def attach_forecast_attributes(
+    base: dict[str, Any],
+    forecast_list: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Attach common forecast attributes to *base* in-place and return it.
+
+    Adds:
+      * ``forecast`` list
+      * tomorrow convenience fields (tomorrow_has_index, tomorrow_value, …)
+      * d2 convenience fields (d2_has_index, d2_value, …)
+      * ``trend`` (up / down / flat / None)
+      * ``expected_peak`` (offset, date, value, category / None)
+
+    Behaviour mirrors the original ``_process_forecast_attributes`` method on
+    the coordinator so TYPE and PLANT sensor output stays unchanged.
+    """
+    base["forecast"] = forecast_list
+    forecast_by_offset = {item.get("offset"): item for item in forecast_list}
+
+    def _set_convenience(prefix: str, off: int) -> None:
+        f = forecast_by_offset.get(off)
+        base[f"{prefix}_has_index"] = f.get("has_index") if f else False
+        base[f"{prefix}_value"] = f.get("value") if f and f.get("has_index") else None
+        base[f"{prefix}_category"] = (
+            f.get("category") if f and f.get("has_index") else None
+        )
+        base[f"{prefix}_description"] = (
+            f.get("description") if f and f.get("has_index") else None
+        )
+        base[f"{prefix}_color_hex"] = (
+            f.get("color_hex") if f and f.get("has_index") else None
+        )
+
+    _set_convenience("tomorrow", 1)
+    _set_convenience("d2", 2)
+
+    # Trend (today vs tomorrow)
+    now_val = base.get("value")
+    tomorrow_val = base.get("tomorrow_value")
+    if isinstance(now_val, (int, float)) and isinstance(tomorrow_val, (int, float)):
+        if tomorrow_val > now_val:
+            base["trend"] = "up"
+        elif tomorrow_val < now_val:
+            base["trend"] = "down"
+        else:
+            base["trend"] = "flat"
+    else:
+        base["trend"] = None
+
+    # Expected peak (excluding today)
+    peak = None
+    for f in forecast_list:
+        if f.get("has_index") and isinstance(f.get("value"), (int, float)):
+            if peak is None or f["value"] > peak["value"]:
+                peak = f
+    base["expected_peak"] = (
+        {
+            "offset": peak["offset"],
+            "date": peak["date"],
+            "value": peak["value"],
+            "category": peak["category"],
+        }
+        if peak
+        else None
+    )
+    return base

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -67,6 +67,24 @@ def current_day_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
     return sorted(entries, key=lambda entry: entry.code)
 
 
+def forecast_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
+    """Collect all base type entries for forecast aggregation.
+
+    Unlike current_day_type_entries, this does not require a finite
+    current-day value so future-only types are included.
+    """
+    entries: list[SummaryEntry] = []
+    for key, info in data_map.items():
+        if key.endswith(("_d1", "_d2")):
+            continue
+        if not isinstance(info, dict) or info.get("source") != "type":
+            continue
+        code = normalize_entry_code(key, info, "type_")
+        name = info.get("displayName") or code
+        entries.append(SummaryEntry(code, str(name), key, info))
+    return sorted(entries, key=lambda entry: entry.code)
+
+
 def top_type_entries(
     data_map: dict[str, Any],
 ) -> tuple[float | int | None, list[SummaryEntry]]:
@@ -98,7 +116,10 @@ def _overall_forecast_from_type_forecasts(
             if not isinstance(f_item, dict):
                 continue
             offset = f_item.get("offset")
-            if not isinstance(offset, int) or offset < 1:
+            if (
+                not (isinstance(offset, int) and not isinstance(offset, bool))
+                or offset < 1
+            ):
                 continue
             offsets.setdefault(offset, []).append((entry, f_item))
 
@@ -113,7 +134,7 @@ def _overall_forecast_from_type_forecasts(
         valid = [
             (entry, f)
             for entry, f in pairs
-            if f.get("has_index") and is_finite_number(f.get("value"))
+            if f.get("has_index") is True and is_finite_number(f.get("value"))
         ]
 
         if not valid:
@@ -192,12 +213,13 @@ def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
         "tie_count": len(top_entries),
     }
 
-    # Build aggregated forecast from type entries and attach if non-empty.
-    type_entries = current_day_type_entries(data_map)
+    # Build aggregated forecast from all type entries (including future-only).
+    type_entries = forecast_type_entries(data_map)
     forecast_list = _overall_forecast_from_type_forecasts(type_entries)
     if forecast_list:
-        overall["value"] = top_value
-        overall = attach_forecast_attributes(overall, forecast_list)
+        overall = attach_forecast_attributes(
+            overall, forecast_list, current_value=top_value
+        )
 
     return {
         "plants_in_season_today": {

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import Any, NamedTuple
 
+from .forecast import attach_forecast_attributes
+
 
 class SummaryEntry(NamedTuple):
     """Represent a normalized daily summary entry."""
@@ -77,6 +79,86 @@ def top_type_entries(
     return top_value, top_entries
 
 
+def _overall_forecast_from_type_forecasts(
+    type_entries: list[SummaryEntry],
+) -> list[dict[str, Any]]:
+    """Build aggregated forecast list from current-day type forecast attributes.
+
+    Returns an empty list when there are no future offsets (forecast_days=1).
+
+    For each future offset, the highest indexed value across all types is used.
+    Ties are preserved with deterministic ordering by normalised type code.
+    """
+    offsets: dict[int, list[tuple[SummaryEntry, dict[str, Any]]]] = {}
+    for entry in type_entries:
+        forecast = entry.info.get("forecast")
+        if not isinstance(forecast, list) or not forecast:
+            continue
+        for f_item in forecast:
+            if not isinstance(f_item, dict):
+                continue
+            offset = f_item.get("offset")
+            if not isinstance(offset, int) or offset < 1:
+                continue
+            offsets.setdefault(offset, []).append((entry, f_item))
+
+    if not offsets:
+        return []
+
+    result: list[dict[str, Any]] = []
+    for offset in sorted(offsets):
+        pairs = offsets[offset]
+        pairs.sort(key=lambda pair: pair[0].code)
+
+        valid = [
+            (entry, f)
+            for entry, f in pairs
+            if f.get("has_index") and is_finite_number(f.get("value"))
+        ]
+
+        if not valid:
+            _, first_f = pairs[0]
+            result.append(
+                {
+                    "offset": offset,
+                    "date": first_f.get("date"),
+                    "has_index": False,
+                    "value": None,
+                    "category": None,
+                    "description": None,
+                    "color_hex": None,
+                    "color_rgb": None,
+                    "top_pollen_codes": [],
+                    "top_pollen_names": [],
+                    "top_pollen_categories": [],
+                    "tie_count": 0,
+                }
+            )
+        else:
+            max_val = max(f["value"] for _, f in valid)
+            tied = [(entry, f) for entry, f in valid if f["value"] == max_val]
+            tied.sort(key=lambda pair: pair[0].code)
+            _, first_f = tied[0]
+            result.append(
+                {
+                    "offset": offset,
+                    "date": first_f.get("date"),
+                    "has_index": True,
+                    "value": max_val,
+                    "category": first_f.get("category"),
+                    "description": first_f.get("description"),
+                    "color_hex": first_f.get("color_hex"),
+                    "color_rgb": first_f.get("color_rgb"),
+                    "top_pollen_codes": [entry.code for entry, _ in tied],
+                    "top_pollen_names": [entry.name for entry, _ in tied],
+                    "top_pollen_categories": [f.get("category") for _, f in tied],
+                    "tie_count": len(tied),
+                }
+            )
+
+    return result
+
+
 def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
     """Return payloads for the daily summary sensors."""
     plant_entries = current_day_plant_entries(data_map)
@@ -100,6 +182,23 @@ def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
     top_names = [entry.name for entry in top_entries]
     first_info = top_entries[0].info if top_entries else {}
 
+    overall: dict[str, Any] = {
+        "state": top_value,
+        "category": first_info.get("category"),
+        "description": first_info.get("description"),
+        "top_pollen_codes": [entry.code for entry in top_entries],
+        "top_pollen_names": top_names,
+        "top_pollen_categories": [entry.info.get("category") for entry in top_entries],
+        "tie_count": len(top_entries),
+    }
+
+    # Build aggregated forecast from type entries and attach if non-empty.
+    type_entries = current_day_type_entries(data_map)
+    forecast_list = _overall_forecast_from_type_forecasts(type_entries)
+    if forecast_list:
+        overall["value"] = top_value
+        overall = attach_forecast_attributes(overall, forecast_list)
+
     return {
         "plants_in_season_today": {
             "state": season_state,
@@ -112,17 +211,7 @@ def daily_summary(data_map: dict[str, Any]) -> dict[str, Any]:
             "unknown_season_codes": [entry.code for entry in unknown_entries],
             "unknown_season_names": [entry.name for entry in unknown_entries],
         },
-        "overall_pollen_risk_today": {
-            "state": top_value,
-            "category": first_info.get("category"),
-            "description": first_info.get("description"),
-            "top_pollen_codes": [entry.code for entry in top_entries],
-            "top_pollen_names": top_names,
-            "top_pollen_categories": [
-                entry.info.get("category") for entry in top_entries
-            ],
-            "tie_count": len(top_entries),
-        },
+        "overall_pollen_risk_today": overall,
         "top_pollen_types_today": {
             "state": ", ".join(top_names) if top_names else None,
             "top_value": top_value,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,231 @@
+"""Unit tests for the shared forecast attribute helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+FORECAST_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "pollenlevels"
+    / "forecast.py"
+)
+
+
+def _load_forecast_module() -> ModuleType:
+    """Load forecast.py directly (pure module, no HA imports)."""
+    spec = importlib.util.spec_from_file_location(
+        "pollenlevels_forecast", FORECAST_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+attach_forecast_attributes = _load_forecast_module().attach_forecast_attributes
+
+
+def test_attach_empty_forecast() -> None:
+    """An empty forecast list sets forecast to [] and convenience defaults."""
+    base = {"value": 3}
+    result = attach_forecast_attributes(base, [])
+
+    assert result is base
+    assert result["forecast"] == []
+    assert result["tomorrow_has_index"] is False
+    assert result["tomorrow_value"] is None
+    assert result["tomorrow_category"] is None
+    assert result["tomorrow_description"] is None
+    assert result["tomorrow_color_hex"] is None
+    assert result["d2_has_index"] is False
+    assert result["d2_value"] is None
+    assert result["trend"] is None
+    assert result["expected_peak"] is None
+
+
+def test_attach_single_offset() -> None:
+    """A single offset-1 entry populates tomorrow_* fields and trend."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 5,
+            "category": "High",
+            "description": "High risk",
+            "color_hex": "#FF0000",
+            "color_rgb": [255, 0, 0],
+        }
+    ]
+    base = {"value": 2}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["forecast"] == forecast
+    assert result["tomorrow_has_index"] is True
+    assert result["tomorrow_value"] == 5
+    assert result["tomorrow_category"] == "High"
+    assert result["tomorrow_description"] == "High risk"
+    assert result["tomorrow_color_hex"] == "#FF0000"
+    assert result["d2_has_index"] is False
+    assert result["d2_value"] is None
+    assert result["trend"] == "up"
+    assert result["expected_peak"] == {
+        "offset": 1,
+        "date": "2026-06-10",
+        "value": 5,
+        "category": "High",
+    }
+
+
+def test_attach_two_offsets() -> None:
+    """Offsets 1 and 2 populate tomorrow_* and d2_* fields."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 4,
+            "category": "Moderate",
+            "description": "Moderate",
+            "color_hex": "#FFFF00",
+            "color_rgb": [255, 255, 0],
+        },
+        {
+            "offset": 2,
+            "date": "2026-06-11",
+            "has_index": True,
+            "value": 6,
+            "category": "Very High",
+            "description": "Very High",
+            "color_hex": "#FF0000",
+            "color_rgb": [255, 0, 0],
+        },
+    ]
+    base = {"value": 3}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["tomorrow_value"] == 4
+    assert result["d2_value"] == 6
+    assert result["d2_has_index"] is True
+    assert result["d2_category"] == "Very High"
+    assert result["expected_peak"] == {
+        "offset": 2,
+        "date": "2026-06-11",
+        "value": 6,
+        "category": "Very High",
+    }
+
+
+def test_trend_flat() -> None:
+    """Equal today and tomorrow values produce trend 'flat'."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 3,
+            "category": "Moderate",
+            "description": "Moderate",
+            "color_hex": None,
+            "color_rgb": None,
+        }
+    ]
+    base = {"value": 3}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["trend"] == "flat"
+
+
+def test_trend_down() -> None:
+    """Tomorrow value lower than today produces trend 'down'."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 1,
+            "category": "Low",
+            "description": "Low",
+            "color_hex": None,
+            "color_rgb": None,
+        }
+    ]
+    base = {"value": 4}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["trend"] == "down"
+
+
+def test_trend_none_when_missing_value() -> None:
+    """Trend is None when today or tomorrow value is missing."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": False,
+            "value": None,
+            "category": None,
+            "description": None,
+            "color_hex": None,
+            "color_rgb": None,
+        }
+    ]
+    base = {"value": 3}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["trend"] is None
+
+
+def test_expected_peak_picks_highest() -> None:
+    """Expected peak selects the highest future indexed value."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 3,
+            "category": "Moderate",
+            "description": "Moderate",
+            "color_hex": None,
+            "color_rgb": None,
+        },
+        {
+            "offset": 2,
+            "date": "2026-06-11",
+            "has_index": True,
+            "value": 7,
+            "category": "Very High",
+            "description": "Very High",
+            "color_hex": None,
+            "color_rgb": None,
+        },
+    ]
+    base = {"value": 1}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["expected_peak"]["offset"] == 2
+    assert result["expected_peak"]["value"] == 7
+
+
+def test_expected_peak_none_when_all_missing() -> None:
+    """Expected peak is None when no forecast entry has a valid index."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": False,
+            "value": None,
+            "category": None,
+            "description": None,
+            "color_hex": None,
+            "color_rgb": None,
+        }
+    ]
+    base = {"value": 2}
+    result = attach_forecast_attributes(base, forecast)
+
+    assert result["expected_peak"] is None

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 FORECAST_PATH = (
     Path(__file__).resolve().parents[1]
@@ -209,6 +210,26 @@ def test_expected_peak_picks_highest() -> None:
 
     assert result["expected_peak"]["offset"] == 2
     assert result["expected_peak"]["value"] == 7
+
+
+def test_attach_current_value_overrides_base_value() -> None:
+    """current_value param is used for trend when base has no 'value' key."""
+    base: dict[str, Any] = {}
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 5,
+            "category": "High",
+            "description": "High",
+            "color_hex": "#FF0000",
+            "color_rgb": [255, 0, 0],
+        }
+    ]
+    result = attach_forecast_attributes(base, forecast, current_value=3)
+    assert result["trend"] == "up"
+    assert "value" not in result
 
 
 def test_expected_peak_none_when_all_missing() -> None:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -61,6 +61,7 @@ def _load_summary_module() -> ModuleType:
 _module = _load_summary_module()
 daily_summary = _module.daily_summary
 current_day_type_entries = _module.current_day_type_entries
+forecast_type_entries = _module.forecast_type_entries
 is_finite_number = _module.is_finite_number
 
 
@@ -239,7 +240,7 @@ def test_overall_forecast_two_days() -> None:
 
     overall = summary["overall_pollen_risk_today"]
     assert overall["state"] == 2
-    assert overall["value"] == 2
+    assert "value" not in overall
     assert len(overall["forecast"]) == 1
     assert overall["forecast"][0]["offset"] == 1
     assert overall["forecast"][0]["value"] == 5
@@ -459,3 +460,186 @@ def test_overall_forecast_ignores_per_day_d1_d2_keys() -> None:
     assert len(overall["forecast"]) == 1
     assert overall["forecast"][0]["value"] == 3  # from current-day entry
     assert overall["forecast"][0]["top_pollen_codes"] == ["GRASS"]
+
+
+def test_forecast_type_entries_includes_future_only_types() -> None:
+    """Forecast aggregation includes types with no finite current-day value."""
+    entries = forecast_type_entries(
+        {
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": None,
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+            },
+            "type_mold_d1": {
+                "source": "type",
+                "displayName": "Mold tomorrow",
+                "value": 5,
+            },
+        }
+    )
+
+    codes = {e.code for e in entries}
+    assert codes == {"GRASS", "TREE"}
+
+
+def test_overall_forecast_future_only_types_included() -> None:
+    """A type with no current-day value can still contribute to overall forecast."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            },
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": None,
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 4,
+                        "category": "Moderate",
+                        "description": "Moderate",
+                        "color_hex": "#FFFF00",
+                        "color_rgb": [255, 255, 0],
+                    }
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 3
+    assert "value" not in overall
+    assert overall["forecast"][0]["value"] == 5
+    assert overall["forecast"][0]["top_pollen_codes"] == ["GRASS"]
+
+
+def test_overall_forecast_all_current_values_missing_with_future() -> None:
+    """Overall can still produce forecast when no type has a finite current-day value."""
+    summary = daily_summary(
+        {
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": None,
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 4,
+                        "category": "Moderate",
+                        "description": "Moderate",
+                        "color_hex": "#FFFF00",
+                        "color_rgb": [255, 255, 0],
+                    }
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] is None
+    assert "value" not in overall
+    assert len(overall["forecast"]) == 1
+    assert overall["forecast"][0]["value"] == 4
+
+
+def test_overall_forecast_bool_offset_ignored() -> None:
+    """Forecast entries with bool offsets are not treated as valid offsets."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "forecast": [
+                    {
+                        "offset": True,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    },
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 4,
+                        "category": "Moderate",
+                        "description": "Moderate",
+                        "color_hex": "#FFFF00",
+                        "color_rgb": [255, 255, 0],
+                    },
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert len(overall["forecast"]) == 1
+    assert overall["forecast"][0]["value"] == 4
+
+
+def test_overall_forecast_has_index_must_be_true_explicit() -> None:
+    """Only has_index=True (not truthy 1) is accepted as indexed for overall."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": 1,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    },
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert len(overall["forecast"]) == 1
+    item = overall["forecast"][0]
+    assert item["has_index"] is False
+    assert item["value"] is None

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -541,6 +541,79 @@ def test_overall_forecast_future_only_types_included() -> None:
     assert overall["forecast"][0]["top_pollen_codes"] == ["GRASS"]
 
 
+def test_overall_forecast_future_only_type_can_win_future_risk() -> None:
+    """A future-only type (no value today) can dominate the aggregated forecast."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 2,
+                        "category": "Low",
+                        "description": "Low",
+                        "color_hex": "#00FF00",
+                        "color_rgb": [0, 255, 0],
+                    }
+                ],
+            },
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": None,
+                "category": None,
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 3
+    assert "value" not in overall
+    assert len(overall["forecast"]) == 1
+    assert overall["forecast"][0]["offset"] == 1
+    assert overall["forecast"][0]["date"] == "2026-06-10"
+    assert overall["forecast"][0]["has_index"] is True
+    assert overall["forecast"][0]["value"] == 5
+    assert overall["forecast"][0]["category"] == "High"
+    assert overall["forecast"][0]["description"] == "High"
+    assert overall["forecast"][0]["color_hex"] == "#FF0000"
+    assert overall["forecast"][0]["color_rgb"] == [255, 0, 0]
+    assert overall["forecast"][0]["top_pollen_codes"] == ["TREE"]
+    assert overall["forecast"][0]["top_pollen_names"] == ["Tree"]
+    assert overall["forecast"][0]["top_pollen_categories"] == ["High"]
+    assert overall["forecast"][0]["tie_count"] == 1
+    assert overall["tomorrow_has_index"] is True
+    assert overall["tomorrow_value"] == 5
+    assert overall["tomorrow_category"] == "High"
+    assert overall["trend"] == "up"
+    assert overall["expected_peak"] == {
+        "offset": 1,
+        "date": "2026-06-10",
+        "value": 5,
+        "category": "High",
+    }
+
+
 def test_overall_forecast_all_current_values_missing_with_future() -> None:
     """Overall can still produce forecast when no type has a finite current-day value."""
     summary = daily_summary(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -3,28 +3,68 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
-SUMMARY_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "custom_components"
-    / "pollenlevels"
-    / "summary.py"
-)
+PKG_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels"
+
+SUMMARY_PATH = PKG_PATH / "summary.py"
+FORECAST_PATH = PKG_PATH / "forecast.py"
+
+_PKG_NAME = "custom_components.pollenlevels"
 
 
 def _load_summary_module() -> ModuleType:
-    """Load summary.py directly without importing the integration package."""
-    spec = importlib.util.spec_from_file_location("pollenlevels_summary", SUMMARY_PATH)
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    """Load summary.py with package context so relative imports resolve.
+
+    Also loads forecast.py as a sibling module.  Does NOT import Home
+    Assistant.
+    """
+    # -- create stub packages in sys.modules so relative imports work --------
+    parent_name = "custom_components"
+    if parent_name not in sys.modules:
+        parent = ModuleType(parent_name)
+        parent.__path__ = [str(PKG_PATH.parent)]
+        parent.__package__ = parent_name
+        sys.modules[parent_name] = parent
+
+    if _PKG_NAME not in sys.modules:
+        pkg = ModuleType(_PKG_NAME)
+        pkg.__path__ = [str(PKG_PATH)]
+        pkg.__package__ = _PKG_NAME
+        sys.modules[_PKG_NAME] = pkg
+
+    # -- load forecast.py first (dependency of summary.py) ------------------
+    forecast_spec = importlib.util.spec_from_file_location(
+        f"{_PKG_NAME}.forecast", FORECAST_PATH
+    )
+    assert forecast_spec is not None
+    assert forecast_spec.loader is not None
+    forecast_module = importlib.util.module_from_spec(forecast_spec)
+    sys.modules[f"{_PKG_NAME}.forecast"] = forecast_module
+    forecast_spec.loader.exec_module(forecast_module)
+
+    # -- load summary.py ----------------------------------------------------
+    summary_spec = importlib.util.spec_from_file_location(
+        f"{_PKG_NAME}.summary", SUMMARY_PATH
+    )
+    assert summary_spec is not None
+    assert summary_spec.loader is not None
+    summary_module = importlib.util.module_from_spec(summary_spec)
+    sys.modules[f"{_PKG_NAME}.summary"] = summary_module
+    summary_spec.loader.exec_module(summary_module)
+
+    return summary_module
 
 
-daily_summary = _load_summary_module().daily_summary
+_module = _load_summary_module()
+daily_summary = _module.daily_summary
+current_day_type_entries = _module.current_day_type_entries
+is_finite_number = _module.is_finite_number
+
+
+# ── existing tests (unchanged) ─────────────────────────────────────────────
 
 
 def test_daily_summary_uses_empty_states_without_data() -> None:
@@ -134,3 +174,288 @@ def test_daily_summary_tracks_unknown_plant_season_values() -> None:
         "unknown_season_codes": ["BIRCH", "ELM"],
         "unknown_season_names": ["Birch", "Elm"],
     }
+
+
+# ── forecast attribute tests ───────────────────────────────────────────────
+
+
+def test_overall_forecast_not_added_when_no_future_offsets() -> None:
+    """No forecast-related attributes when type entries lack forecast data."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+            },
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": 2,
+                "category": "Low",
+                "forecast": [],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 3
+    assert "forecast" not in overall
+    assert "tomorrow_has_index" not in overall
+    assert "d2_has_index" not in overall
+    assert "trend" not in overall
+    assert "expected_peak" not in overall
+    assert "value" not in overall
+
+
+def test_overall_forecast_two_days() -> None:
+    """A 2-day forecast (offset 1) exposes one forecast item and convenience."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 2,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            }
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 2
+    assert overall["value"] == 2
+    assert len(overall["forecast"]) == 1
+    assert overall["forecast"][0]["offset"] == 1
+    assert overall["forecast"][0]["value"] == 5
+    assert overall["forecast"][0]["has_index"] is True
+    assert overall["forecast"][0]["top_pollen_codes"] == ["GRASS"]
+    assert overall["forecast"][0]["top_pollen_names"] == ["Grass"]
+    assert overall["forecast"][0]["tie_count"] == 1
+    assert overall["tomorrow_has_index"] is True
+    assert overall["tomorrow_value"] == 5
+    assert overall["tomorrow_category"] == "High"
+    assert overall["trend"] == "up"
+    assert overall["d2_has_index"] is False
+    assert overall["d2_value"] is None
+    assert overall["expected_peak"] == {
+        "offset": 1,
+        "date": "2026-06-10",
+        "value": 5,
+        "category": "High",
+    }
+
+
+def test_overall_forecast_three_days() -> None:
+    """A 3-day forecast exposes offsets 1 and 2 with correct convenience."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 1,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 3,
+                        "category": "Moderate",
+                        "description": "Moderate",
+                        "color_hex": "#FFFF00",
+                        "color_rgb": [255, 255, 0],
+                    },
+                    {
+                        "offset": 2,
+                        "date": "2026-06-11",
+                        "has_index": True,
+                        "value": 7,
+                        "category": "Very High",
+                        "description": "Very High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    },
+                ],
+            }
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 1
+    assert len(overall["forecast"]) == 2
+    assert overall["forecast"][0]["offset"] == 1
+    assert overall["forecast"][1]["offset"] == 2
+    assert overall["tomorrow_value"] == 3
+    assert overall["d2_value"] == 7
+    assert overall["d2_has_index"] is True
+    assert overall["expected_peak"]["offset"] == 2
+    assert overall["expected_peak"]["value"] == 7
+
+
+def test_overall_forecast_tie_handling() -> None:
+    """Tied max future values preserve both type codes and names."""
+    summary = daily_summary(
+        {
+            "type_weed": {
+                "source": "type",
+                "code": "WEED",
+                "displayName": "Weed",
+                "value": 2,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 3,
+                "category": "Moderate",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 5,
+                        "category": "High",
+                        "description": "High risk",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    forecast_item = overall["forecast"][0]
+    assert forecast_item["value"] == 5
+    assert forecast_item["has_index"] is True
+    assert forecast_item["top_pollen_codes"] == ["GRASS", "WEED"]
+    assert forecast_item["top_pollen_names"] == ["Grass", "Weed"]
+    assert forecast_item["top_pollen_categories"] == ["High", "High"]
+    assert forecast_item["tie_count"] == 2
+    # Deterministic ordering: GRASS before WEED
+    assert forecast_item["top_pollen_codes"] == ["GRASS", "WEED"]
+
+
+def test_overall_forecast_missing_future_index() -> None:
+    """Offset with no valid indexed value produces has_index=False and empty lists."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 2,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": False,
+                        "value": None,
+                        "category": None,
+                        "description": None,
+                        "color_hex": None,
+                        "color_rgb": None,
+                    }
+                ],
+            }
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert len(overall["forecast"]) == 1
+    item = overall["forecast"][0]
+    assert item["offset"] == 1
+    assert item["has_index"] is False
+    assert item["value"] is None
+    assert item["category"] is None
+    assert item["description"] is None
+    assert item["color_hex"] is None
+    assert item["color_rgb"] is None
+    assert item["top_pollen_codes"] == []
+    assert item["top_pollen_names"] == []
+    assert item["top_pollen_categories"] == []
+    assert item["tie_count"] == 0
+    assert overall["tomorrow_has_index"] is False
+    assert overall["tomorrow_value"] is None
+    assert overall["trend"] is None
+
+
+def test_overall_forecast_ignores_per_day_d1_d2_keys() -> None:
+    """Per-day _d1/_d2 type entries do not contribute to the overall forecast."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 2,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 3,
+                        "category": "Moderate",
+                        "description": "Moderate",
+                        "color_hex": "#FFFF00",
+                        "color_rgb": [255, 255, 0],
+                    }
+                ],
+            },
+            "type_grass_d1": {
+                "source": "type",
+                "displayName": "Grass D+1",
+                "value": 9,
+                "category": "Extreme",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 9,
+                        "category": "Extreme",
+                        "description": "Extreme",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    }
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert len(overall["forecast"]) == 1
+    assert overall["forecast"][0]["value"] == 3  # from current-day entry
+    assert overall["forecast"][0]["top_pollen_codes"] == ["GRASS"]


### PR DESCRIPTION
## Summary

Expose plant-style forecast attributes on the `overall_pollen_risk_today` summary sensor so compatible Lovelace cards can render upcoming-day general pollen risk values. No new entities are created — all future information is available as sensor attributes only.

## Changes

### `custom_components/pollenlevels/forecast.py` (new)

- Added pure helper `attach_forecast_attributes()` to attach `forecast`, `tomorrow_*`, `d2_*`, `trend`, and `expected_peak` attributes to a sensor payload dict.
- Added optional `current_value` support so summary sensors can calculate trend from today's value without leaking a public `value` attribute.

### `custom_components/pollenlevels/summary.py`

- Added `forecast_type_entries()` to collect all base TYPE entries for forecast aggregation without requiring a finite current-day value.
- Included future-only pollen types in the aggregated overall forecast when they have valid future forecast data.
- Added `_overall_forecast_from_type_forecasts()` to aggregate per-offset forecast entries across base TYPE entries.
- Kept current-day overall risk calculation unchanged: today's state still comes only from finite current-day TYPE values.
- Updated `daily_summary()` to use `forecast_type_entries()` for future forecast aggregation and pass `current_value=top_value` to the shared helper.
- Ensured no public `value` key is added to the `overall_pollen_risk_today` payload.
- Hardened aggregation by rejecting boolean offsets and requiring `has_index is True` explicitly.

### `custom_components/pollenlevels/coordinator.py`

- Reused the shared `attach_forecast_attributes()` helper for existing TYPE and PLANT sensor forecast attributes.
- Removed the duplicated inline `_process_forecast_attributes()` method.
- Kept existing TYPE and PLANT forecast output shape unchanged.

### `CHANGELOG.md`

- Added entry under `[3.0.0b3] - 2026-06-09`.

### Tests

#### `tests/test_forecast.py` (9 tests)

- Covers empty forecast lists, single/two offsets, trend directions (`up`, `flat`, `down`, `None`), expected peak selection, missing-index fallback, and the `current_value` override parameter.

#### `tests/test_summary.py` (16 tests)

- Preserves existing summary coverage for empty data, ties, non-finite values, and plant season tracking.
- Adds coverage for two-day and three-day overall forecasts.
- Covers deterministic tie handling.
- Covers missing future indexes.
- Ensures per-day `_d1` / `_d2` TYPE entities are ignored.
- Ensures future-only TYPE entries are included in the aggregated overall forecast.
- Ensures a future-only TYPE entry can dominate the aggregated future risk.
- Covers the case where all current-day TYPE values are missing but future forecast data exists.
- Covers boolean offset rejection.
- Covers strict `has_index is True` handling.

## Validation

- `ruff check .` — passed
- `black --check .` — passed
- `pytest tests/test_forecast.py tests/test_summary.py tests/test_sensor.py` — passed (`99 passed`)
- `pytest` — passed (`99 passed`)

## Files changed

- `CHANGELOG.md`
- `custom_components/pollenlevels/coordinator.py`
- `custom_components/pollenlevels/forecast.py`
- `custom_components/pollenlevels/summary.py`
- `tests/test_forecast.py`
- `tests/test_summary.py`

## Design decisions

- **No new entities.** Forecast is exposed exclusively through sensor attributes to keep the entity count low.
- **No D+1/D+2 summary sensors.** `overall_pollen_risk_today` is a computed summary sensor, and per-day summary entities would duplicate information already available in `forecast[]`.
- **No `code` attribute.** The overall sensor represents a synthetic aggregate, not a specific pollen type.
- **Forecast is attribute-first.** Upcoming days are exposed through `attributes.forecast[]`.
- **`forecast_days = 5` means today plus four future offsets.** The sensor state represents today, while `forecast[]` can expose `offset` 1 through 4.
- **Convenience fields stay limited to D+1/D+2.** `tomorrow_*` and `d2_*` remain compatibility helpers; D+3/D+4 data is available through `forecast[]`.
- **Future-only types contribute.** Pollen types with no finite index today but valid future forecast data can contribute to the aggregated overall forecast.
- **Current-day behavior is preserved.** Today's overall state still comes only from finite current-day TYPE values.
- **Bool offsets are rejected.** Python treats `bool` as a subclass of `int`, so the offset check explicitly rejects boolean values to avoid treating `True` as `offset = 1`.
- **`has_index is True` is required.** The summary aggregation uses identity checks instead of truthiness so values like `1` are not accidentally accepted as indexed forecast data.

## Out of scope

- Removing existing `_d1` / `_d2` TYPE forecast sensors.
- Adding D+3 / D+4 standalone sensors.
- Changing config flow options.
- Changing translations.
- Changing diagnostics.
- Changing API request behavior.
- Changing migration logic.
- Bumping the release version outside the existing changelog entry.