### PR TITLE
chore: tune CodeRabbit review signal

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,13 +5,10 @@ early_access: false
 enable_free_tier: true
 
 tone_instructions: >
-  Be concise, practical, and evidence-based. Focus on correctness, security,
-  Home Assistant compatibility, async behavior, migration safety, privacy,
-  registry stability, and maintainability. Prefer actionable bug-risk comments
-  over style-only comments. Do not stay silent on plausible functional bugs,
-  Home Assistant API misuse, migration regressions, privacy leaks, or lifecycle
-  cleanup issues. Avoid cosmetic suggestions unless they prevent a real bug,
-  user-facing regression, or CI failure.
+  Be concise and evidence-based. Focus on correctness, HA compatibility,
+  async behavior, migration safety, privacy, registry stability, and
+  maintainability. Flag plausible bugs, API misuse, lifecycle issues,
+  and privacy leaks.
 
 reviews:
   profile: "assertive"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,11 +6,15 @@ enable_free_tier: true
 
 tone_instructions: >
   Be concise, practical, and evidence-based. Focus on correctness, security,
-  Home Assistant compatibility, async behavior, privacy, and maintainability.
-  Avoid cosmetic suggestions unless they prevent a real bug or CI failure.
+  Home Assistant compatibility, async behavior, migration safety, privacy,
+  registry stability, and maintainability. Prefer actionable bug-risk comments
+  over style-only comments. Do not stay silent on plausible functional bugs,
+  Home Assistant API misuse, migration regressions, privacy leaks, or lifecycle
+  cleanup issues. Avoid cosmetic suggestions unless they prevent a real bug,
+  user-facing regression, or CI failure.
 
 reviews:
-  profile: "chill"
+  profile: "assertive"
   request_changes_workflow: false
   high_level_summary: true
   poem: false
@@ -19,6 +23,10 @@ reviews:
   enable_prompt_for_ai_agents: false
   abort_on_close: true
   disable_cache: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
 
   finishing_touches:
     docstrings:
@@ -106,10 +114,50 @@ reviews:
         - Raw API payloads that may contain sensitive user data.
         Prefer redacted, rounded, or summarized diagnostics.
 
+    - path: "custom_components/pollenlevels/__init__.py"
+      instructions: |
+        Review Home Assistant setup and unload lifecycle carefully.
+        Focus on:
+        - Public Home Assistant APIs only.
+        - Correct ConfigEntry and ConfigSubentry lifecycle behavior.
+        - Correct setup, unload, reload, and cleanup behavior.
+        - Avoiding stale runtime data after subentry removal.
+        - Avoiding refreshes of deleted or stale locations.
+        - Correct error handling with ConfigEntryNotReady.
+        - No logging of API keys, precise coordinates, raw URLs, or raw API payloads.
+        - No changes that could break entity IDs, unique IDs, devices, dashboards, automations, or history.
+
+    - path: "custom_components/pollenlevels/migration.py"
+      instructions: |
+        Treat migration code as high risk.
+        Review carefully for:
+        - Preservation of entity_id, unique_id, devices, dashboards, automations, and history.
+        - Correct consolidation of legacy entries by API key.
+        - No merging of locations that use different API keys.
+        - Safe handling of invalid legacy coordinates and corrupt stored data.
+        - Safe retry behavior when registry migration cannot be completed.
+        - No changes to legacy IDs, device identifiers, or registry logic unless covered by explicit tests.
+        - No exposure of API keys, precise coordinates, raw URLs, or raw API payloads in logs, issues, diagnostics, or exceptions.
+        - Correct behavior for one legacy location, multiple locations with the same key, multiple keys, mixed keys, parent entries without locations, and alpha/beta upgrades.
+
+    - path: "custom_components/pollenlevels/issue_helpers.py"
+      instructions: |
+        Review Home Assistant Repairs issue handling carefully.
+        Focus on:
+        - Use of public Home Assistant repair issue APIs only.
+        - Stable and deterministic issue IDs.
+        - Correct create/delete lifecycle.
+        - Issues are created only for persistent stored-data problems, not temporary API or network failures.
+        - Issues are removed when the stored data becomes valid or migration succeeds.
+        - Translation placeholders match translation files.
+        - No API keys, precise coordinates, raw URLs, or raw API payloads appear in issue titles, descriptions, placeholders, logs, or exceptions.
+
     - path: "custom_components/pollenlevels/translations/**/*.json"
       instructions: |
         Check that translation keys stay consistent across locales.
         Do not suggest changing stable public keys unless required.
+        For Repairs/issues translations, verify all locales define the same keys
+        and preserve required placeholders such as {entry_title} and {location_title}.
         English technical strings are acceptable when intentionally shared
         across locales during development.
 
@@ -135,6 +183,29 @@ reviews:
         - Regression coverage for config flow, coordinator, diagnostics,
           migration, entity registry, and services/actions.
         - No tests depending on real network calls or real API keys.
+
+    - path: "tests/_ha_stubs.py"
+      instructions: |
+        Review Home Assistant test stubs carefully.
+        Focus on:
+        - Stubs should model the Home Assistant behavior needed by the tests.
+        - Stubs must not hide real lifecycle, registry, repairs, or migration bugs.
+        - Keep stubs minimal and deterministic.
+        - Avoid broad fake behavior that makes tests pass without validating the production contract.
+
+    - path: "tests/test_migration.py"
+      instructions: |
+        Review migration tests as regression protection.
+        Check that tests cover:
+        - One legacy location.
+        - Multiple legacy locations sharing one API key.
+        - Multiple API keys.
+        - Mixed same-key and different-key scenarios.
+        - Invalid coordinates.
+        - Corrupt or unmigratable subentries.
+        - Parent without locations where applicable.
+        - Entity registry and device registry preservation.
+        - No leaked API keys or precise coordinates in logs, diagnostics, issues, or exceptions.
 
     - path: "README.md"
       instructions: |


### PR DESCRIPTION
## Summary

Tune CodeRabbit so it can better replace Gemini Code Assist as the primary automated PR reviewer.

## Changes

- Switch CodeRabbit from `chill` to `assertive`.
- Keep `request_changes_workflow: false` so CodeRabbit comments more but does not block merges.
- Disable docstring pre-merge warnings to reduce irrelevant noise.
- Add focused review instructions for Home Assistant setup lifecycle, migrations, Repairs issues, HA stubs, migration tests, and translation placeholders.

## Notes

- Runtime code is unchanged.
- Tests are unchanged.
- Version numbers are unchanged.
- This PR only updates `.coderabbit.yaml`.
- The goal is to increase bug-detection signal while keeping merges under human control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened review configuration to enforce concise, evidence-based guidance with an assertive profile and stricter checks for compatibility, async behavior, migration safety, privacy, registry/lifecycle stability, and translation consistency.
  * Added pre-merge adjustment to disable docstring enforcement.
  * Tightened test and migration review criteria to require deterministic stubs, broader regression scenarios, and prevention of sensitive-data leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->