### PR TITLE
test: lock summary sensor attribute contract

### DIFF
--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
 import importlib.util
 import sys
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from types import ModuleType
 
@@ -126,14 +126,19 @@ def test_summary_sensor_attribute_contract_distinguishes_summary_sensors(
     plants = summary["plants_in_season_today"]
 
     # -- state sanity --------------------------------------------------------
-    assert type(overall["state"]) is int, "overall state must be strictly an int"
-    assert overall["state"] == 3
+    overall_state = overall["state"]
+    assert isinstance(overall_state, int), "overall state must be numeric"
+    assert not isinstance(overall_state, bool), "overall state must not be boolean"
+    assert overall_state == 3
 
-    assert type(top_types["state"]) is str, "top_types state must be strictly a str"
-    assert top_types["state"] == "Grass"
+    top_types_state = top_types["state"]
+    assert isinstance(top_types_state, str), "top_types state must be textual"
+    assert top_types_state == "Grass"
 
-    assert type(plants["state"]) is int, "plants state must be strictly an int"
-    assert plants["state"] == 1
+    plants_state = plants["state"]
+    assert isinstance(plants_state, int), "plants state must be numeric"
+    assert not isinstance(plants_state, bool), "plants state must not be boolean"
+    assert plants_state == 1
 
     # -- top_pollen_codes contract ------------------------------------------
     assert "top_pollen_codes" in overall

--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -1,0 +1,132 @@
+"""Contract tests for public daily summary attributes."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+PKG_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels"
+
+SUMMARY_PATH = PKG_PATH / "summary.py"
+FORECAST_PATH = PKG_PATH / "forecast.py"
+
+_PKG_NAME = "custom_components.pollenlevels"
+
+
+def _load_summary_module() -> ModuleType:
+    """Load summary.py with package context so relative imports resolve."""
+    # -- create stub packages in sys.modules so relative imports work --------
+    parent_name = "custom_components"
+    if parent_name not in sys.modules:
+        parent = ModuleType(parent_name)
+        parent.__path__ = [str(PKG_PATH.parent)]
+        parent.__package__ = parent_name
+        sys.modules[parent_name] = parent
+
+    if _PKG_NAME not in sys.modules:
+        pkg = ModuleType(_PKG_NAME)
+        pkg.__path__ = [str(PKG_PATH)]
+        pkg.__package__ = _PKG_NAME
+        sys.modules[_PKG_NAME] = pkg
+
+    # -- load forecast.py first (dependency of summary.py) ------------------
+    forecast_spec = importlib.util.spec_from_file_location(
+        f"{_PKG_NAME}.forecast", FORECAST_PATH
+    )
+    assert forecast_spec is not None
+    assert forecast_spec.loader is not None
+    forecast_module = importlib.util.module_from_spec(forecast_spec)
+    sys.modules[f"{_PKG_NAME}.forecast"] = forecast_module
+    forecast_spec.loader.exec_module(forecast_module)
+
+    # -- load summary.py ----------------------------------------------------
+    summary_spec = importlib.util.spec_from_file_location(
+        f"{_PKG_NAME}.summary", SUMMARY_PATH
+    )
+    assert summary_spec is not None
+    assert summary_spec.loader is not None
+    summary_module = importlib.util.module_from_spec(summary_spec)
+    sys.modules[f"{_PKG_NAME}.summary"] = summary_module
+    summary_spec.loader.exec_module(summary_module)
+
+    return summary_module
+
+
+_module = _load_summary_module()
+daily_summary = _module.daily_summary
+
+
+def test_summary_sensor_attribute_contract_distinguishes_summary_sensors() -> None:
+    """Lock the public attribute contract of the three daily summary sensors."""
+    data_map: dict[str, dict[str, object]] = {
+        "type_grass": {
+            "source": "type",
+            "code": "GRASS",
+            "displayName": "Grass",
+            "value": 3,
+            "category": "Moderate",
+            "description": "Moderate pollen risk",
+        },
+        "type_tree": {
+            "source": "type",
+            "code": "TREE",
+            "displayName": "Tree",
+            "value": 1,
+            "category": "Very low",
+            "description": "Very low pollen risk",
+        },
+        "plants_grasses": {
+            "source": "plant",
+            "code": "GRAMINALES",
+            "displayName": "Grasses",
+            "inSeason": True,
+        },
+        "plants_birch": {
+            "source": "plant",
+            "code": "BIRCH",
+            "displayName": "Birch",
+            "inSeason": False,
+        },
+    }
+
+    summary = daily_summary(data_map)
+
+    overall = summary["overall_pollen_risk_today"]
+    top_types = summary["top_pollen_types_today"]
+    plants = summary["plants_in_season_today"]
+
+    # -- state sanity --------------------------------------------------------
+    assert type(overall["state"]) is int, "overall state must be strictly an int"
+    assert overall["state"] == 3
+
+    assert isinstance(top_types["state"], str), "top_types state must be textual"
+    assert top_types["state"] == "Grass"
+
+    assert type(plants["state"]) is int, "plants state must be strictly an int"
+    assert plants["state"] == 1
+
+    # -- top_pollen_codes contract ------------------------------------------
+    assert "top_pollen_codes" in overall
+    assert overall["top_pollen_codes"] == ["GRASS"]
+
+    assert "top_pollen_codes" in top_types
+    assert top_types["top_pollen_codes"] == ["GRASS"]
+
+    assert "top_pollen_codes" not in plants
+
+    # -- top_value contract --------------------------------------------------
+    assert "top_value" not in overall
+
+    assert "top_value" in top_types
+    assert top_types["top_value"] == 3
+
+    assert "top_value" not in plants
+
+    # -- plant_codes contract ------------------------------------------------
+    assert "plant_codes" not in overall
+    assert "plant_codes" not in top_types
+
+    assert "plant_codes" in plants
+    assert plants["plant_codes"] == ["GRAMINALES"]

--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -15,9 +15,8 @@ PKG_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pollenle
 SUMMARY_PATH = PKG_PATH / "summary.py"
 FORECAST_PATH = PKG_PATH / "forecast.py"
 
-_PKG_NAME = "custom_components.pollenlevels"
+_PKG_NAME = "_test_pollenlevels_summary_contract"
 _MODULE_NAMES = (
-    "custom_components",
     _PKG_NAME,
     f"{_PKG_NAME}.forecast",
     f"{_PKG_NAME}.summary",
@@ -30,19 +29,13 @@ DailySummaryCallable = Callable[
 
 def _load_summary_module() -> ModuleType:
     """Load summary.py with package context so relative imports resolve."""
-    # -- create stub packages in sys.modules so relative imports work --------
-    parent_name = "custom_components"
-    if parent_name not in sys.modules:
-        parent = ModuleType(parent_name)
-        parent.__path__ = [str(PKG_PATH.parent)]
-        parent.__package__ = parent_name
-        sys.modules[parent_name] = parent
+    for name in reversed(_MODULE_NAMES):
+        sys.modules.pop(name, None)
 
-    if _PKG_NAME not in sys.modules:
-        pkg = ModuleType(_PKG_NAME)
-        pkg.__path__ = [str(PKG_PATH)]
-        pkg.__package__ = _PKG_NAME
-        sys.modules[_PKG_NAME] = pkg
+    pkg = ModuleType(_PKG_NAME)
+    pkg.__path__ = [str(PKG_PATH)]
+    pkg.__package__ = _PKG_NAME
+    sys.modules[_PKG_NAME] = pkg
 
     # -- load forecast.py first (dependency of summary.py) ------------------
     forecast_spec = importlib.util.spec_from_file_location(

--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -66,8 +66,8 @@ def daily_summary_callable() -> Iterator[DailySummaryCallable]:
     missing = object()
     original_modules = {name: sys.modules.get(name, missing) for name in _MODULE_NAMES}
 
-    module = _load_summary_module()
     try:
+        module = _load_summary_module()
         yield module.daily_summary
     finally:
         for name, original_module in original_modules.items():

--- a/tests/test_summary_contract.py
+++ b/tests/test_summary_contract.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 PKG_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels"
 
@@ -13,6 +16,16 @@ SUMMARY_PATH = PKG_PATH / "summary.py"
 FORECAST_PATH = PKG_PATH / "forecast.py"
 
 _PKG_NAME = "custom_components.pollenlevels"
+_MODULE_NAMES = (
+    "custom_components",
+    _PKG_NAME,
+    f"{_PKG_NAME}.forecast",
+    f"{_PKG_NAME}.summary",
+)
+
+DailySummaryCallable = Callable[
+    [dict[str, dict[str, object]]], dict[str, dict[str, object]]
+]
 
 
 def _load_summary_module() -> ModuleType:
@@ -54,11 +67,26 @@ def _load_summary_module() -> ModuleType:
     return summary_module
 
 
-_module = _load_summary_module()
-daily_summary = _module.daily_summary
+@pytest.fixture
+def daily_summary_callable() -> Iterator[DailySummaryCallable]:
+    """Load daily_summary and restore pre-existing module state after the test."""
+    missing = object()
+    original_modules = {name: sys.modules.get(name, missing) for name in _MODULE_NAMES}
+
+    module = _load_summary_module()
+    try:
+        yield module.daily_summary
+    finally:
+        for name, original_module in original_modules.items():
+            if original_module is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
 
 
-def test_summary_sensor_attribute_contract_distinguishes_summary_sensors() -> None:
+def test_summary_sensor_attribute_contract_distinguishes_summary_sensors(
+    daily_summary_callable: DailySummaryCallable,
+) -> None:
     """Lock the public attribute contract of the three daily summary sensors."""
     data_map: dict[str, dict[str, object]] = {
         "type_grass": {
@@ -91,7 +119,7 @@ def test_summary_sensor_attribute_contract_distinguishes_summary_sensors() -> No
         },
     }
 
-    summary = daily_summary(data_map)
+    summary = daily_summary_callable(data_map)
 
     overall = summary["overall_pollen_risk_today"]
     top_types = summary["top_pollen_types_today"]
@@ -101,7 +129,7 @@ def test_summary_sensor_attribute_contract_distinguishes_summary_sensors() -> No
     assert type(overall["state"]) is int, "overall state must be strictly an int"
     assert overall["state"] == 3
 
-    assert isinstance(top_types["state"], str), "top_types state must be textual"
+    assert type(top_types["state"]) is str, "top_types state must be strictly a str"
     assert top_types["state"] == "Grass"
 
     assert type(plants["state"]) is int, "plants state must be strictly an int"


### PR DESCRIPTION
## Summary

Adds focused QA coverage for the v3 summary sensor contract.

This protects compatibility with external Lovelace cards that need to distinguish the numeric overall-risk sensor from textual summary sensors.

## Changes

- Add a dedicated contract test for the daily summary sensors:
  - `overall_pollen_risk_today`
  - `top_pollen_types_today`
  - `plants_in_season_today`
- Assert that `overall_pollen_risk_today` and `top_pollen_types_today` may both expose `top_pollen_codes`.
- Assert that only `top_pollen_types_today` exposes `top_value`.
- Assert that `plants_in_season_today` exposes `plant_codes` and does not expose `top_pollen_codes`.
- Assert numeric states with Ruff-compatible checks that still reject boolean values.
- Load summary helpers under an isolated test-only package namespace and clean it up after the test.

## Out of scope

- No runtime changes.
- No migration changes.
- No entity ID or unique ID changes.
- No translation changes.
- No release bump.
- No documentation changes.

## Tests

- `ruff check .`
- `black --check .`
- `pytest tests/test_summary_contract.py`
- `pytest tests/test_summary.py`