### PR TITLE
chore: sync meta files, relax tool version pins, bump to 3.0.0b4

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install formatters
         run: |
-          python -m pip install --upgrade "black==25.*" "ruff==0.14.*"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14"
 
       - name: Ruff --fix
         run: ruff check --fix .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install linters
         run: |
-          python -m pip install --upgrade "black==25.*" "ruff==0.14.*"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14"
 
       - name: Ruff (check only)
         run: ruff check .

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=9"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8,<9"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black==25.*" "ruff==0.14.*" "pytest>=8,<9"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8,<9"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8,<9"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black==25.*" "ruff==0.14.*" "pytest>=8,<9"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8,<9"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=8"
+          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=9"
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "pytest>=8,<9"
+          python -m pip install "pytest>=8"
           if [ -f requirements_test.txt ]; then
             python -m pip install -r requirements_test.txt
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "pytest>=8"
+          python -m pip install "pytest>=9"
           if [ -f requirements_test.txt ]; then
             python -m pip install -r requirements_test.txt
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Tooling
 - Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
-- Format code with Black (line length 88, target-version `py314`) pinned at `black==25.*`.
-- Lint and sort imports with Ruff targeting `py314`, pinned at `ruff==0.14.*`, matching the configuration in `pyproject.toml`.
+- Format code with Black (line length 88, target-version `py314`) with minimum `black>=25` (enforced via CI; version pin not stored in `pyproject.toml`).
+- Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.14` (enforced via CI), matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
 - Run `black .` (or the narrowest possible path) to ensure formatting.
 
@@ -53,3 +53,7 @@
 
 ## Verification
 - Ensure the integration still loads within Home Assistant with the existing config flows and maintains parity with the current logic paths for entity updates and notifications.
+- Before submitting changes, run the following checks:
+  - `ruff check --fix --select I && ruff check` — lint and import ordering.
+  - `black .` — code formatting.
+  - `pytest tests/` — unit tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.14` (enforced via CI), matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
 - Run `black .` (or the narrowest possible path) to ensure formatting.
+- Tests run with pytest>=9 on Python 3.14.
 
 ## Release & API boundaries
 - Do not change the integration version or changelog entries unless explicitly requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,7 @@
 - Do not add or rely on a `strings.json` file; translation updates should flow from `en.json` to the other language files.
 - Do not introduce `%key:` translation references in this custom repository.
 - Preserve the existing coordinator-driven architecture and avoid introducing blocking I/O in the event loop.
+- Before submitting changes, run:
+  - `ruff check --fix --select I && ruff check` — lint and import ordering.
+  - `black .` — code formatting.
+  - `pytest tests/` — unit tests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | --- | --- |
-| Latest 2.x release | Yes |
+| Latest 3.x release | Yes |
 | Older releases | No, unless explicitly stated |
 
 ## Reporting a Vulnerability

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0b3"
+    "version": "3.0.0b4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0b3"
+version = "3.0.0b4"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 
@@ -36,9 +36,6 @@ known-first-party = ["custom_components.pollenlevels"]
 combine-as-imports = true
 
 [tool.pytest.ini_options]
-# Use importlib mode to avoid test module name collisions in environments
-# where unrelated packages (or plugins) ship a top-level "tests" package.
-addopts = ["--import-mode=importlib"]
 testpaths = ["tests"]
 
 # --- Optional hardening (uncomment if needed) ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 # Tooling aligned to the Home Assistant Python floor (>=3.14.0).
-# NOTE: We purposely DO NOT set [tool.black].required-version; CI pins Black/Ruff
-# to the current minor series. If you ever need an exact lock, set both:
+# NOTE: We purposely DO NOT set [tool.black].required-version; CI installs
+# Black/Ruff from minimum supported versions to keep tooling forward-compatible.
+# If you ever need an exact lock, set both:
 #   - pyproject: required-version = "<desired black version>"
 #   - CI: pip install "black==<desired black version>" "ruff==<desired ruff version>"
 


### PR DESCRIPTION
## Summary

This PR synchronizes meta/configuration files across the repository and bumps the integration version to 3.0.0b4.

### Changes

#### 1. Relax tool version pins (Black `>=25`, Ruff `>=0.14`)
- **Affected files**: `.github/workflows/lint.yml`, `format.yml`, `package-test.yml`, `release.yml`, `AGENTS.md`
- **Before**: `black==25.*`, `ruff==0.14.*` (pinned to a specific minor series)
- **After**: `black>=25`, `ruff>=0.14` (minimum version floor)
- **Reason**: These versions were chosen solely because they were the first releases to support py314. Newer Black/Ruff releases that also support py314 should be auto-accepted rather than requiring manual pin bumps. CI catches any regressions on every push/PR.

#### 2. Expand verification instructions
- **Affected files**: `AGENTS.md` (Verification section), `CONTRIBUTING.md`
- **Added**: Concrete verification commands (`ruff check --fix --select I && ruff check`, `black .`, `pytest tests/`)
- **Reason**: The previous instructions were vague ("ensure the integration loads"). Contributors now have exact commands to run before submitting changes.

#### 3. Update SECURITY.md version scope
- **Affected file**: `SECURITY.md`
- **Changed**: Supported version from "Latest 2.x release" to "Latest 3.x release"
- **Reason**: The project is on v3 beta; the 2.x line is no longer the active development target.

#### 4. Remove pytest `--import-mode=importlib`
- **Affected file**: `pyproject.toml`
- **Removed**: `addopts = ["--import-mode=importlib"]`
- **Reason**: This was a preemptive guard against a hypothetical top-level `tests` package collision, which does not exist in the Home Assistant custom component ecosystem. The flag can interfere with pytest plugins and adds unnecessary configuration.

#### 5. Bump version to 3.0.0b4
- **Affected files**: `manifest.json`, `pyproject.toml`
- **Changed**: `3.0.0b3` → `3.0.0b4`
- **Reason**: Matches the latest release documented in `CHANGELOG.md`.

### Verification

```
ruff check --fix --select I && ruff check  # All checks passed
black --check .                              # 33 files unchanged
pytest tests/                                 # 458 passed, 0 failed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows and validation steps to use minimum-version constraints for tooling (Black, Ruff, pytest) for more flexible installs.

* **Documentation**
  * Enhanced contributor guidance and pre-submission checklist with explicit linting, formatting, and test commands.
  * Clarified tooling guidance and verification steps.

* **Version**
  * Bumped release to 3.0.0b4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->