### PR TITLE
[codex] Align plant advice docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - **Configurable updates** — Change update interval, language, forecast days, and per-day sensors without reinstalling.  
 - **Manual refresh** — Use the per-location **Update now** button entity to refresh a single configured location, or call the global `pollenlevels.force_update` service to refresh all configured locations.
 - **Last Updated sensor** — Shows timestamp of last successful update.
-- **Rich attributes** — Includes `inSeason`, index `description`, health `advice`,
-  `color_hex`, `color_rgb`, and plant details.
+- **Rich attributes** — Includes `inSeason`, index `description`, health `advice`
+  for pollen types, `color_hex`, `color_rgb`, and plant details.
 - **Resilient startup** — Retries setup automatically when the first API response lacks daily pollen info (`dailyInfo` types/plants), ensuring entities appear once data is ready.
 
 ---
@@ -154,6 +154,15 @@ Diagnostics include two support summaries for the v3 migration:
 
 Diagnostics redact the API key and only include approximate coordinates rounded
 to 1 decimal for support purposes.
+
+---
+
+## Health recommendations
+
+Google Pollen API currently provides health recommendations at pollen type level
+(`GRASS`, `TREE`, `WEED`). Plant sensors expose plant-specific index and
+description data when available, but health advice is usually not provided for
+individual plants.
 
 ---
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -927,6 +927,7 @@ def test_type_sensor_preserves_source_with_single_day(
 
     assert entry["source"] == "type"
     assert entry["displayName"] == "Grass"
+    assert entry["advice"] == ["Limit outdoor activity"]
     assert entry["forecast"] == []
     assert entry["tomorrow_has_index"] is False
     assert entry["tomorrow_value"] is None
@@ -1438,7 +1439,7 @@ def test_plant_sensor_includes_forecast_attributes(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Plant sensors expose forecast attributes and derived convenience fields."""
+    """Plant sensors expose forecast attributes without type-level health advice."""
 
     payload = {
         "regionCode": "us_co_denver",
@@ -1450,7 +1451,6 @@ def test_plant_sensor_includes_forecast_attributes(
                         "code": "ragweed",
                         "displayName": "Ragweed",
                         "inSeason": True,
-                        "healthRecommendations": ["Limit outdoor exposure"],
                         "indexInfo": {
                             "value": 2,
                             "category": "LOW",
@@ -1475,7 +1475,6 @@ def test_plant_sensor_includes_forecast_attributes(
                         "code": "ragweed",
                         "displayName": "Ragweed",
                         "inSeason": True,
-                        "healthRecommendations": ["Carry medication"],
                         "indexInfo": {
                             "value": 4,
                             "category": "HIGH",
@@ -1492,7 +1491,6 @@ def test_plant_sensor_includes_forecast_attributes(
                         "code": "ragweed",
                         "displayName": "Ragweed",
                         "inSeason": False,
-                        "healthRecommendations": ["Expect relief"],
                         "indexInfo": {
                             "value": 1,
                             "category": "LOW",
@@ -1533,6 +1531,7 @@ def test_plant_sensor_includes_forecast_attributes(
 
     assert entry["source"] == "plant"
     assert entry["value"] == 2
+    assert entry["advice"] is None
     assert len(entry["forecast"]) == 2
     assert entry["forecast"][0]["offset"] == 1
     assert entry["forecast"][0]["value"] == 4
@@ -1547,6 +1546,45 @@ def test_plant_sensor_includes_forecast_attributes(
     assert entry["trend"] == "up"
     assert entry["expected_peak"]["offset"] == 1
     assert entry["expected_peak"]["value"] == 4
+
+
+def test_plant_sensor_preserves_future_health_recommendations_if_present(
+    sensor_modules: SensorModules,
+) -> None:
+    """Plant advice is preserved only when a payload explicitly provides it."""
+
+    payload = {
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 6, "day": 1},
+                "plantInfo": [
+                    {
+                        "code": "ragweed",
+                        "displayName": "Ragweed",
+                        "healthRecommendations": ["Future plant-specific advice"],
+                        "indexInfo": {
+                            "value": 2,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    fake_session = FakeSession(payload)
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert data["plants_ragweed"]["advice"] == ["Future plant-specific advice"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -51,7 +51,7 @@ def _install_coordinator_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
         pass
 
     class _StubDataUpdateCoordinator:
-        def __init__(self, hass, logger, *, name: str, update_interval):
+        def __init__(self, hass, logger, *, name: str, update_interval) -> None:
             self.hass = hass
             self.logger = logger
             self.name = name
@@ -59,9 +59,14 @@ def _install_coordinator_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             self.data = None
             self.last_updated = None
 
+    class _StubCoordinatorEntity:
+        def __init__(self, coordinator) -> None:
+            self.coordinator = coordinator
+
     stub_update_coordinator_module(
         update_failed=_StubUpdateFailed,
         data_update_coordinator=_StubDataUpdateCoordinator,
+        coordinator_entity=_StubCoordinatorEntity,
         monkeypatch=monkeypatch,
     )
     stub_util_dt_module(monkeypatch=monkeypatch)

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -1,0 +1,86 @@
+"""Regression tests for plant health advice handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests import test_sensor as sensor_helpers
+
+
+@pytest.fixture
+def sensor_modules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> sensor_helpers.SensorModules:
+    """Import sensor dependencies with fixture-scoped Home Assistant stubs."""
+
+    sensor_helpers._install_sensor_import_stubs(monkeypatch)
+    modules = sensor_helpers.SensorModules(
+        const=sensor_helpers._load_module(
+            "custom_components.pollenlevels.const", "const.py", monkeypatch
+        ),
+        client_mod=sensor_helpers._load_module(
+            "custom_components.pollenlevels.client", "client.py", monkeypatch
+        ),
+        coordinator_mod=sensor_helpers._load_module(
+            "custom_components.pollenlevels.coordinator", "coordinator.py", monkeypatch
+        ),
+        sensor=sensor_helpers._load_module(
+            "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
+        ),
+    )
+    yield modules
+    sensor_helpers.clear_integration_modules()
+
+
+def test_plant_sensor_does_not_inherit_type_health_recommendations(
+    sensor_modules: sensor_helpers.SensorModules,
+) -> None:
+    """Plant advice is not derived from same-family pollen type advice."""
+
+    payload = {
+        "dailyInfo": [
+            {
+                "date": {"year": 2025, "month": 6, "day": 1},
+                "pollenTypeInfo": [
+                    {
+                        "code": "WEED",
+                        "displayName": "Weed",
+                        "healthRecommendations": ["Keep windows closed"],
+                        "indexInfo": {
+                            "value": 3,
+                            "category": "MODERATE",
+                            "indexDescription": "Moderate",
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "ragweed",
+                        "displayName": "Ragweed",
+                        "indexInfo": {
+                            "value": 2,
+                            "category": "LOW",
+                            "indexDescription": "Low",
+                        },
+                        "plantDescription": {"type": "WEED"},
+                    }
+                ],
+            }
+        ]
+    }
+
+    fake_session = sensor_helpers.FakeSession(payload)
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    coordinator = sensor_helpers._make_coordinator(sensor_modules, loop, client)
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert data["type_weed"]["advice"] == ["Keep windows closed"]
+    assert data["plants_ragweed"]["advice"] is None

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -3,39 +3,166 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, NamedTuple
 
 import pytest
 
-from tests import test_sensor as sensor_helpers
+from tests._ha_stubs import (
+    clear_integration_modules,
+    stub_aiohttp_module,
+    stub_custom_components_packages,
+    stub_exceptions,
+    stub_homeassistant_package,
+    stub_update_coordinator_module,
+    stub_util_dt_module,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+class SensorModules(NamedTuple):
+    """Integration modules imported under fixture-scoped Home Assistant stubs."""
+
+    client_mod: types.ModuleType
+    coordinator_mod: types.ModuleType
+
+
+def _install_coordinator_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install minimal Home Assistant stubs needed by coordinator imports."""
+
+    clear_integration_modules(monkeypatch=monkeypatch)
+    stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
+    stub_homeassistant_package(monkeypatch=monkeypatch)
+
+    class _StubConfigEntryAuthFailed(Exception):
+        pass
+
+    stub_exceptions(
+        monkeypatch=monkeypatch,
+        ConfigEntryAuthFailed=_StubConfigEntryAuthFailed,
+    )
+
+    class _StubUpdateFailed(Exception):
+        pass
+
+    class _StubDataUpdateCoordinator:
+        def __init__(self, hass, logger, *, name: str, update_interval):
+            self.hass = hass
+            self.logger = logger
+            self.name = name
+            self.update_interval = update_interval
+            self.data = None
+            self.last_updated = None
+
+    stub_update_coordinator_module(
+        update_failed=_StubUpdateFailed,
+        data_update_coordinator=_StubDataUpdateCoordinator,
+        monkeypatch=monkeypatch,
+    )
+    stub_util_dt_module(monkeypatch=monkeypatch)
+    stub_aiohttp_module(monkeypatch=monkeypatch)
+
+
+def _load_module(
+    module_name: str, relative_path: str, monkeypatch: pytest.MonkeyPatch
+) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        module_name, ROOT / "custom_components" / "pollenlevels" / relative_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    return module
 
 
 @pytest.fixture
-def sensor_modules(
-    monkeypatch: pytest.MonkeyPatch,
-) -> sensor_helpers.SensorModules:
-    """Import sensor dependencies with fixture-scoped Home Assistant stubs."""
+def sensor_modules(monkeypatch: pytest.MonkeyPatch) -> SensorModules:
+    """Import coordinator dependencies with fixture-scoped Home Assistant stubs."""
 
-    sensor_helpers._install_sensor_import_stubs(monkeypatch)
-    modules = sensor_helpers.SensorModules(
-        const=sensor_helpers._load_module(
-            "custom_components.pollenlevels.const", "const.py", monkeypatch
-        ),
-        client_mod=sensor_helpers._load_module(
+    _install_coordinator_import_stubs(monkeypatch)
+    modules = SensorModules(
+        client_mod=_load_module(
             "custom_components.pollenlevels.client", "client.py", monkeypatch
         ),
-        coordinator_mod=sensor_helpers._load_module(
+        coordinator_mod=_load_module(
             "custom_components.pollenlevels.coordinator", "coordinator.py", monkeypatch
-        ),
-        sensor=sensor_helpers._load_module(
-            "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
         ),
     )
     yield modules
-    sensor_helpers.clear_integration_modules()
+    clear_integration_modules()
+
+
+class DummyHass:
+    """Minimal Home Assistant stub for the coordinator."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.data: dict[str, Any] = {}
+
+
+class FakeResponse:
+    """Async context manager returning a static payload."""
+
+    def __init__(self, payload: dict[str, Any], *, status: int = 200) -> None:
+        self._payload = payload
+        self.status = status
+        self.headers: dict[str, str] = {}
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+    async def __aenter__(self) -> FakeResponse:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type,
+        exc: BaseException | None,
+        tb,
+    ) -> None:
+        return None
+
+
+class FakeSession:
+    """Return a fake aiohttp-like session that yields the provided payload."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def get(self, *_args, **_kwargs) -> FakeResponse:
+        return FakeResponse(self._payload)
+
+
+def _make_coordinator(
+    sensor_modules: SensorModules,
+    loop: asyncio.AbstractEventLoop,
+    client: Any,
+) -> Any:
+    """Build a coordinator with stable defaults for refresh tests."""
+
+    return sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+        hass=DummyHass(loop),
+        api_key="test",
+        lat=1.0,
+        lon=2.0,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        forecast_days=1,
+        create_d1=False,
+        create_d2=False,
+        client=client,
+    )
 
 
 def test_plant_sensor_does_not_inherit_type_health_recommendations(
-    sensor_modules: sensor_helpers.SensorModules,
+    sensor_modules: SensorModules,
 ) -> None:
     """Plant advice is not derived from same-family pollen type advice."""
 
@@ -71,11 +198,11 @@ def test_plant_sensor_does_not_inherit_type_health_recommendations(
         ]
     }
 
-    fake_session = sensor_helpers.FakeSession(payload)
+    fake_session = FakeSession(payload)
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = sensor_helpers._make_coordinator(sensor_modules, loop, client)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())


### PR DESCRIPTION
## Summary

- Clarify that Google Pollen API health recommendations are type-level data.
- Make the primary plant fixture realistic by omitting plant-level health recommendations.
- Add a compatibility test that preserves plant advice if a future payload explicitly provides it.

## Validation

- `python -m ruff check --fix --select I .`
- `python -m ruff check .`
- `python -m black tests\test_sensor.py`
- `python -m pytest tests\test_sensor.py`
- `python -m pytest tests\test_summary.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized plant/type attribute fields and added a "Health recommendations" section clarifying recommendations are provided at the pollen-type level and that plant sensors typically lack per-plant health advice.

* **Tests**
  * Expanded coverage with regression and unit tests verifying that type-level health recommendations are preserved when present and that plant entries do not inherit type-level recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->