### PR TITLE
[codex] Prepare beta 4 fixed forecast cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,6 +69,13 @@ reviews:
     - "!**/*.egg-info/**"
 
   path_instructions:
+    - path: "**/*.py"
+      instructions: |
+        This repository targets Python 3.14+ and CI formats with Black using
+        target-version py314. Black 26+ may format multi-exception handlers as
+        `except A, B:`. Treat that syntax as valid for this repository; do not
+        flag it as a SyntaxError or request `except (A, B):` unless CI fails.
+
     - path: "custom_components/pollenlevels/**/*.py"
       instructions: |
         Review as a Home Assistant custom integration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Tooling
 - Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
 - Format code with Black (line length 88, target-version `py314`) with minimum `black>=25` (enforced via CI; version pin not stored in `pyproject.toml`).
+- Black 26+ may format multi-exception handlers as `except A, B:` for Python 3.14; keep the formatter output unless CI changes.
 - Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.14` (enforced via CI), matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
 - Run `black .` (or the narrowest possible path) to ensure formatting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
-## [3.0.0b4] - 2026-06-09
+## [3.0.0rc1] - 2026-06-11
+
+### Changed
+
+- Forecast days are now fixed at 5 for all entries and locations, so all users
+  get the maximum forecast horizon supported by the Google Maps Pollen API.
+- Removed the configuration options for forecast days and separate per-day TYPE
+  forecast sensors from setup and options flows.
+- **Breaking change:** Removed optional per-day pollen TYPE forecast sensors
+  ending in `_d1` and `_d2`. Forecast data remains available through attributes
+  on the base pollen type, plant, and summary sensors, including `forecast`,
+  `tomorrow_*`, `d2_*`, `trend`, and `expected_peak`.
+- Existing entries with stored `forecast_days` or `create_forecast_sensors`
+  options are upgraded automatically. Legacy `_d1` and `_d2` entity registry
+  entries owned by Pollen Levels are removed during setup/reload.
 
 ### Fixed
 
 - Added a Home Assistant Repair issue when stored Pollen Levels location
   data is invalid, so users get visible guidance to delete/recreate the
   affected location or restore a backup.
+- Added a Home Assistant Repair warning when legacy per-day forecast sensors or
+  options are detected, so users know to update dashboards, automations,
+  templates, and custom cards that still reference `_d1` or `_d2` entities.
 
 ## [3.0.0b3] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.0.0rc1] - 2026-06-11
+## [3.0.0b4] - 2026-06-11
 
 ### Changed
 
@@ -10,6 +10,9 @@
   ending in `_d1` and `_d2`. Forecast data remains available through attributes
   on the base pollen type, plant, and summary sensors, including `forecast`,
   `tomorrow_*`, `d2_*`, `trend`, and `expected_peak`.
+- This beta intentionally brings the `_d1` and `_d2` cleanup forward so the
+  fixed 5-day forecast model, legacy entity cleanup, and Repair warning can be
+  tested together before the release candidate.
 - Existing entries with stored `forecast_days` or `create_forecast_sensors`
   options are upgraded automatically. Legacy `_d1` and `_d2` entity registry
   entries owned by Pollen Levels are removed during setup/reload.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,7 +1,11 @@
 # ❓ Frequently Asked Questions (FAQ)
+
 *Last verified: 2026-06-12 (UTC). Pricing and quota limits may change; always confirm the current values in the official Google Maps Platform pages linked below.*
 
 ## 1. How many requests can I make to the Google Maps Pollen API?
+
+Pricing/free usage cap last checked: **2026-06-13 (UTC)**.
+
 Google's current Pollen API documentation describes pay-as-you-go pricing per
 request, based on usage volume tiers. The current global Google Maps Platform
 pricing list shows **Pollen Usage** with a **Free Usage Cap of 5,000 monthly
@@ -23,6 +27,7 @@ method; that is a service rate limit, not the monthly free usage cap.
 ---
 
 ## 2. Does this integration consume a lot of API calls?
+
 No. By default the integration fetches every **6 hours** (~**4 requests/day**),
 which is roughly **~120 requests/month per location**. That is well below the
 current **5,000 monthly billable events** Free Usage Cap shown for the
@@ -33,6 +38,7 @@ billing credits on your account.
 ---
 
 ## 3. Can I manually refresh the data?
+
 Yes. You can use either method:
 - Press the per-location **Update now** button entity created by the integration to refresh one configured location.
 - Call the `pollenlevels.force_update` service from **Developer Tools → Services** to refresh all configured locations.
@@ -41,6 +47,7 @@ Both methods request an immediate coordinator refresh. The normal scheduled poll
 ---
 
 ## 4. Why am I getting “Invalid API Key” or “Quota Exceeded” errors?
+
 - **Invalid API Key**: Confirm the key is correct and that the **Pollen API** is enabled in your project.  
 - **Quota Exceeded**: You may have hit **your custom daily/minute caps** (see §10) or another Google Cloud quota/billing limit on the project.
   **Check/adjust quotas**: https://console.cloud.google.com/google/maps-apis/quotas  
@@ -51,18 +58,21 @@ Both methods request an immediate coordinator refresh. The normal scheduled poll
 ---
 
 ## 5. How is the pollen data obtained?
+
 Data is sourced from the **Google Maps Pollen API**, which provides localized pollen levels for **trees, grasses, and weeds**, plus plant-level details and up to **5-day forecasts**.  
 Docs: https://developers.google.com/maps/documentation/pollen/overview
 
 ---
 
 ## 6. Can I request pollen data in my language?
+
 Yes. Set a **language code** in the integration options (e.g., `en`, `es`, `fr`, `de`, `uk`).  
 This controls localized fields returned by the API.
 
 ---
 
 ## 7. How can I reduce API usage?
+
 - Increase the update interval (e.g., every 12 or 24 hours).
 - Avoid excessive manual refreshes.
 - **Set daily/minute quota caps** (see §10).
@@ -71,16 +81,19 @@ This controls localized fields returned by the API.
 ---
 
 ## 8. Will this work without internet?
+
 No. The integration requires internet access to reach the Google Maps Pollen API.
 
 ---
 
 ## 9. Does the integration store my API key?
+
 The API key is stored securely by Home Assistant and is **never shared** with third parties.
 
 ---
 
 ## 10. Which QUOTAS should I cap in Google Cloud Console?
+
 Open **Google Cloud Console → Google Maps Platform → Quotas** and select **Pollen API**.  
 Direct link: https://console.cloud.google.com/google/maps-apis/quotas
 
@@ -120,12 +133,14 @@ Reference guide: https://cloud.google.com/apis/docs/capping-api-usage
 ---
 
 ## 11. Are there rate limits?
+
 Yes. The **default rate limit is 6,000 queries per minute (QPM)** for the Pollen API.  
 FAQ: https://developers.google.com/maps/documentation/pollen/faq
 
 ---
 
 ## 12. What happens to my entries when upgrading to the v3 pre-release?
+
 The v3 pre-release migrates Pollen Levels to Home Assistant config subentries.
 Legacy 2.x entries that share the same Google API key are grouped under one
 parent API-key entry, and each migrated location becomes one location subentry.
@@ -201,6 +216,7 @@ entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.
 ---
 
 ## References (official)
+
 - **Core services pricing list (Environment → Pollen Usage)** — last updated shown on page: https://developers.google.com/maps/billing-and-pricing/pricing  
 - **Pollen API usage & billing (quota editing steps)**: https://developers.google.com/maps/documentation/pollen/usage-and-billing  
 - **Pollen API — Forecast endpoint**: https://developers.google.com/maps/documentation/pollen/forecast  

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,14 +3,15 @@
 
 ## 1. How many requests can I make to the Google Maps Pollen API?
 Google's current Pollen API documentation describes pay-as-you-go pricing per
-request, based on usage volume tiers. The old Google Maps Platform monthly
-credit ended on **February 28, 2025**, so you should treat Pollen API usage as
-billable unless your own Google Cloud billing account, credits or contract say
-otherwise.
+request, based on usage volume tiers. The current global Google Maps Platform
+pricing list shows **Pollen Usage** with a **Free Usage Cap of 5,000 monthly
+billable events**, followed by paid per-1,000-event tiers.
 
-Use Google Cloud quotas, budgets and alerts to control spend. The Pollen API
-currently documents a maximum **6,000 queries per minute (QPM)** limit for each
-API method, but that is a service limit, not an included usage allowance.
+The old separate Google Maps Platform monthly credit ended on
+**February 28, 2025**. Use the Pollen SKU's current Free Usage Cap, plus Google
+Cloud quotas, budgets and alerts, to control spend. The Pollen API also
+documents a maximum **6,000 queries per minute (QPM)** limit for each API
+method; that is a service rate limit, not the monthly free usage cap.
 
 **Pricing list (official):** https://developers.google.com/maps/billing-and-pricing/pricing
 **Pollen usage & billing page:** https://developers.google.com/maps/documentation/pollen/usage-and-billing
@@ -23,9 +24,11 @@ API method, but that is a service limit, not an included usage allowance.
 
 ## 2. Does this integration consume a lot of API calls?
 No. By default the integration fetches every **6 hours** (~**4 requests/day**),
-which is roughly **~120 requests/month per location**. Your actual cost depends
-on Google's current Pollen API pricing, your configured locations, manual
-refreshes, quota settings and any billing credits on your account.
+which is roughly **~120 requests/month per location**. That is well below the
+current **5,000 monthly billable events** Free Usage Cap shown for the
+**Pollen Usage** SKU. Your actual cost depends on Google's current Pollen API
+pricing, your configured locations, manual refreshes, quota settings and any
+billing credits on your account.
 
 ---
 
@@ -96,12 +99,14 @@ Typical quota items you’ll see (names may vary slightly by locale):
 
 **Recommended hard caps (safe defaults):**
 > **Caution:** Quota caps are a useful safety guard, but Google notes they may
-> not be enforced with absolute precision due to latency. Keep conservative
-> limits and monitor billing instead of relying on a cap as your only guardrail.
+> not be enforced with absolute precision due to latency. Keep a buffer below
+> the monthly Free Usage Cap and monitor billing instead of relying on a cap as
+> your only guardrail.
 
-- **Forecast Usage per day** → choose a cap that matches your budget and number
-  of locations. For example, one location at the default 6-hour interval uses
-  about 4 forecast requests/day before manual refreshes.
+- **Forecast Usage per day** → **150**
+  (about 4,500/month, leaving a buffer below the current 5,000 monthly Free
+  Usage Cap; increase only if you have multiple locations or frequent manual
+  refreshes and accept the possible cost).
 - **Forecast Usage per minute** → **10**
 - **Forecast Usage per minute per user** → **10**
 - **HeatMap quotas** → **0** (or minimum allowed) to disable tiles.

--- a/FAQ.md
+++ b/FAQ.md
@@ -154,6 +154,7 @@ Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
 ---
 
 ## 13. Can I choose how many forecast days Pollen Levels requests?
+
 No. Starting with v3 RC1, Pollen Levels always requests 5 forecast days. This
 keeps the integration simpler and gives all existing sensors the maximum
 available forecast attributes.
@@ -164,6 +165,7 @@ No base sensors are renamed or recreated.
 ---
 
 ## 14. Where did my `_d1` and `_d2` forecast sensors go?
+
 Pollen Levels no longer creates separate per-day forecast entities. Future
 forecast data is available on the base pollen sensors through the `forecast`,
 `tomorrow_*` and `d2_*` attributes.

--- a/FAQ.md
+++ b/FAQ.md
@@ -168,7 +168,7 @@ No base sensors are renamed or recreated.
 
 Pollen Levels no longer creates separate per-day forecast entities. Future
 forecast data is available on the base pollen sensors through the `forecast`,
-`tomorrow_*` and `d2_*` attributes.
+`tomorrow_*`, `d2_*`, `trend`, and `expected_peak` attributes.
 
 Update any dashboards, automations, templates or custom cards that reference
 entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.

--- a/FAQ.md
+++ b/FAQ.md
@@ -143,10 +143,10 @@ During parent API-key reauthentication or reconfiguration, the integration tries
 configured locations until one validates successfully. Authentication and quota
 errors are treated as API-key-level failures.
 
-During startup, the parent entry can still load when one location has a
-non-auth failure as long as another configured location loads successfully. A
-skipped location may need a manual reload of the parent entry after the
-underlying problem is fixed.
+During startup, if any configured location cannot complete its initial refresh,
+the parent entry is marked not ready and Home Assistant will retry setup. Fix
+the underlying location or API issue, then reload or retry the Pollen Levels
+entry.
 
 Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
 2.x after this migration is not supported.
@@ -169,6 +169,9 @@ No base sensors are renamed or recreated.
 Pollen Levels no longer creates separate per-day forecast entities. Future
 forecast data is available on the base pollen sensors through the `forecast`,
 `tomorrow_*`, `d2_*`, `trend`, and `expected_peak` attributes.
+
+If the integration detects legacy per-day forecast entities or settings during
+upgrade, it also creates a persistent Repair warning in Home Assistant.
 
 Update any dashboards, automations, templates or custom cards that reference
 entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,10 +1,18 @@
 # ❓ Frequently Asked Questions (FAQ)
-*Last verified: 2026-05-18 (UTC). Pricing and quota limits may change; always confirm the current values in the official Google Maps Platform pages linked below.*
+*Last verified: 2026-06-12 (UTC). Pricing and quota limits may change; always confirm the current values in the official Google Maps Platform pages linked below.*
 
 ## 1. How many requests can I make to the Google Maps Pollen API?
-As of **March 1, 2025**, Google Maps Platform applies **free monthly usage caps per SKU**.  
-For the **Pollen API (SKU: “Pollen Usage”, Pro)** the **free cap is 5,000 requests/month**. Beyond the free cap, usage is billed pay-as-you-go per 1,000 requests.  
-**Pricing list (official):** https://developers.google.com/maps/billing-and-pricing/pricing  
+Google's current Pollen API documentation describes pay-as-you-go pricing per
+request, based on usage volume tiers. The old Google Maps Platform monthly
+credit ended on **February 28, 2025**, so you should treat Pollen API usage as
+billable unless your own Google Cloud billing account, credits or contract say
+otherwise.
+
+Use Google Cloud quotas, budgets and alerts to control spend. The Pollen API
+currently documents a maximum **6,000 queries per minute (QPM)** limit for each
+API method, but that is a service limit, not an included usage allowance.
+
+**Pricing list (official):** https://developers.google.com/maps/billing-and-pricing/pricing
 **Pollen usage & billing page:** https://developers.google.com/maps/documentation/pollen/usage-and-billing
 
 **Quick links**
@@ -14,7 +22,10 @@ For the **Pollen API (SKU: “Pollen Usage”, Pro)** the **free cap is 5,000 re
 ---
 
 ## 2. Does this integration consume a lot of API calls?
-No. By default the integration fetches every **6 hours** (~**4 requests/day**), which is roughly **~120 requests/month per location**, well below the free cap.
+No. By default the integration fetches every **6 hours** (~**4 requests/day**),
+which is roughly **~120 requests/month per location**. Your actual cost depends
+on Google's current Pollen API pricing, your configured locations, manual
+refreshes, quota settings and any billing credits on your account.
 
 ---
 
@@ -28,7 +39,7 @@ Both methods request an immediate coordinator refresh. The normal scheduled poll
 
 ## 4. Why am I getting “Invalid API Key” or “Quota Exceeded” errors?
 - **Invalid API Key**: Confirm the key is correct and that the **Pollen API** is enabled in your project.  
-- **Quota Exceeded**: You may have hit **your custom daily/minute caps** (see §10) or the **monthly free cap**.  
+- **Quota Exceeded**: You may have hit **your custom daily/minute caps** (see §10) or another Google Cloud quota/billing limit on the project.
   **Check/adjust quotas**: https://console.cloud.google.com/google/maps-apis/quotas  
 
 > **Note:** **Budgets/alerts don’t stop usage**; they only notify.  
@@ -51,8 +62,8 @@ This controls localized fields returned by the API.
 ## 7. How can I reduce API usage?
 - Increase the update interval (e.g., every 12 or 24 hours).
 - Avoid excessive manual refreshes.
-- **Set daily/minute caps** (see §10).
-- Monitor usage and set alerts in Google Cloud.
+- **Set daily/minute quota caps** (see §10).
+- Monitor usage and set Google Cloud budgets/alerts for the billing account.
 
 ---
 
@@ -66,7 +77,7 @@ The API key is stored securely by Home Assistant and is **never shared** with th
 
 ---
 
-## 10. Which QUOTAS should I cap in Google Cloud Console (to stay within the free tier)?
+## 10. Which QUOTAS should I cap in Google Cloud Console?
 Open **Google Cloud Console → Google Maps Platform → Quotas** and select **Pollen API**.  
 Direct link: https://console.cloud.google.com/google/maps-apis/quotas
 
@@ -84,10 +95,13 @@ Typical quota items you’ll see (names may vary slightly by locale):
 > **Safe setting:** You can set **HeatMap** quotas to **0** (or the minimum allowed) to block tile usage and avoid accidental billing.
 
 **Recommended hard caps (safe defaults):**
-> **Caution:** Quota caps are a useful safety guard, but Google notes they may not be enforced with absolute precision due to latency. Keep a buffer below the free cap instead of setting limits right at the monthly maximum.
+> **Caution:** Quota caps are a useful safety guard, but Google notes they may
+> not be enforced with absolute precision due to latency. Keep conservative
+> limits and monitor billing instead of relying on a cap as your only guardrail.
 
-- **Forecast Usage per day** → **150**  
-  (≈ 4,500/month, comfortably under the 5,000 free cap; increase only if you have multiple locations or frequent manual refreshes)
+- **Forecast Usage per day** → choose a cap that matches your budget and number
+  of locations. For example, one location at the default 6-hour interval uses
+  about 4 forecast requests/day before manual refreshes.
 - **Forecast Usage per minute** → **10**
 - **Forecast Usage per minute per user** → **10**
 - **HeatMap quotas** → **0** (or minimum allowed) to disable tiles.

--- a/FAQ.md
+++ b/FAQ.md
@@ -122,7 +122,7 @@ Migrated location subentries keep the legacy entry ID internally so existing
 entity unique IDs, device identifiers, dashboards, history, and automations
 continue to match after the entries are consolidated.
 
-If grouped legacy entries used different update, language, or forecast options,
+If grouped legacy entries used different update interval or language options,
 the parent keeps the first entry's options and fills missing values from the
 remaining entries. You can adjust the shared options after upgrading.
 
@@ -150,6 +150,26 @@ underlying problem is fixed.
 
 Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
 2.x after this migration is not supported.
+
+---
+
+## 13. Can I choose how many forecast days Pollen Levels requests?
+No. Starting with v3 RC1, Pollen Levels always requests 5 forecast days. This
+keeps the integration simpler and gives all existing sensors the maximum
+available forecast attributes.
+
+Existing users who previously selected fewer days are upgraded automatically.
+No base sensors are renamed or recreated.
+
+---
+
+## 14. Where did my `_d1` and `_d2` forecast sensors go?
+Pollen Levels no longer creates separate per-day forecast entities. Future
+forecast data is available on the base pollen sensors through the `forecast`,
+`tomorrow_*` and `d2_*` attributes.
+
+Update any dashboards, automations, templates or custom cards that reference
+entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.
 
 ---
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -155,7 +155,7 @@ Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
 
 ## 13. Can I choose how many forecast days Pollen Levels requests?
 
-No. Starting with v3 RC1, Pollen Levels always requests 5 forecast days. This
+No. Starting with v3 beta 4, Pollen Levels always requests 5 forecast days. This
 keeps the integration simpler and gives all existing sensors the maximum
 available forecast attributes.
 
@@ -172,6 +172,9 @@ forecast data is available on the base pollen sensors through the `forecast`,
 
 If the integration detects legacy per-day forecast entities or settings during
 upgrade, it also creates a persistent Repair warning in Home Assistant.
+
+This cleanup has been brought forward in v3 beta 4 so the migration can be
+tested before the release candidate.
 
 Update any dashboards, automations, templates or custom cards that reference
 entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - **Multi-language support** — UI in 21 languages (**EN, ES, CA, DE, FR, IT, PL, RU, UK, NL, ZH-Hans, SV, CS, PT-BR, DA, NB, PT-PT, RO, FI, HU, ZH-Hant**) + API responses in any language.
 - **Dynamic sensors** — Auto-creates sensors for all pollen types found in your location.  
 - **Daily summary sensors** — Adds plants in season today, overall pollen risk today, and top pollen types today.
-- **Multi-day forecast for TYPES & PLANTS** —
+- **Five-day forecast for TYPES, PLANTS, and summary sensors** —
+  Pollen Levels always requests the maximum 5-day forecast horizon supported by
+  the Google Maps Pollen API.
   - `forecast` list with `{offset, date, has_index, value, category, description, color_*}`
   - Convenience: `tomorrow_*` and `d2_*`
   - Derived: `trend` and `expected_peak`
-  - **Per-day sensors:** remain **TYPES-only** with selector options `none`, `D+1`,
-    or `D+1+2` (creates both `(D+1)` and `(D+2)` sensors).
-    **PLANTS** expose forecast **as attributes only** (no extra entities).
+  - **PLANTS** expose forecast as attributes only (no extra entities).
 - **Smart grouping** — Organizes sensors into:
   - **Pollen Types** (Grass / Tree / Weed)
   - **Plants** (Oak, Pine, Birch, etc.)
   - **Pollen Info** (Region / Date metadata)  
-- **Configurable updates** — Change update interval, language, forecast days, and per-day sensors without reinstalling.  
+- **Configurable updates** — Change update interval and API response language without reinstalling.
 - **Manual refresh** — Use the per-location **Update now** button entity to refresh a single configured location, or call the global `pollenlevels.force_update` service to refresh all configured locations.
 - **Last Updated sensor** — Shows timestamp of last successful update.
 - **Rich attributes** — Includes `inSeason`, index `description`, health `advice`
@@ -72,23 +72,58 @@ You can change:
 
 - **Update interval (hours)** (1–24)
 - **API response language code**
-- **Forecast days** (`1–5`) for pollen TYPES
-- **Per-day TYPE sensors** via `create_forecast_sensors`:
-  - `none` → no extra sensors
-  - `D+1` → sensors for each TYPE with suffix `(D+1)`
-  - `D+1+2` → sensors for `(D+1)` and `(D+2)`
-
-> **Validation rules:**
-> - `D+1` requires `forecast_days ≥ 2`
-> - `D+1+2` requires `forecast_days ≥ 3`
 
 The config and options flows use modern Home Assistant selectors and include
 links to Google’s API key setup and security best practices so you can follow
 the recommended restrictions.
 
-> **After saving Options:** if per-day sensors are disabled or `forecast_days` becomes insufficient, the integration **removes** any stale D+1/D+2 entities from the **Entity Registry** automatically. No manual cleanup needed.
+Forecast days are no longer configurable. Pollen Levels always requests 5 days
+of forecast data so existing sensors can expose the maximum available forecast
+attributes.
 
 Go to **Settings → Devices & Services → Pollen Levels → Configure**.
+
+---
+
+## Migrating from per-day forecast sensors
+
+Pollen Levels no longer creates separate per-day pollen type forecast sensors
+such as:
+
+```text
+sensor.example_grass_d1
+sensor.example_grass_d2
+```
+
+Forecast data is now exposed on the base pollen type sensor through attributes.
+Existing legacy `_d1` and `_d2` entity registry entries owned by Pollen Levels
+are removed automatically during setup/reload. Recorder history is not purged.
+
+Before:
+
+```jinja
+{{ states("sensor.example_grass_d1") }}
+{{ states("sensor.example_grass_d2") }}
+```
+
+After:
+
+```jinja
+{{ state_attr("sensor.example_grass", "tomorrow_value") }}
+{{ state_attr("sensor.example_grass", "d2_value") }}
+```
+
+For advanced templates, use the `forecast` attribute and select the desired
+offset:
+
+```jinja
+{% set forecast = state_attr("sensor.example_grass", "forecast") or [] %}
+{% set tomorrow = forecast | selectattr("offset", "eq", 1) | first %}
+{{ tomorrow.value if tomorrow else none }}
+```
+
+With the fixed 5-day horizon, the base sensor can expose future forecast items
+with offsets `1` to `4`, depending on the data returned by the API.
 
 ---
 
@@ -110,7 +145,7 @@ migration:
   entity unique IDs, devices, dashboards, history, and automations continue to
   match.
 
-If legacy entries sharing a key used different update, language, or forecast
+If legacy entries sharing a key used different update interval or language
 options, the parent entry keeps the first entry's options and fills missing
 values from the remaining entries. You can adjust the shared options after
 upgrading from **Settings -> Devices & Services -> Pollen Levels -> Configure**.
@@ -119,8 +154,8 @@ To add another location after upgrading, go to **Settings -> Devices & Services
 -> Pollen Levels**, open the parent entry, and add a new location subentry.
 Reconfigure a location from that same entry when only its name or map
 coordinates need to change. Each location has its own sensors and **Update now**
-button; shared options such as update interval, language, and forecast settings
-stay on the parent **Configure** flow.
+button; shared options such as update interval and language stay on the parent
+**Configure** flow.
 
 When reauthenticating or reconfiguring the parent API key, the integration tries
 the configured locations until one returns usable pollen data. Authentication
@@ -270,6 +305,8 @@ severity:
 
 If you want a dedicated pollen Lovelace card with forecast visualizations and a visual editor UI,
 **pollenprognos-card** supports this integration since **v2.9.0**.
+The base sensor `forecast`, `tomorrow_*`, `d2_*`, `trend`, and `expected_peak`
+attributes keep their existing format for card compatibility.
 
 - Repo: [pollenprognos-card](https://github.com/krissen/pollenprognos-card)
 - Install: HACS → Frontend
@@ -345,7 +382,7 @@ color: '[[[
 ## 🌐 Example API request
 
 ```bash
-curl -X GET "https://pollen.googleapis.com/v1/forecast:lookup?key=YOUR_KEY&location.latitude=48.8566&location.longitude=2.3522&days=2&languageCode=es"
+curl -X GET "https://pollen.googleapis.com/v1/forecast:lookup?key=YOUR_KEY&location.latitude=48.8566&location.longitude=2.3522&days=5&languageCode=es"
 ```
 
 > **Note:** Replace `YOUR_KEY` locally and never share full API URLs containing `key=...` publicly.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ You need a valid Google Cloud API key with access to the **Maps Pollen API**.
 The setup form also links directly to the Google documentation for obtaining
 an API key and best-practice restrictions.
 
-👉 See the **[FAQ](FAQ.md)** for **quota tips**, rate-limit behavior, and best practices to avoid exhausting your free tier.
+👉 See the **[FAQ](FAQ.md)** for **quota tips**, rate-limit behavior, and best practices to monitor and control Google Cloud billing.
 
 HTTP referrer (website) restrictions are intended for browser-based apps and
 are not supported by this integration.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ sensor.example_grass_d2
 Forecast data is now exposed on the base pollen type sensor through attributes.
 Existing legacy `_d1` and `_d2` entity registry entries owned by Pollen Levels
 are removed automatically during setup/reload. Recorder history is not purged.
+This beta brings that cleanup forward so the migration can be tested with the
+fixed 5-day forecast model before the release candidate.
 
 Before:
 

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -386,7 +386,7 @@ async def async_setup_entry(
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except ConfigEntryAuthFailed, ConfigEntryNotReady:
+    except (ConfigEntryAuthFailed, ConfigEntryNotReady):
         entry.runtime_data = None
         raise
     except Exception as err:

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -20,26 +20,24 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .client import GooglePollenApiClient
 from .const import (
     CONF_API_KEY,
-    CONF_CREATE_FORECAST_SENSORS,
-    CONF_FORECAST_DAYS,
+    CONF_CREATE_FORECAST_SENSORS as CONF_CREATE_FORECAST_SENSORS,
+    CONF_FORECAST_DAYS as CONF_FORECAST_DAYS,
     CONF_LANGUAGE_CODE,
     CONF_LATITUDE,
     CONF_LEGACY_ENTRY_ID,
     CONF_LONGITUDE,
     CONF_UPDATE_INTERVAL,
     DEFAULT_ENTRY_TITLE,
-    DEFAULT_FORECAST_DAYS,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
-    MAX_FORECAST_DAYS,
     MAX_UPDATE_INTERVAL_HOURS,
-    MIN_FORECAST_DAYS,
     MIN_UPDATE_INTERVAL_HOURS,
     SUBENTRY_TYPE_LOCATION,
 )
 from .coordinator import PollenDataUpdateCoordinator
 from .issue_helpers import (
     create_invalid_stored_location_issue,
+    create_per_day_forecast_sensors_removed_issue,
     delete_entry_invalid_stored_location_issue,
     invalid_stored_location_issue_id as invalid_stored_location_issue_id,
 )
@@ -53,13 +51,13 @@ from .runtime import (
     PollenLevelsRuntimeData,
     PollenLocationRuntime,
 )
-from .sensor import ForecastSensorMode
 from .util import (
     api_key_unique_id as api_key_unique_id,
-    normalize_sensor_mode,
+    has_legacy_per_day_option,
     redact_sensitive_values,
     safe_parse_int,
     stale_runtime_location_filter,
+    strip_legacy_forecast_options,
     validate_location_pair,
 )
 
@@ -70,6 +68,25 @@ _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 6
 _FORCE_UPDATE_CONCURRENCY_LIMIT = 1
 PLATFORMS = ["sensor", "button"]
+
+
+def _drop_legacy_parent_options(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Remove obsolete parent data/options from earlier v3 prereleases."""
+    data = dict(entry.data or {})
+    options = dict(entry.options or {})
+    found_per_day_option = has_legacy_per_day_option(data, options)
+    cleaned_data = strip_legacy_forecast_options(data)
+    cleaned = strip_legacy_forecast_options(options)
+    updates: dict[str, Any] = {}
+    if cleaned_data != data:
+        updates["data"] = cleaned_data
+    if cleaned != options:
+        updates["options"] = cleaned
+    if not updates:
+        return found_per_day_option
+
+    hass.config_entries.async_update_entry(entry, **updates)
+    return found_per_day_option
 
 
 def _iter_location_subentries(
@@ -247,6 +264,10 @@ async def async_setup_entry(
         )
         return True
 
+    legacy_per_day_option_detected = _drop_legacy_parent_options(hass, entry)
+    if legacy_per_day_option_detected:
+        create_per_day_forecast_sensors_removed_issue(hass)
+
     options = entry.options or {}
 
     parsed_hours = safe_parse_int(
@@ -257,32 +278,7 @@ async def async_setup_entry(
     )
     hours = parsed_hours if parsed_hours is not None else DEFAULT_UPDATE_INTERVAL
     hours = max(MIN_UPDATE_INTERVAL_HOURS, min(MAX_UPDATE_INTERVAL_HOURS, hours))
-    parsed_forecast_days = safe_parse_int(
-        options.get(
-            CONF_FORECAST_DAYS,
-            entry.data.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS),
-        )
-    )
-    forecast_days = (
-        parsed_forecast_days
-        if parsed_forecast_days is not None
-        else DEFAULT_FORECAST_DAYS
-    )
-    forecast_days = max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, forecast_days))
     language = options.get(CONF_LANGUAGE_CODE, entry.data.get(CONF_LANGUAGE_CODE))
-    raw_mode = options.get(
-        CONF_CREATE_FORECAST_SENSORS,
-        entry.data.get(CONF_CREATE_FORECAST_SENSORS, ForecastSensorMode.NONE),
-    )
-    normalized_mode = normalize_sensor_mode(raw_mode, _LOGGER)
-    try:
-        mode = ForecastSensorMode(normalized_mode)
-    except ValueError, TypeError:
-        mode = ForecastSensorMode.NONE
-    create_d1 = (
-        mode in (ForecastSensorMode.D1, ForecastSensorMode.D1_D2) and forecast_days >= 2
-    )
-    create_d2 = mode == ForecastSensorMode.D1_D2 and forecast_days >= 3
 
     api_key = entry.data.get(CONF_API_KEY)
     if not isinstance(api_key, str) or not api_key.strip():
@@ -344,9 +340,6 @@ async def async_setup_entry(
             subentry_id=subentry_id,
             entry_title=title,
             legacy_entry_id=legacy_entry_id,
-            forecast_days=forecast_days,
-            create_d1=create_d1,
-            create_d2=create_d2,
             client=client,
         )
 

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -386,7 +386,7 @@ async def async_setup_entry(
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except (ConfigEntryAuthFailed, ConfigEntryNotReady):
+    except ConfigEntryAuthFailed, ConfigEntryNotReady:
         entry.runtime_data = None
         raise
     except Exception as err:

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -58,7 +58,7 @@ class GooglePollenApiClient:
             if math.isfinite(parsed) and parsed > 0:
                 return parsed
             return 2.0
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             retry_at = dt_util.parse_http_date(retry_after_raw)
             if retry_at is not None:
                 delay = (retry_at - dt_util.utcnow()).total_seconds()

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -58,7 +58,7 @@ class GooglePollenApiClient:
             if math.isfinite(parsed) and parsed > 0:
                 return parsed
             return 2.0
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             retry_at = dt_util.parse_http_date(retry_after_raw)
             if retry_at is not None:
                 delay = (retry_at - dt_util.utcnow()).total_seconds()

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -1,7 +1,6 @@
 """Config & options flow for Pollen Levels.
 
 Notes:
-- Unified per-day sensors option ('create_forecast_sensors'): "none" | "D+1" | "D+1+2".
 - Allows empty language (omit languageCode). Trims language whitespace on save.
 - Redacts API keys in debug logs.
 - Timeout handling: on Python 3.14, built-in `TimeoutError` also covers `asyncio.TimeoutError`,
@@ -30,9 +29,6 @@ from homeassistant.helpers.selector import (
     NumberSelector,
     NumberSelectorConfig,
     NumberSelectorMode,
-    SelectSelector,
-    SelectSelectorConfig,
-    SelectSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -42,19 +38,14 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from .client import GooglePollenApiClient, PollenQuotaExceededError
 from .const import (
     CONF_API_KEY,
-    CONF_CREATE_FORECAST_SENSORS,
-    CONF_FORECAST_DAYS,
     CONF_LANGUAGE_CODE,
     CONF_LEGACY_ENTRY_ID,
     CONF_UPDATE_INTERVAL,
     DEFAULT_ENTRY_TITLE,
-    DEFAULT_FORECAST_DAYS,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
-    FORECAST_SENSORS_CHOICES,
-    MAX_FORECAST_DAYS,
+    FORECAST_DAYS,
     MAX_UPDATE_INTERVAL_HOURS,
-    MIN_FORECAST_DAYS,
     MIN_UPDATE_INTERVAL_HOURS,
     POLLEN_API_KEY_URL,
     RESTRICTING_API_KEYS_URL,
@@ -64,21 +55,16 @@ from .util import (
     api_key_unique_id,
     entry_api_key,
     format_location_unique_id,
-    normalize_sensor_mode,
     redact_api_key,
     redact_sensitive_values,
     safe_parse_int,
+    strip_legacy_forecast_options,
     validate_latitude,
     validate_location_pair,
     validate_longitude,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-FORECAST_DAYS_OPTIONS = [
-    str(i) for i in range(MIN_FORECAST_DAYS, MAX_FORECAST_DAYS + 1)
-]
-_FORECAST_MODE_MIN_DAYS = {"D+1": 2, "D+1+2": 3}
 
 # BCP-47-ish regex (common patterns, not full grammar).
 LANGUAGE_CODE_REGEX = re.compile(
@@ -106,8 +92,6 @@ def is_valid_language_code(value: str) -> str:
 def _language_error_to_form_key(error: vol.Invalid) -> str:
     """Convert voluptuous validation errors into form error keys."""
     message = getattr(error, "error_message", "")
-    if message == "empty":
-        return "empty"
     if message == "invalid_language":
         return "invalid_language_format"
     return "invalid_language_format"
@@ -129,23 +113,6 @@ def _format_visible_coordinate(value: Any, *, lat: bool) -> str:
     if parsed is None:
         return ""
     return f"{parsed:.2f}"
-
-
-def _required_forecast_days_for_mode(mode: str) -> int:
-    """Return the minimum forecast days required for a sensor mode."""
-    return _FORECAST_MODE_MIN_DAYS.get(mode, MIN_FORECAST_DAYS)
-
-
-def _normalize_forecast_mode_for_save(raw_value: Any) -> str:
-    """Normalize a forecast sensor mode before saving it."""
-    return normalize_sensor_mode(raw_value, _LOGGER)
-
-
-def _forecast_mode_combo_error(forecast_days: int, mode: str) -> str | None:
-    """Return an error key when forecast days and mode are incompatible."""
-    if forecast_days < _required_forecast_days_for_mode(mode):
-        return "invalid_option_combo"
-    return None
 
 
 def _safe_error_message(error: Exception | str, fallback: str) -> str:
@@ -226,7 +193,7 @@ async def _async_validate_api_location(
         data = await client.async_fetch_pollen_data(
             latitude=latitude,
             longitude=longitude,
-            days=1,
+            days=FORECAST_DAYS,
             language_code=language_code,
         )
 
@@ -323,12 +290,6 @@ def _build_step_user_schema(hass: Any, user_input: dict[str, Any] | None) -> vol
 
     update_interval_raw = user_input.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     interval_default = _sanitize_update_interval_for_default(update_interval_raw)
-    forecast_days_default = _sanitize_forecast_days_for_default(
-        user_input.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS)
-    )
-    sensor_mode_default = _sanitize_forecast_mode_for_default(
-        user_input.get(CONF_CREATE_FORECAST_SENSORS, FORECAST_SENSORS_CHOICES[0])
-    )
 
     schema = vol.Schema(
         {
@@ -355,24 +316,6 @@ def _build_step_user_schema(hass: Any, user_input: dict[str, Any] | None) -> vol
                     CONF_LANGUAGE_CODE, getattr(hass.config, "language", "")
                 ),
             ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
-            vol.Optional(
-                CONF_FORECAST_DAYS,
-                default=forecast_days_default,
-            ): SelectSelector(
-                SelectSelectorConfig(
-                    mode=SelectSelectorMode.DROPDOWN,
-                    options=FORECAST_DAYS_OPTIONS,
-                )
-            ),
-            vol.Optional(
-                CONF_CREATE_FORECAST_SENSORS,
-                default=sensor_mode_default,
-            ): SelectSelector(
-                SelectSelectorConfig(
-                    mode=SelectSelectorMode.DROPDOWN,
-                    options=FORECAST_SENSORS_CHOICES,
-                )
-            ),
         }
     )
     return schema
@@ -466,8 +409,6 @@ def _parent_entry_options(normalized: dict[str, Any]) -> dict[str, Any]:
     for key in (
         CONF_UPDATE_INTERVAL,
         CONF_LANGUAGE_CODE,
-        CONF_FORECAST_DAYS,
-        CONF_CREATE_FORECAST_SENSORS,
     ):
         if key in normalized:
             options[key] = normalized[key]
@@ -605,27 +546,6 @@ def _sanitize_update_interval_for_default(raw_value: Any) -> int:
     return max(MIN_UPDATE_INTERVAL_HOURS, min(MAX_UPDATE_INTERVAL_HOURS, parsed))
 
 
-def _sanitize_forecast_days_for_default(raw_value: Any) -> str:
-    """Parse and clamp forecast days to be used as a UI default."""
-    parsed, _ = _parse_int_option(
-        raw_value,
-        DEFAULT_FORECAST_DAYS,
-        min_value=MIN_FORECAST_DAYS,
-        max_value=MAX_FORECAST_DAYS,
-        error_key="invalid_forecast_days",
-    )
-    parsed = max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, parsed))
-    return str(parsed)
-
-
-def _sanitize_forecast_mode_for_default(raw_value: Any) -> str:
-    """Normalize forecast sensor mode to be used as a UI default."""
-    mode = normalize_sensor_mode(raw_value, _LOGGER)
-    if mode in FORECAST_SENSORS_CHOICES:
-        return mode
-    return FORECAST_SENSORS_CHOICES[0]
-
-
 class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Pollen Levels."""
 
@@ -660,6 +580,7 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         normalized: dict[str, Any] = dict(user_input)
         normalized.pop(CONF_NAME, None)
         normalized.pop(CONF_LOCATION, None)
+        normalized = strip_legacy_forecast_options(normalized)
 
         api_key = str(user_input.get(CONF_API_KEY, "")) if user_input else ""
         api_key = api_key.strip()
@@ -677,29 +598,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors[CONF_UPDATE_INTERVAL] = interval_error
             placeholders.pop("error_message", None)
             return errors, None
-
-        forecast_days, days_error = _parse_int_option(
-            normalized.get(CONF_FORECAST_DAYS),
-            DEFAULT_FORECAST_DAYS,
-            min_value=MIN_FORECAST_DAYS,
-            max_value=MAX_FORECAST_DAYS,
-            error_key="invalid_forecast_days",
-        )
-        normalized[CONF_FORECAST_DAYS] = forecast_days
-        if days_error:
-            errors[CONF_FORECAST_DAYS] = days_error
-            placeholders.pop("error_message", None)
-            return errors, None
-
-        mode = _normalize_forecast_mode_for_save(
-            normalized.get(CONF_CREATE_FORECAST_SENSORS, FORECAST_SENSORS_CHOICES[0])
-        )
-        combo_error = _forecast_mode_combo_error(forecast_days, mode)
-        if combo_error:
-            errors[CONF_CREATE_FORECAST_SENSORS] = combo_error
-            placeholders.pop("error_message", None)
-            return errors, None
-        normalized[CONF_CREATE_FORECAST_SENSORS] = mode
 
         latlon = None
         if CONF_LOCATION in user_input:
@@ -1106,18 +1004,6 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
             CONF_LANGUAGE_CODE,
             self.config_entry.data.get(CONF_LANGUAGE_CODE, self.hass.config.language),
         )
-        current_days_raw = self.config_entry.options.get(
-            CONF_FORECAST_DAYS,
-            self.config_entry.data.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS),
-        )
-        current_days_default = _sanitize_forecast_days_for_default(current_days_raw)
-        current_days = int(current_days_default)
-        current_mode = self.config_entry.options.get(CONF_CREATE_FORECAST_SENSORS)
-        if current_mode is None:
-            current_mode = self.config_entry.data.get(
-                CONF_CREATE_FORECAST_SENSORS, "none"
-            )
-        current_mode = _sanitize_forecast_mode_for_default(current_mode)
 
         options_schema = vol.Schema(
             {
@@ -1135,22 +1021,6 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
                 vol.Optional(CONF_LANGUAGE_CODE, default=current_lang): TextSelector(
                     TextSelectorConfig(type=TextSelectorType.TEXT)
                 ),
-                vol.Optional(
-                    CONF_FORECAST_DAYS, default=current_days_default
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        mode=SelectSelectorMode.DROPDOWN,
-                        options=FORECAST_DAYS_OPTIONS,
-                    )
-                ),
-                vol.Optional(
-                    CONF_CREATE_FORECAST_SENSORS, default=current_mode
-                ): SelectSelector(
-                    SelectSelectorConfig(
-                        mode=SelectSelectorMode.DROPDOWN,
-                        options=FORECAST_SENSORS_CHOICES,
-                    )
-                ),
             }
         )
 
@@ -1159,6 +1029,7 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
                 **self.config_entry.options,
                 **user_input,
             }
+            normalized_input = strip_legacy_forecast_options(normalized_input)
             interval_value, interval_error = _parse_update_interval(
                 normalized_input.get(CONF_UPDATE_INTERVAL, current_interval),
                 current_interval,
@@ -1175,17 +1046,6 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
                     description_placeholders=placeholders,
                 )
 
-            forecast_days, days_error = _parse_int_option(
-                normalized_input.get(CONF_FORECAST_DAYS, current_days),
-                current_days,
-                min_value=MIN_FORECAST_DAYS,
-                max_value=MAX_FORECAST_DAYS,
-                error_key="invalid_forecast_days",
-            )
-            normalized_input[CONF_FORECAST_DAYS] = forecast_days
-            if days_error:
-                errors[CONF_FORECAST_DAYS] = days_error
-
             try:
                 raw_lang = normalized_input.get(
                     CONF_LANGUAGE_CODE,
@@ -1198,18 +1058,6 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
                 if lang:
                     lang = is_valid_language_code(lang)
                 normalized_input[CONF_LANGUAGE_CODE] = lang
-
-                days = normalized_input[CONF_FORECAST_DAYS]
-                mode = _normalize_forecast_mode_for_save(
-                    normalized_input.get(
-                        CONF_CREATE_FORECAST_SENSORS,
-                        current_mode,
-                    )
-                )
-                normalized_input[CONF_CREATE_FORECAST_SENSORS] = mode
-                combo_error = _forecast_mode_combo_error(days, mode)
-                if combo_error:
-                    errors[CONF_CREATE_FORECAST_SENSORS] = combo_error
 
             except vol.Invalid as ve:
                 _LOGGER.warning(

--- a/custom_components/pollenlevels/const.py
+++ b/custom_components/pollenlevels/const.py
@@ -11,20 +11,17 @@ CONF_UPDATE_INTERVAL = "update_interval"
 CONF_LANGUAGE_CODE = "language_code"
 CONF_LEGACY_ENTRY_ID = "legacy_entry_id"
 
-# Forecast-related options (Phase 1.1: types only)
+# Legacy option keys kept only to ignore/remove stored options from releases
+# where forecast days and per-day type forecast sensors were configurable.
 CONF_FORECAST_DAYS = "forecast_days"
-CONF_CREATE_FORECAST_SENSORS = (
-    "create_forecast_sensors"  # values: "none" | "D+1" | "D+1+2"
-)
+CONF_CREATE_FORECAST_SENSORS = "create_forecast_sensors"
+FORECAST_DAYS = 5
 
 # Defaults
 DEFAULT_UPDATE_INTERVAL = 6
 MIN_UPDATE_INTERVAL_HOURS = 1
 MAX_UPDATE_INTERVAL_HOURS = 24
-DEFAULT_FORECAST_DAYS = 2  # today + 1 (tomorrow)
 DEFAULT_ENTRY_TITLE = "Pollen Levels"
-MAX_FORECAST_DAYS = 5
-MIN_FORECAST_DAYS = 1
 POLLEN_API_TIMEOUT = 10
 MAX_RETRIES = 1
 POLLEN_API_KEY_URL = (
@@ -34,8 +31,6 @@ RESTRICTING_API_KEYS_URL = (
     "https://developers.google.com/maps/api-security-best-practices"
 )
 
-# Allowed values for create_forecast_sensors selector
-FORECAST_SENSORS_CHOICES: list[str] = ["none", "D+1", "D+1+2"]
 ATTRIBUTION = "Data provided by Google Maps Pollen API"
 SUBENTRY_TYPE_LOCATION = "location"
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -19,7 +19,7 @@ from .const import (
     FORECAST_DAYS,
 )
 from .forecast import attach_forecast_attributes
-from .util import redact_api_key, safe_parse_int
+from .util import redact_api_key, redact_sensitive_values, safe_parse_int
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -224,6 +224,11 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             raise
         except Exception as err:  # Keep previous behavior for unexpected errors
             msg = redact_api_key(err, self.api_key)
+            msg = redact_sensitive_values(
+                msg,
+                latitude=self.lat,
+                longitude=self.lon,
+            )
             _LOGGER.error("Pollen API error: %s", msg)
             raise UpdateFailed(msg) from err
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -36,7 +36,7 @@ def _normalize_channel(v: Any) -> int | None:
     """
     try:
         f = float(v)
-    except TypeError, ValueError, OverflowError:
+    except (TypeError, ValueError, OverflowError):
         return None
     if not math.isfinite(f):
         return None

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -36,7 +36,7 @@ def _normalize_channel(v: Any) -> int | None:
     """
     try:
         f = float(v)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
     if not math.isfinite(f):
         return None

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -16,8 +16,7 @@ from .client import GooglePollenApiClient
 from .const import (
     DEFAULT_ENTRY_TITLE,
     DOMAIN,
-    MAX_FORECAST_DAYS,
-    MIN_FORECAST_DAYS,
+    FORECAST_DAYS,
 )
 from .forecast import attach_forecast_attributes
 from .util import redact_api_key, safe_parse_int
@@ -149,9 +148,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         hours: int,
         language: str | None,
         entry_id: str,
-        forecast_days: int,
-        create_d1: bool,
-        create_d2: bool,
         client: GooglePollenApiClient,
         entry_title: str = DEFAULT_ENTRY_TITLE,
         subentry_id: str | None = None,
@@ -186,13 +182,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.device_identity_id = self.entity_identity_id
         self.entry_title = entry_title or DEFAULT_ENTRY_TITLE
-        # Clamp defensively for legacy/manual entries to supported range.
-        parsed_days = safe_parse_int(forecast_days)
-        if parsed_days is None:
-            parsed_days = MIN_FORECAST_DAYS
-        self.forecast_days = max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, parsed_days))
-        self.create_d1 = create_d1
-        self.create_d2 = create_d2
+        self.forecast_days = FORECAST_DAYS
         self._client = client
         self._missing_dailyinfo_warned = False
         self._stale_dailyinfo_warned = False
@@ -399,55 +389,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             base = attach_forecast_attributes(base, forecast_list)
             new_data[type_key] = base
 
-            # Optional per-day sensors (only if requested and day exists)
-            def _add_day_sensor(
-                off: int,
-                *,
-                _forecast_list=forecast_list,
-                _base=base,
-                _tcode=tcode,
-                _type_key=type_key,
-            ) -> None:
-                """Create a per-day type sensor for a given offset."""
-                f = next((d for d in _forecast_list if d["offset"] == off), None)
-                if not f:
-                    return
-
-                # Use day-specific 'inSeason' and 'advice' from the forecast day.
-                try:
-                    day_obj = daily[off]
-                except IndexError, TypeError:
-                    day_obj = None
-                day_item = type_by_day_code[off].get(_tcode) if day_obj else None
-                day_in_season = (
-                    day_item.get("inSeason") if isinstance(day_item, dict) else None
-                )
-                day_advice = (
-                    day_item.get("healthRecommendations")
-                    if isinstance(day_item, dict)
-                    else None
-                )
-
-                dname = f"{_base.get('displayName', _tcode)} (D+{off})"
-                new_data[f"{_type_key}_d{off}"] = {
-                    "source": "type",
-                    "displayName": dname,
-                    "value": f.get("value") if f.get("has_index") else None,
-                    "category": f.get("category") if f.get("has_index") else None,
-                    "description": f.get("description") if f.get("has_index") else None,
-                    "inSeason": day_in_season,
-                    "advice": day_advice,
-                    "color_hex": f.get("color_hex"),
-                    "color_rgb": f.get("color_rgb"),
-                    "date": f.get("date"),
-                    "has_index": f.get("has_index"),
-                }
-
-            if self.create_d1:
-                _add_day_sensor(1)
-            if self.create_d2:
-                _add_day_sensor(2)
-
         # Forecast for PLANTS (attributes only; no per-day plant sensors)
         for key in plant_keys:
             base = new_data.get(key) or {}
@@ -471,8 +412,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             types = 0
             plants = 0
             meta = 0
-            per_day = 0
-            for key, value in new_data.items():
+            for value in new_data.values():
                 source = value.get("source")
                 if source == "type":
                     types += 1
@@ -480,20 +420,15 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     plants += 1
                 else:
                     meta += 1
-                if key.endswith(("_d1", "_d2")):
-                    per_day += 1
             updated = self.last_updated.isoformat() if self.last_updated else "unknown"
             _LOGGER.debug(
-                "Update complete: entries=%d types=%d plants=%d meta=%d per_day=%d "
-                "forecast_days=%d d1=%s d2=%s updated=%s",
+                "Update complete: entries=%d types=%d plants=%d meta=%d "
+                "forecast_days=%d updated=%s",
                 total,
                 types,
                 plants,
                 meta,
-                per_day,
                 self.forecast_days,
-                self.create_d1,
-                self.create_d2,
                 updated,
             )
         return self.data

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -67,7 +67,7 @@ def _rounded(value: Any) -> float | None:
     """
     try:
         f = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
     if not math.isfinite(f):
         return None
@@ -230,7 +230,7 @@ def _registry_summary(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]
 
         entity_registry = er.async_get(hass)
         entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    except (ImportError, RuntimeError, KeyError, AttributeError):
+    except ImportError, RuntimeError, KeyError, AttributeError:
         entities = []
 
     for entity in entities:
@@ -249,7 +249,7 @@ def _registry_summary(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]
 
         device_registry = dr.async_get(hass)
         devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-    except (ImportError, RuntimeError, KeyError, AttributeError):
+    except ImportError, RuntimeError, KeyError, AttributeError:
         devices = []
 
     for device in devices:

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -105,8 +105,10 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
     coord_info = {
         "entry_id": getattr(coordinator, "entry_id", None),
         "subentry_id": getattr(coordinator, "subentry_id", None),
-        "legacy_entry_id": getattr(coordinator, "legacy_entry_id", None),
-        "entity_identity_id": getattr(coordinator, "entity_identity_id", None),
+        "has_legacy_entry_id": bool(getattr(coordinator, "legacy_entry_id", None)),
+        "has_entity_identity_id": bool(
+            getattr(coordinator, "entity_identity_id", None)
+        ),
         "forecast_days": FORECAST_DAYS,
         "language": getattr(coordinator, "language", None),
         "last_updated": _iso_or_none(getattr(coordinator, "last_updated", None)),

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -2,7 +2,7 @@
 
 This exposes non-sensitive runtime details useful for support:
 - Entry data/options (with API key and location redacted)
-- Coordinator snapshot (last_updated, forecast_days, language, flags)
+- Coordinator snapshot (last_updated, forecast_days, language)
 - Forecast summaries for TYPES & PLANTS (attributes-only for plants)
 - Daily summary sensor snapshot derived from coordinator data
 - A sample of the request params with the API key redacted
@@ -22,17 +22,13 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_API_KEY,
-    CONF_CREATE_FORECAST_SENSORS,
-    CONF_FORECAST_DAYS,
     CONF_LANGUAGE_CODE,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_UPDATE_INTERVAL,
     DEFAULT_ENTRY_TITLE,
-    DEFAULT_FORECAST_DAYS,  # use constant instead of magic number
     DOMAIN,
-    MAX_FORECAST_DAYS,
-    MIN_FORECAST_DAYS,
+    FORECAST_DAYS,
 )
 from .runtime import PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
@@ -41,7 +37,6 @@ from .util import (
     has_legacy_location_data,
     redact_api_key,
     redact_sensitive_values,
-    safe_parse_int,
 )
 
 # Redact potentially sensitive values from diagnostics. Diagnostics intentionally
@@ -79,17 +74,6 @@ def _rounded(value: Any) -> float | None:
     return round(f, 1)
 
 
-def _effective_days(options: dict[str, Any], data: dict[str, Any]) -> int:
-    """Return sanitized forecast days for diagnostics examples."""
-    days_raw = options.get(
-        CONF_FORECAST_DAYS,
-        data.get(CONF_FORECAST_DAYS, DEFAULT_FORECAST_DAYS),
-    )
-    parsed_days = safe_parse_int(days_raw)
-    days_effective = DEFAULT_FORECAST_DAYS if parsed_days is None else parsed_days
-    return max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, days_effective))
-
-
 def _redact_diagnostics_text(
     value: Any,
     api_key: str | None,
@@ -123,10 +107,8 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
         "subentry_id": getattr(coordinator, "subentry_id", None),
         "legacy_entry_id": getattr(coordinator, "legacy_entry_id", None),
         "entity_identity_id": getattr(coordinator, "entity_identity_id", None),
-        "forecast_days": getattr(coordinator, "forecast_days", None),
+        "forecast_days": FORECAST_DAYS,
         "language": getattr(coordinator, "language", None),
-        "create_d1": getattr(coordinator, "create_d1", None),
-        "create_d2": getattr(coordinator, "create_d2", None),
         "last_updated": _iso_or_none(getattr(coordinator, "last_updated", None)),
         "data_keys_total": 0,
         "data_keys": [],
@@ -146,22 +128,10 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
         and v.get("source") == "type"
         and not k.endswith(("_d1", "_d2"))
     ]
-    type_perday_keys = [
-        k
-        for k, v in data_map.items()
-        if isinstance(v, dict)
-        and v.get("source") == "type"
-        and k.endswith(("_d1", "_d2"))
-    ]
-    type_codes = sorted(
-        {k.split("_", 1)[1].split("_d", 1)[0].upper() for k in type_main_keys}
-    )
+    type_codes = sorted({k.split("_", 1)[1].upper() for k in type_main_keys})
     forecast_summary["type"] = {
         "total_main": len(type_main_keys),
-        "total_per_day": len(type_perday_keys),
-        "create_d1": getattr(coordinator, "create_d1", None),
-        "create_d2": getattr(coordinator, "create_d2", None),
-        "days": getattr(coordinator, "forecast_days", None),
+        "days": FORECAST_DAYS,
         "codes": type_codes,
     }
 
@@ -176,8 +146,8 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
     plants_with_trend = [v for v in plant_items if v.get("trend") is not None]
 
     forecast_summary["plant"] = {
-        "enabled": bool(getattr(coordinator, "forecast_days", 1) >= 2),
-        "days": getattr(coordinator, "forecast_days", None),
+        "enabled": FORECAST_DAYS >= 2,
+        "days": FORECAST_DAYS,
         "total": len(plant_items),
         "with_attr": len(plants_with_attr),
         "with_nonempty": len(plants_with_nonempty),
@@ -307,7 +277,6 @@ async def async_get_config_entry_diagnostics(
     options: dict[str, Any] = dict(entry.options or {})
     data: dict[str, Any] = dict(entry.data or {})
     runtime = cast(PollenLevelsRuntimeData | None, getattr(entry, "runtime_data", None))
-    days_effective = _effective_days(options, data)
     lang = options.get(CONF_LANGUAGE_CODE, data.get(CONF_LANGUAGE_CODE))
     locations: dict[str, Any] = {}
     stale_location_ids: list[str] = []
@@ -349,7 +318,7 @@ async def async_get_config_entry_diagnostics(
                 "key": redact_api_key(api_key, api_key_text) or "***",
                 "location.latitude": _rounded(lat),
                 "location.longitude": _rounded(lon),
-                "days": days_effective,
+                "days": FORECAST_DAYS,
             }
             if lang:
                 request_params_example["languageCode"] = lang
@@ -381,8 +350,6 @@ async def async_get_config_entry_diagnostics(
             "options": {
                 CONF_UPDATE_INTERVAL: options.get(CONF_UPDATE_INTERVAL),
                 CONF_LANGUAGE_CODE: options.get(CONF_LANGUAGE_CODE),
-                CONF_FORECAST_DAYS: options.get(CONF_FORECAST_DAYS),
-                CONF_CREATE_FORECAST_SENSORS: options.get(CONF_CREATE_FORECAST_SENSORS),
             },
             "data": {
                 CONF_LANGUAGE_CODE: data.get(CONF_LANGUAGE_CODE),

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -67,7 +67,7 @@ def _rounded(value: Any) -> float | None:
     """
     try:
         f = float(value)
-    except TypeError, ValueError, OverflowError:
+    except (TypeError, ValueError, OverflowError):
         return None
     if not math.isfinite(f):
         return None
@@ -230,7 +230,7 @@ def _registry_summary(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]
 
         entity_registry = er.async_get(hass)
         entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    except ImportError, RuntimeError, KeyError, AttributeError:
+    except (ImportError, RuntimeError, KeyError, AttributeError):
         entities = []
 
     for entity in entities:
@@ -249,7 +249,7 @@ def _registry_summary(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]
 
         device_registry = dr.async_get(hass)
         devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-    except ImportError, RuntimeError, KeyError, AttributeError:
+    except (ImportError, RuntimeError, KeyError, AttributeError):
         devices = []
 
     for device in devices:

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -1,4 +1,4 @@
-"""Helpers for creating and deleting Home Assistant Repair issues for invalid stored locations."""
+"""Helpers for creating and deleting Home Assistant Repair issues."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DEFAULT_ENTRY_TITLE, DOMAIN
+
+PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
 
 
 def invalid_stored_location_issue_id(
@@ -42,6 +44,19 @@ def create_invalid_stored_location_issue(
             "entry_title": entry_title,
             "location_title": location_title,
         },
+    )
+
+
+def create_per_day_forecast_sensors_removed_issue(hass: HomeAssistant) -> None:
+    """Create a Repair issue for removed legacy per-day forecast sensors."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
+        is_fixable=False,
+        is_persistent=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
     )
 
 

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0rc1"
+    "version": "3.0.0b4"
 }

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0b4"
+    "version": "3.0.0rc1"
 }

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -79,7 +79,7 @@ def _location_unique_id(lat: Any, lon: Any) -> str | None:
     try:
         lat_float = float(lat)
         lon_float = float(lon)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
     if not _coordinates_are_valid(lat_float, lon_float):
         return None
@@ -539,7 +539,7 @@ def _migrate_entity_registry_for_merged_entry(
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-    except ImportError, RuntimeError, KeyError, AttributeError:
+    except (ImportError, RuntimeError, KeyError, AttributeError):
         return True, 0
 
     migrated = True
@@ -598,7 +598,7 @@ def _migrate_device_registry_for_merged_entry(
         from homeassistant.helpers import device_registry as dr
 
         registry = dr.async_get(hass)
-    except ImportError, RuntimeError, KeyError, AttributeError:
+    except (ImportError, RuntimeError, KeyError, AttributeError):
         return True, 0, 0
 
     migrated = True

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -79,7 +79,7 @@ def _location_unique_id(lat: Any, lon: Any) -> str | None:
     try:
         lat_float = float(lat)
         lon_float = float(lon)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if not _coordinates_are_valid(lat_float, lon_float):
         return None
@@ -539,7 +539,7 @@ def _migrate_entity_registry_for_merged_entry(
         from homeassistant.helpers import entity_registry as er
 
         registry = er.async_get(hass)
-    except (ImportError, RuntimeError, KeyError, AttributeError):
+    except ImportError, RuntimeError, KeyError, AttributeError:
         return True, 0
 
     migrated = True
@@ -598,7 +598,7 @@ def _migrate_device_registry_for_merged_entry(
         from homeassistant.helpers import device_registry as dr
 
         registry = dr.async_get(hass)
-    except (ImportError, RuntimeError, KeyError, AttributeError):
+    except ImportError, RuntimeError, KeyError, AttributeError:
         return True, 0, 0
 
     migrated = True

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -15,8 +15,6 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_API_KEY,
-    CONF_CREATE_FORECAST_SENSORS,
-    CONF_FORECAST_DAYS,
     CONF_LANGUAGE_CODE,
     CONF_LATITUDE,
     CONF_LEGACY_ENTRY_ID,
@@ -28,12 +26,15 @@ from .const import (
 )
 from .issue_helpers import (
     create_entry_invalid_stored_location_issue,
+    create_per_day_forecast_sensors_removed_issue,
     delete_entry_invalid_stored_location_issue,
 )
 from .util import (
+    LEGACY_FORECAST_OPTION_KEYS,
     api_key_unique_id,
     entry_api_key,
-    normalize_sensor_mode,
+    has_legacy_per_day_option,
+    strip_legacy_forecast_options,
     validate_location_pair,
 )
 
@@ -169,28 +170,13 @@ def _clean_parent_options(entry: ConfigEntry) -> dict[str, Any]:
     """Return v3 parent options migrated from legacy data/options."""
     existing_data = entry.data or {}
     existing_options = entry.options or {}
-    new_options = dict(existing_options)
+    new_options = strip_legacy_forecast_options(existing_options)
     for option_key in (
         CONF_UPDATE_INTERVAL,
         CONF_LANGUAGE_CODE,
-        CONF_FORECAST_DAYS,
     ):
         if option_key not in new_options and option_key in existing_data:
             new_options[option_key] = existing_data[option_key]
-
-    mode = new_options.get(
-        CONF_CREATE_FORECAST_SENSORS,
-        existing_data.get(CONF_CREATE_FORECAST_SENSORS),
-    )
-
-    mode_raw = getattr(mode, "value", mode)
-    if mode_raw is not None:
-        mode_raw = str(mode_raw)
-        normalized_mode = normalize_sensor_mode(mode_raw, _LOGGER)
-        if new_options.get(CONF_CREATE_FORECAST_SENSORS) != normalized_mode:
-            new_options[CONF_CREATE_FORECAST_SENSORS] = normalized_mode
-    else:
-        new_options.pop(CONF_CREATE_FORECAST_SENSORS, None)
 
     new_options.pop(LEGACY_HTTP_REFERER_KEY, None)
     return new_options
@@ -461,26 +447,18 @@ def _entry_needs_cleanup(
     cleanup_needed = (
         LEGACY_HTTP_REFERER_KEY in existing_data
         or LEGACY_HTTP_REFERER_KEY in existing_options
-        or CONF_CREATE_FORECAST_SENSORS in existing_data
+        or any(key in existing_data for key in LEGACY_FORECAST_OPTION_KEYS)
+        or any(key in existing_options for key in LEGACY_FORECAST_OPTION_KEYS)
         or CONF_LATITUDE in existing_data
         or CONF_LONGITUDE in existing_data
         or CONF_UPDATE_INTERVAL in existing_data
         or CONF_LANGUAGE_CODE in existing_data
-        or CONF_FORECAST_DAYS in existing_data
         or (
             not existing_subentries
             and not is_entry_merged(entry)
             and current_version < target_version
         )
     )
-    if not cleanup_needed and CONF_CREATE_FORECAST_SENSORS in existing_options:
-        stored_mode = existing_options.get(CONF_CREATE_FORECAST_SENSORS)
-        stored_mode_raw = getattr(stored_mode, "value", stored_mode)
-        if stored_mode_raw is not None:
-            stored_mode_raw = str(stored_mode_raw)
-            cleanup_needed = (
-                normalize_sensor_mode(stored_mode_raw, _LOGGER) != stored_mode_raw
-            )
     return cleanup_needed
 
 
@@ -818,6 +796,10 @@ async def _async_migrate_grouped_entries(
             create_entry_invalid_stored_location_issue(hass, source)
             return False
 
+    legacy_per_day_option_detected = any(
+        has_legacy_per_day_option(candidate.data, candidate.options)
+        for candidate in group
+    )
     parent_options = _clean_parent_options(parent)
     for candidate in group:
         if candidate is parent:
@@ -901,6 +883,8 @@ async def _async_migrate_grouped_entries(
             return False
 
     _update_parent_entry(hass, parent, api_key, parent_options, target_version)
+    if legacy_per_day_option_detected:
+        create_per_day_forecast_sensors_removed_issue(hass)
 
     for source in group:
         if source is parent:
@@ -1009,6 +993,9 @@ async def async_handle_entry_migration(
 
         existing_data = entry.data or {}
         existing_options = entry.options or {}
+        legacy_per_day_option_detected = has_legacy_per_day_option(
+            entry.data, entry.options
+        )
         cleanup_needed = _entry_needs_cleanup(entry, current_version, target_version)
         target_unique_id = api_key_unique_id(api_key) if api_key is not None else None
         unique_id_changed = (
@@ -1109,6 +1096,8 @@ async def async_handle_entry_migration(
             hass.config_entries.async_update_entry(entry, **updates)
         else:
             hass.config_entries.async_update_entry(entry, version=new_version)
+        if legacy_per_day_option_detected:
+            create_per_day_forecast_sensors_removed_issue(hass)
         delete_entry_invalid_stored_location_issue(hass, entry)
         _LOGGER.info(
             "Completed Pollen Levels v3 migration for parent %s "

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    FORECAST_DAYS,
 )
 from .coordinator import PollenDataUpdateCoordinator
 from .issue_helpers import create_per_day_forecast_sensors_removed_issue
@@ -105,9 +106,8 @@ async def _remove_legacy_per_day_entities(
             removal = registry.async_remove(entity_id)
         except Exception:
             _LOGGER.exception(
-                "Failed to remove legacy per-day entity from registry: %s (%s)",
+                "Failed to remove legacy per-day entity from registry: %s",
                 entity_id,
-                unique_id,
             )
             return
 
@@ -122,9 +122,8 @@ async def _remove_legacy_per_day_entities(
         if _matches(ent.unique_id):
             found += 1
             _LOGGER.debug(
-                "Removing legacy per-day entity from registry: %s (%s)",
+                "Removing legacy per-day entity from registry: %s",
                 ent.entity_id,
-                ent.unique_id,
             )
             _queue_removal(ent.entity_id, ent.unique_id)
 
@@ -132,16 +131,15 @@ async def _remove_legacy_per_day_entities(
         results = await asyncio.gather(
             *(removal for _, _, removal in removals), return_exceptions=True
         )
-        for (entity_id, unique_id, _removal), result in zip(
+        for (entity_id, _unique_id, _removal), result in zip(
             removals, results, strict=True
         ):
             if isinstance(result, asyncio.CancelledError):
                 raise result
             if isinstance(result, Exception):
                 _LOGGER.error(
-                    "Failed to remove legacy per-day entity from registry: %s (%s)",
+                    "Failed to remove legacy per-day entity from registry: %s",
                     entity_id,
-                    unique_id,
                     exc_info=(type(result), result, result.__traceback__),
                 )
                 continue
@@ -149,10 +147,9 @@ async def _remove_legacy_per_day_entities(
 
     if removed:
         _LOGGER.info(
-            "Entity Registry cleanup: removed %d legacy per-day sensors for entry %s identity %s",
+            "Entity Registry cleanup: removed %d legacy per-day sensors for entry %s",
             removed,
             entry_id,
-            identity_id,
         )
     return found, removed
 
@@ -248,13 +245,13 @@ async def async_setup_entry(
         )
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            ids = [getattr(s, "unique_id", None) for s in sensors]
-            preview = ids[:10]
-            extra = max(0, len(ids) - len(preview))
+            labels = [getattr(s, "code", type(s).__name__) for s in sensors]
+            preview = labels[:10]
+            extra = max(0, len(labels) - len(preview))
             suffix = f", +{extra} more" if extra else ""
             _LOGGER.debug(
                 "Creating %d sensors for subentry %s (preview=%s%s)",
-                len(ids),
+                len(labels),
                 location.subentry_id,
                 preview,
                 suffix,
@@ -330,8 +327,8 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
             if info.get(k) is not None:
                 attrs[k] = info.get(k)
 
-        # Only include forecast-related attributes if more than 1 day was requested.
-        include_forecast = getattr(self.coordinator, "forecast_days", 1) > 1
+        # Forecast attributes are fixed by the integration-wide Google API horizon.
+        include_forecast = FORECAST_DAYS > 1
 
         # Forecast-related attributes:
         # - For TYPE sensors: include on base sensors

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -81,10 +81,11 @@ async def _remove_legacy_per_day_entities(
     hass: HomeAssistant,
     entry_id: str,
     identity_id: str,
-) -> int:
+) -> tuple[int, int]:
     """Remove legacy per-day type forecast entities from the Entity Registry."""
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, entry_id)
+    found = 0
     removed = 0
 
     def _matches(uid: Any) -> bool:
@@ -119,6 +120,7 @@ async def _remove_legacy_per_day_entities(
         if ent.domain != "sensor" or ent.platform != DOMAIN:
             continue
         if _matches(ent.unique_id):
+            found += 1
             _LOGGER.debug(
                 "Removing legacy per-day entity from registry: %s (%s)",
                 ent.entity_id,
@@ -152,7 +154,7 @@ async def _remove_legacy_per_day_entities(
             entry_id,
             identity_id,
         )
-    return removed
+    return found, removed
 
 
 def _add_entities_for_location(
@@ -211,12 +213,14 @@ async def async_setup_entry(
             raise ConfigEntryNotReady(message)
 
         identity_id = coordinator_identity_id(coordinator)
-        removed_legacy_entities = await _remove_legacy_per_day_entities(
-            hass,
-            config_entry.entry_id,
-            identity_id,
+        found_legacy_entities, _removed_legacy_entities = (
+            await _remove_legacy_per_day_entities(
+                hass,
+                config_entry.entry_id,
+                identity_id,
+            )
         )
-        if removed_legacy_entities:
+        if found_legacy_entities:
             create_per_day_forecast_sensors_removed_issue(hass)
 
         sensors: list[CoordinatorEntity] = []

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -1,7 +1,7 @@
 """Pollen Levels sensors with multi-day forecast (types & plants).
 
 Key points:
-- Cleans up stale per-day sensors (D+1/D+2) in Entity Registry on reload.
+- Cleans up legacy per-day sensors (D+1/D+2) in Entity Registry on reload.
 - Normalizes language (trim/omit when empty) before calling the API.
 - Redacts API keys in debug logs.
 - Minimal safe backoff: single retry on transient errors (Timeout/5xx/429).
@@ -16,7 +16,6 @@ import inspect
 import logging
 from collections.abc import Awaitable
 from datetime import date, datetime
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any, cast
 
 # Modern sensor base + enums
@@ -40,23 +39,19 @@ if TYPE_CHECKING:
 from .const import (
     ATTRIBUTION,
     CONF_API_KEY,
-    CONF_FORECAST_DAYS,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_UPDATE_INTERVAL,
-    DEFAULT_FORECAST_DAYS,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
-    MAX_FORECAST_DAYS,
-    MIN_FORECAST_DAYS,
 )
 from .coordinator import PollenDataUpdateCoordinator
+from .issue_helpers import create_per_day_forecast_sensors_removed_issue
 from .runtime import PollenLevelsConfigEntry, PollenLevelsRuntimeData
 from .summary import daily_summary as _daily_summary
 from .util import (
     coordinator_device_id,
     coordinator_identity_id,
-    safe_parse_int,
     stale_runtime_location_filter,
 )
 
@@ -67,7 +62,6 @@ __all__ = [
     "CONF_LATITUDE",
     "CONF_LONGITUDE",
     "CONF_UPDATE_INTERVAL",
-    "DEFAULT_FORECAST_DAYS",
     "DEFAULT_UPDATE_INTERVAL",
 ]
 
@@ -83,37 +77,23 @@ PLANT_TYPE_ICONS = TYPE_ICONS
 DEFAULT_ICON = "mdi:flower-pollen"
 
 
-class ForecastSensorMode(StrEnum):
-    """Options for forecast sensor creation."""
-
-    NONE = "none"
-    D1 = "D+1"
-    D1_D2 = "D+1+2"
-
-
-async def _cleanup_per_day_entities(
+async def _remove_legacy_per_day_entities(
     hass: HomeAssistant,
     entry_id: str,
-    identity_id: str | None = None,
-    allow_d1: bool = False,
-    allow_d2: bool = False,
+    identity_id: str,
 ) -> int:
-    """Remove stale per-day entities (D+1/D+2) from the Entity Registry.
-
-    HA keeps entity registry entries across reloads. If options disable per-day
-    sensors (or forecast_days is insufficient), we proactively remove registry
-    entries to avoid "Unavailable" ghosts in the UI.
-    """
+    """Remove legacy per-day type forecast entities from the Entity Registry."""
     registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(registry, entry_id)
     removed = 0
-    identity_id = identity_id or entry_id
 
-    def _matches(uid: str, suffix: str) -> bool:
-        """Check if a unique_id belongs to this entry and ends with suffix."""
+    def _matches(uid: Any) -> bool:
+        """Check if a unique_id belongs to this identity and is legacy per-day."""
+        if not isinstance(uid, str):
+            return False
         if not uid.startswith(f"{identity_id}_"):
             return False
-        return uid.endswith(suffix)
+        return uid.endswith(("_d1", "_d2"))
 
     removals: list[tuple[str, str, Awaitable[Any]]] = []
 
@@ -124,7 +104,7 @@ async def _cleanup_per_day_entities(
             removal = registry.async_remove(entity_id)
         except Exception:
             _LOGGER.exception(
-                "Failed to remove stale per-day entity from registry: %s (%s)",
+                "Failed to remove legacy per-day entity from registry: %s (%s)",
                 entity_id,
                 unique_id,
             )
@@ -138,17 +118,9 @@ async def _cleanup_per_day_entities(
     for ent in entries:
         if ent.domain != "sensor" or ent.platform != DOMAIN:
             continue
-        if not allow_d1 and _matches(ent.unique_id, "_d1"):
+        if _matches(ent.unique_id):
             _LOGGER.debug(
-                "Removing stale D+1 entity from registry: %s (%s)",
-                ent.entity_id,
-                ent.unique_id,
-            )
-            _queue_removal(ent.entity_id, ent.unique_id)
-            continue
-        if not allow_d2 and _matches(ent.unique_id, "_d2"):
-            _LOGGER.debug(
-                "Removing stale D+2 entity from registry: %s (%s)",
+                "Removing legacy per-day entity from registry: %s (%s)",
                 ent.entity_id,
                 ent.unique_id,
             )
@@ -165,7 +137,7 @@ async def _cleanup_per_day_entities(
                 raise result
             if isinstance(result, Exception):
                 _LOGGER.error(
-                    "Failed to remove stale per-day entity from registry: %s (%s)",
+                    "Failed to remove legacy per-day entity from registry: %s (%s)",
                     entity_id,
                     unique_id,
                     exc_info=(type(result), result, result.__traceback__),
@@ -175,7 +147,7 @@ async def _cleanup_per_day_entities(
 
     if removed:
         _LOGGER.info(
-            "Entity Registry cleanup: removed %d per-day sensors for entry %s identity %s",
+            "Entity Registry cleanup: removed %d legacy per-day sensors for entry %s identity %s",
             removed,
             entry_id,
             identity_id,
@@ -216,7 +188,6 @@ async def async_setup_entry(
     active_subentry_ids, filter_stale_locations = stale_runtime_location_filter(
         config_entry
     )
-    opts = config_entry.options or {}
     for location in runtime.locations.values():
         if filter_stale_locations and location.subentry_id not in active_subentry_ids:
             _LOGGER.debug(
@@ -227,24 +198,6 @@ async def async_setup_entry(
             continue
 
         coordinator = location.coordinator
-        raw_days = opts.get(CONF_FORECAST_DAYS, coordinator.forecast_days)
-        parsed = safe_parse_int(raw_days)
-        if parsed is None:
-            _LOGGER.warning(
-                "Invalid forecast_days '%s' for entry %s subentry %s; defaulting to %s",
-                raw_days,
-                config_entry.entry_id,
-                location.subentry_id,
-                coordinator.forecast_days,
-            )
-        forecast_days = parsed if parsed is not None else coordinator.forecast_days
-        forecast_days = max(MIN_FORECAST_DAYS, min(MAX_FORECAST_DAYS, forecast_days))
-        create_d1 = coordinator.create_d1
-        create_d2 = coordinator.create_d2
-
-        allow_d1 = create_d1 and forecast_days >= 2
-        allow_d2 = create_d2 and forecast_days >= 3
-
         data = coordinator.data or {}
         has_daily = ("date" in data) or any(
             key.startswith(("type_", "plant_", "plants_")) for key in data
@@ -258,21 +211,19 @@ async def async_setup_entry(
             raise ConfigEntryNotReady(message)
 
         identity_id = coordinator_identity_id(coordinator)
-        await _cleanup_per_day_entities(
+        removed_legacy_entities = await _remove_legacy_per_day_entities(
             hass,
             config_entry.entry_id,
             identity_id,
-            allow_d1=allow_d1,
-            allow_d2=allow_d2,
         )
+        if removed_legacy_entities:
+            create_per_day_forecast_sensors_removed_issue(hass)
 
         sensors: list[CoordinatorEntity] = []
         for code in data:
             if code in ("region", "date"):
                 continue
-            if code.endswith("_d1") and not allow_d1:
-                continue
-            if code.endswith("_d2") and not allow_d2:
+            if code.endswith(("_d1", "_d2")):
                 continue
             sensors.append(PollenSensor(coordinator, code))
 
@@ -308,7 +259,7 @@ async def async_setup_entry(
 
 
 class PollenSensor(CoordinatorEntity, SensorEntity):
-    """Represent a pollen sensor for a type, plant, or per-day type."""
+    """Represent a pollen sensor for a type or plant."""
 
     # Enable long-term statistics for numeric pollen index values
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -347,7 +298,7 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         """
         info = self.coordinator.data.get(self.code, {})
         if info.get("source") == "type":
-            base_key = self.code.split("_", 1)[1].split("_d", 1)[0].upper()
+            base_key = self.code.split("_", 1)[1].upper()
             return TYPE_ICONS.get(base_key, DEFAULT_ICON)
         # Normalize plant 'type' to uppercase to map icons reliably
         ptype = (info.get("type") or "").upper()
@@ -379,9 +330,9 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         include_forecast = getattr(self.coordinator, "forecast_days", 1) > 1
 
         # Forecast-related attributes:
-        # - For TYPE sensors: include on main sensors only (not per-day _d1/_d2)
+        # - For TYPE sensors: include on base sensors
         # - For PLANT sensors: include as attributes (no per-day plant sensors)
-        if info.get("source") == "type" and not self.code.endswith(("_d1", "_d2")):
+        if info.get("source") == "type":
             if include_forecast:
                 # Add forecast attributes only when forecast is enabled.
                 for k in (

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -637,7 +637,7 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -187,6 +187,21 @@ async def async_setup_entry(
     active_subentry_ids, filter_stale_locations = stale_runtime_location_filter(
         config_entry
     )
+    legacy_entities_found = False
+    for location in runtime.locations.values():
+        identity_id = coordinator_identity_id(location.coordinator)
+        found_legacy_entities, _removed_legacy_entities = (
+            await _remove_legacy_per_day_entities(
+                hass,
+                config_entry.entry_id,
+                identity_id,
+            )
+        )
+        legacy_entities_found = legacy_entities_found or found_legacy_entities
+
+    if legacy_entities_found:
+        create_per_day_forecast_sensors_removed_issue(hass)
+
     for location in runtime.locations.values():
         if filter_stale_locations and location.subentry_id not in active_subentry_ids:
             _LOGGER.debug(
@@ -208,17 +223,6 @@ async def async_setup_entry(
             )
             _LOGGER.warning(message)
             raise ConfigEntryNotReady(message)
-
-        identity_id = coordinator_identity_id(coordinator)
-        found_legacy_entities, _removed_legacy_entities = (
-            await _remove_legacy_per_day_entities(
-                hass,
-                config_entry.entry_id,
-                identity_id,
-            )
-        )
-        if found_legacy_entities:
-            create_per_day_forecast_sensors_removed_issue(hass)
 
         sensors: list[CoordinatorEntity] = []
         for code in data:

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -633,7 +633,7 @@ class DateSensor(_BaseMetaSensor):
         try:
             y, m, d = map(int, date_str.split("-"))
             return date(y, m, d)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             _LOGGER.error("Invalid date format received: %s", date_str)
             return None
 

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -102,7 +102,7 @@ def _overall_forecast_from_type_forecasts(
 ) -> list[dict[str, Any]]:
     """Build aggregated forecast list from current-day type forecast attributes.
 
-    Returns an empty list when there are no future offsets (forecast_days=1).
+    Returns an empty list when there are no future offsets in the payload.
 
     For each future offset, the highest indexed value across all types is used.
     Ties are preserved with deterministic ordering by normalised type code.

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configuració de Nivells de pol·len",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Introdueix la teva clau API de Google ([obtén-la aquí]({api_key_url})) i revisa les bones pràctiques ([bones pràctiques]({restricting_api_keys_url})). Selecciona la ubicació al mapa, l'interval d'actualització (hores) i el codi d'idioma de la resposta de l'API. Pollen Levels sempre sol·licita l'horitzó màxim de previsió de 5 dies.",
         "data": {
           "api_key": "Clau API",
           "name": "Nom",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opcions",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Canvia l'interval d'actualització i l'idioma de l'API per a {title}. Pollen Levels sempre sol·licita l'horitzó màxim de previsió de 5 dies.",
         "data": {
           "update_interval": "Interval d’actualització (hores)",
           "language_code": "Codi d’idioma de la resposta de l’API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha trobat dades d'ubicació emmagatzemades no vàlides per a {entry_title}: {location_title}. Elimina i torna a crear la ubicació afectada, o restaura una còpia de seguretat de Home Assistant anterior a la creació de la ubicació no vàlida."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "S'han eliminat els sensors de previsió per dia",
+      "description": "Pollen Levels ja no crea entitats de previsió separades acabades en _d1 o _d2. Les dades de previsió continuen disponibles als sensors base de pol·len mitjançant els atributs forecast, tomorrow_* i d2_*. Actualitza els taulers, automatitzacions, plantilles i targetes personalitzades que encara facin referència a les entitats antigues."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configuració de Nivells de pol·len",
-        "description": "Introdueix la teva clau API de Google ([aconsegueix-la aquí]({api_key_url})) i revisa les bones pràctiques ([bones pràctiques]({restricting_api_keys_url})). Selecciona la ubicació al mapa, l’interval d’actualització (hores) i el codi d’idioma de la resposta de l’API. També pots definir els dies de previsió i l'abast dels sensors per dia (TIPUS).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Clau API",
           "name": "Nom",
           "location": "Ubicació",
           "update_interval": "Interval d’actualització (hores)",
-          "language_code": "Codi d’idioma de la resposta de l’API",
-          "forecast_days": "Dies de previsió (1–5)",
-          "create_forecast_sensors": "Abast dels sensors per dia (TIPUS)"
+          "language_code": "Codi d’idioma de la resposta de l’API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Quota excedida\n\n{error_message}",
       "invalid_language_format": "Utilitza un codi BCP-47 canònic com \"en\" o \"es-ES\".",
       "empty": "Aquest camp no pot estar buit",
-      "invalid_option_combo": "Augmenta els 'Dies de previsió' per cobrir els sensors per dia seleccionats.",
       "invalid_coordinates": "Selecciona una ubicació vàlida al mapa.",
       "unknown": "Error desconegut",
       "invalid_update_interval": "L’interval d’actualització ha d’estar entre 1 i 24 hores.",
-      "invalid_forecast_days": "Els dies de previsió han d’estar entre 1 i 5.",
       "already_configured": "Aquesta ubicació ja està configurada.",
       "api_key_already_configured": "Aquesta clau API ja està configurada."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opcions",
-        "description": "Canvia l’interval d’actualització, l’idioma de resposta de l’API, els dies de previsió i els sensors per dia per a {title}.\nOpcions de sensors per dia (TIPUS): Només avui (none), Fins demà (D+1), Fins demà passat (D+2; crea tant els sensors D+1 com D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Interval d’actualització (hores)",
-          "language_code": "Codi d’idioma de la resposta de l’API",
-          "forecast_days": "Dies de previsió (1–5)",
-          "create_forecast_sensors": "Abast dels sensors per dia (TIPUS)"
+          "language_code": "Codi d’idioma de la resposta de l’API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Utilitza un codi BCP-47 canònic com \"en\" o \"es-ES\".",
-      "empty": "Aquest camp no pot estar buit",
-      "invalid_option_combo": "Augmenta els 'Dies de previsió' per cobrir els sensors per dia seleccionats.",
       "unknown": "Error desconegut",
-      "invalid_update_interval": "L’interval d’actualització ha d’estar entre 1 i 24 hores.",
-      "invalid_forecast_days": "Els dies de previsió han d’estar entre 1 i 5."
+      "invalid_update_interval": "L’interval d’actualització ha d’estar entre 1 i 24 hores."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ubicació emmagatzemada no vàlida a Pollen Levels",
       "description": "Pollen Levels ha trobat dades d'ubicació emmagatzemades no vàlides per a {entry_title}: {location_title}. Elimina i torna a crear la ubicació afectada, o restaura una còpia de seguretat de Home Assistant anterior a la creació de la ubicació no vàlida."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Konfigurace úrovní pylu",
-        "description": "Zadejte svůj Google API klíč ([získejte jej zde]({api_key_url})) a přečtěte si doporučené postupy ([doporučené postupy]({restricting_api_keys_url})). Vyberte polohu na mapě, interval aktualizace (v hodinách) a jazykový kód odpovědi API. Můžete také nastavit dny předpovědi a rozsah senzorů po dnech (TYPY).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Klíč API",
           "name": "Název",
           "location": "Poloha",
           "update_interval": "Interval aktualizace (hodiny)",
-          "language_code": "Kód jazyka odpovědi API",
-          "forecast_days": "Dny předpovědi (1–5)",
-          "create_forecast_sensors": "Rozsah senzorů po dnech (TYPY)"
+          "language_code": "Kód jazyka odpovědi API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Překročena kvóta\n\n{error_message}",
       "invalid_language_format": "Použijte kanonický kód BCP-47, například \"en\" nebo \"es-ES\".",
       "empty": "Toto pole nemůže být prázdné",
-      "invalid_option_combo": "Zvyšte „Dny předpovědi“, aby pokryly vybrané senzory po dnech.",
       "invalid_coordinates": "Vyberte platné umístění na mapě.",
       "unknown": "Neznámá chyba",
       "invalid_update_interval": "Interval aktualizace musí být mezi 1 a 24 hodinami.",
-      "invalid_forecast_days": "Dny předpovědi musí být v rozmezí 1–5.",
       "already_configured": "Toto umístění je již nakonfigurováno.",
       "api_key_already_configured": "Tento klíč API je již nakonfigurován."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Možnosti",
-        "description": "Změňte interval aktualizace, jazyk API, dny předpovědi a senzory po dnech pro {title}.\nMožnosti senzorů po dnech (TYPY): Pouze dnes (none), Do zítra (D+1), Do pozítří (D+2; vytvoří senzory D+1 i D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Interval aktualizace (hodiny)",
-          "language_code": "Kód jazyka odpovědi API",
-          "forecast_days": "Dny předpovědi (1–5)",
-          "create_forecast_sensors": "Rozsah senzorů po dnech (TYPY)"
+          "language_code": "Kód jazyka odpovědi API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Použijte kanonický kód BCP-47, například \"en\" nebo \"es-ES\".",
-      "empty": "Toto pole nemůže být prázdné",
-      "invalid_option_combo": "Zvyšte „Dny předpovědi“, aby pokryly vybrané senzory po dnech.",
       "unknown": "Neznámá chyba",
-      "invalid_update_interval": "Interval aktualizace musí být mezi 1 a 24 hodinami.",
-      "invalid_forecast_days": "Dny předpovědi musí být v rozmezí 1–5."
+      "invalid_update_interval": "Interval aktualizace musí být mezi 1 a 24 hodinami."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Neplatná uložená lokalita Pollen Levels",
       "description": "Pollen Levels našel neplatná uložená data lokality pro {entry_title}: {location_title}. Odstraňte a znovu vytvořte dotčenou lokalitu nebo obnovte zálohu Home Assistant z doby před vytvořením neplatné lokality."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfigurace úrovní pylu",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Zadejte svůj klíč Google API Key ([získat zde]({api_key_url})) a projděte si doporučené postupy ([doporučené postupy]({restricting_api_keys_url})). Vyberte polohu na mapě, interval aktualizace (v hodinách) a jazykový kód odpovědi API. Pollen Levels vždy požaduje maximální 5denní horizont předpovědi.",
         "data": {
           "api_key": "Klíč API",
           "name": "Název",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Možnosti",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Změňte interval aktualizace a jazyk API pro {title}. Pollen Levels vždy požaduje maximální 5denní horizont předpovědi.",
         "data": {
           "update_interval": "Interval aktualizace (hodiny)",
           "language_code": "Kód jazyka odpovědi API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels našel neplatná uložená data lokality pro {entry_title}: {location_title}. Odstraňte a znovu vytvořte dotčenou lokalitu nebo obnovte zálohu Home Assistant z doby před vytvořením neplatné lokality."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Senzory denní předpovědi byly odstraněny",
+      "description": "Pollen Levels již nevytváří samostatné entity předpovědi končící na _d1 nebo _d2. Data předpovědi jsou stále dostupná u základních pylových senzorů prostřednictvím atributů forecast, tomorrow_* a d2_*. Aktualizujte nástěnky, automatizace, šablony a vlastní karty, které stále odkazují na staré entity."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Konfiguration af pollenniveauer",
-        "description": "Indtast din Google API-nøgle ([hent den her]({api_key_url})) og læs bedste praksis ([bedste praksis]({restricting_api_keys_url})). Vælg din placering på kortet, opdateringsinterval (timer) og sprogkode for API-svaret. Du kan også angive prognosedage og omfanget af sensorer pr. dag (TYPER).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-nøgle",
           "name": "Navn",
           "location": "Placering",
           "update_interval": "Opdateringsinterval (timer)",
-          "language_code": "Sprogkode for API-svar",
-          "forecast_days": "Prognosedage (1–5)",
-          "create_forecast_sensors": "Omfang af sensorer pr. dag (TYPER)"
+          "language_code": "Sprogkode for API-svar"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kvote overskredet\n\n{error_message}",
       "invalid_language_format": "Brug en kanonisk BCP-47-kode som \"en\" eller \"es-ES\".",
       "empty": "Dette felt må ikke være tomt",
-      "invalid_option_combo": "Forøg \"Prognosedage\" for at dække valgte sensorer pr. dag.",
       "invalid_coordinates": "Vælg en gyldig placering på kortet.",
       "unknown": "Ukendt fejl",
       "invalid_update_interval": "Opdateringsintervallet skal være mellem 1 og 24 timer.",
-      "invalid_forecast_days": "Prognosedage skal være mellem 1 og 5.",
       "already_configured": "Denne placering er allerede konfigureret.",
       "api_key_already_configured": "Denne API-nøgle er allerede konfigureret."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Indstillinger",
-        "description": "Skift opdateringsinterval, API-sprog, prognosedage og sensorer pr. dag for {title}.\nIndstillinger for sensorer pr. dag (TYPER): Kun i dag (none), Til og med i morgen (D+1), Til og med overmorgen (D+2; opretter både D+1- og D+2-sensorer).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Opdateringsinterval (timer)",
-          "language_code": "Sprogkode for API-svar",
-          "forecast_days": "Prognosedage (1–5)",
-          "create_forecast_sensors": "Omfang af sensorer pr. dag (TYPER)"
+          "language_code": "Sprogkode for API-svar"
         }
       }
     },
     "error": {
       "invalid_language_format": "Brug en kanonisk BCP-47-kode som \"en\" eller \"es-ES\".",
-      "empty": "Dette felt må ikke være tomt",
-      "invalid_option_combo": "Forøg \"Prognosedage\" for at dække valgte sensorer pr. dag.",
       "unknown": "Ukendt fejl",
-      "invalid_update_interval": "Opdateringsintervallet skal være mellem 1 og 24 timer.",
-      "invalid_forecast_days": "Prognosedage skal være mellem 1 og 5."
+      "invalid_update_interval": "Opdateringsintervallet skal være mellem 1 og 24 timer."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ugyldig gemt Pollen Levels-placering",
       "description": "Pollen Levels fandt ugyldige gemte placeringsdata for {entry_title}: {location_title}. Slet og opret den berørte placering igen, eller gendan en Home Assistant-sikkerhedskopi før den ugyldige placering blev oprettet."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguration af pollenniveauer",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Indtast din Google API Key ([hent den her]({api_key_url})) og gennemgå anbefalet praksis ([anbefalet praksis]({restricting_api_keys_url})). Vælg din placering på kortet, opdateringsinterval (timer) og sprogkode for API-svaret. Pollen Levels anmoder altid om den maksimale prognosehorisont på 5 dage.",
         "data": {
           "api_key": "API-nøgle",
           "name": "Navn",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Indstillinger",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Skift opdateringsinterval og API-sprog for {title}. Pollen Levels anmoder altid om den maksimale prognosehorisont på 5 dage.",
         "data": {
           "update_interval": "Opdateringsinterval (timer)",
           "language_code": "Sprogkode for API-svar"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels fandt ugyldige gemte placeringsdata for {entry_title}: {location_title}. Slet og opret den berørte placering igen, eller gendan en Home Assistant-sikkerhedskopi før den ugyldige placering blev oprettet."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Prognosesensorer pr. dag blev fjernet",
+      "description": "Pollen Levels opretter ikke længere separate prognoseenheder, der slutter på _d1 eller _d2. Prognosedata er stadig tilgængelige på de grundlæggende pollensensorer via attributterne forecast, tomorrow_* og d2_*. Opdater dashboards, automatiseringer, skabeloner og brugerdefinerede kort, der stadig henviser til de gamle enheder."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Konfiguration",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Gib deinen Google API Key ein ([hier erhalten]({api_key_url})) und prüfe die Best Practices ([Best Practices]({restricting_api_keys_url})). Wähle den Standort auf der Karte, das Aktualisierungsintervall (Stunden) und den Sprachcode für die API-Antwort. Pollen Levels fordert immer den maximalen 5-Tage-Vorhersagezeitraum an.",
         "data": {
           "api_key": "API-Schlüssel",
           "name": "Name",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Optionen",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Ändere das Aktualisierungsintervall und die API-Sprache für {title}. Pollen Levels fordert immer den maximalen 5-Tage-Vorhersagezeitraum an.",
         "data": {
           "update_interval": "Aktualisierungsintervall (Stunden)",
           "language_code": "Sprachcode für die API-Antwort"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels hat ungültige gespeicherte Standortdaten für {entry_title}: {location_title} gefunden. Löschen und erstellen Sie den betroffenen Standort neu oder stellen Sie ein Home Assistant-Backup von vor der Erstellung des ungültigen Standorts wieder her."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Vorhersagesensoren pro Tag wurden entfernt",
+      "description": "Pollen Levels erstellt keine separaten Vorhersage-Entitäten mit der Endung _d1 oder _d2 mehr. Vorhersagedaten bleiben über die Attribute forecast, tomorrow_* und d2_* auf den Basis-Pollensensoren verfügbar. Aktualisiere Dashboards, Automationen, Vorlagen und benutzerdefinierte Karten, die noch auf die alten Entitäten verweisen."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Konfiguration",
-        "description": "Gib deinen Google API-Schlüssel ein ([hier abrufen]({api_key_url})) und lies die Best Practices ([Best Practices]({restricting_api_keys_url})). Wähle deinen Standort auf der Karte, das Aktualisierungsintervall (Stunden) und den Sprachcode der API-Antwort. Sie können auch Vorhersagetage und den Umfang der Tagessensoren (TYPEN) festlegen.",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-Schlüssel",
           "name": "Name",
           "location": "Standort",
           "update_interval": "Aktualisierungsintervall (Stunden)",
-          "language_code": "Sprachcode für die API-Antwort",
-          "forecast_days": "Vorhersagetage (1–5)",
-          "create_forecast_sensors": "Bereich der Tagessensoren (TYPEN)"
+          "language_code": "Sprachcode für die API-Antwort"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kontingent überschritten\n\n{error_message}",
       "invalid_language_format": "Verwenden Sie einen kanonischen BCP-47-Code wie \"en\" oder \"es-ES\".",
       "empty": "Dieses Feld darf nicht leer sein",
-      "invalid_option_combo": "Erhöhe 'Vorhersagetage', um die gewählten Tagessensoren abzudecken.",
       "invalid_coordinates": "Wähle einen gültigen Standort auf der Karte aus.",
       "unknown": "Unbekannter Fehler",
       "invalid_update_interval": "Das Aktualisierungsintervall muss zwischen 1 und 24 Stunden liegen.",
-      "invalid_forecast_days": "Vorhersagetage müssen zwischen 1 und 5 liegen.",
       "already_configured": "Dieser Standort ist bereits konfiguriert.",
       "api_key_already_configured": "Dieser API-Schlüssel ist bereits konfiguriert."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Optionen",
-        "description": "Ändere Aktualisierungsintervall, API-Sprache, Vorhersagetage und Tagessensoren für {title}.\nOptionen für Tagessensoren (TYPEN): Nur heute (none), Bis morgen (D+1), Bis übermorgen (D+2; erstellt sowohl D+1- als auch D+2-Sensoren).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Aktualisierungsintervall (Stunden)",
-          "language_code": "Sprachcode für die API-Antwort",
-          "forecast_days": "Vorhersagetage (1–5)",
-          "create_forecast_sensors": "Bereich der Tagessensoren (TYPEN)"
+          "language_code": "Sprachcode für die API-Antwort"
         }
       }
     },
     "error": {
       "invalid_language_format": "Verwenden Sie einen kanonischen BCP-47-Code wie \"en\" oder \"es-ES\".",
-      "empty": "Dieses Feld darf nicht leer sein",
-      "invalid_option_combo": "Erhöhe 'Vorhersagetage', um die gewählten Tagessensoren abzudecken.",
       "unknown": "Unbekannter Fehler",
-      "invalid_update_interval": "Das Aktualisierungsintervall muss zwischen 1 und 24 Stunden liegen.",
-      "invalid_forecast_days": "Vorhersagetage müssen zwischen 1 und 5 liegen."
+      "invalid_update_interval": "Das Aktualisierungsintervall muss zwischen 1 und 24 Stunden liegen."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ungültiger gespeicherter Pollen Levels-Standort",
       "description": "Pollen Levels hat ungültige gespeicherte Standortdaten für {entry_title}: {location_title} gefunden. Löschen und erstellen Sie den betroffenen Standort neu oder stellen Sie ein Home Assistant-Backup von vor der Erstellung des ungültigen Standorts wieder her."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Pollen Levels Configuration",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. You can also set forecast days and per-day TYPE sensor range.",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API Key",
           "name": "Name",
           "location": "Location",
           "update_interval": "Update interval (hours)",
-          "language_code": "API response language code",
-          "forecast_days": "Forecast days (1–5)",
-          "create_forecast_sensors": "Per-day TYPE sensors range"
+          "language_code": "API response language code"
         }
       },
       "reauth_confirm": {
@@ -37,11 +35,9 @@
       "quota_exceeded": "Quota exceeded\n\n{error_message}",
       "invalid_language_format": "Use a canonical BCP-47 code such as \"en\" or \"es-ES\".",
       "empty": "This field cannot be empty",
-      "invalid_option_combo": "Increase 'Forecast days' to cover selected per-day sensors.",
       "invalid_coordinates": "Please select a valid location on the map.",
       "unknown": "Unknown error",
-      "invalid_update_interval": "Update interval must be between 1 and 24 hours.",
-      "invalid_forecast_days": "Forecast days must be between 1 and 5."
+      "invalid_update_interval": "Update interval must be between 1 and 24 hours."
     },
     "abort": {
       "already_configured": "This location is already configured.",
@@ -94,22 +90,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Options",
-        "description": "Change the update interval, API language, forecast days and per-day TYPE sensors for {title}.\nOptions for per-day TYPE sensors: Only today (none), Through tomorrow (D+1), Through day after tomorrow (D+2; creates both D+1 and D+2 sensors).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Update interval (hours)",
-          "language_code": "API response language code",
-          "forecast_days": "Forecast days (1–5)",
-          "create_forecast_sensors": "Per-day TYPE sensors range"
+          "language_code": "API response language code"
         }
       }
     },
     "error": {
       "invalid_language_format": "Use a canonical BCP-47 code such as \"en\" or \"es-ES\".",
-      "empty": "This field cannot be empty",
-      "invalid_option_combo": "Increase 'Forecast days' to cover selected per-day sensors.",
       "unknown": "Unknown error",
-      "invalid_update_interval": "Update interval must be between 1 and 24 hours.",
-      "invalid_forecast_days": "Forecast days must be between 1 and 5."
+      "invalid_update_interval": "Update interval must be between 1 and 24 hours."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Invalid stored Pollen Levels location",
       "description": "Pollen Levels found invalid stored location data for {entry_title}: {location_title}. Delete and recreate the affected location, or restore a Home Assistant backup from before the invalid location was created."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configuración de Niveles de Polen",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Introduce tu Google API Key ([consíguela aquí]({api_key_url})) y revisa las prácticas recomendadas ([prácticas recomendadas]({restricting_api_keys_url})). Selecciona tu ubicación en el mapa, el intervalo de actualización (horas) y el código de idioma de la respuesta de la API. Pollen Levels siempre solicita el horizonte máximo de previsión de 5 días.",
         "data": {
           "api_key": "Clave API",
           "name": "Nombre",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opciones",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Cambia el intervalo de actualización y el idioma de la API para {title}. Pollen Levels siempre solicita el horizonte máximo de previsión de 5 días.",
         "data": {
           "update_interval": "Intervalo de actualización (horas)",
           "language_code": "Código de idioma de la respuesta de la API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha encontrado datos de ubicación almacenados inválidos para {entry_title}: {location_title}. Elimina y vuelve a crear la ubicación afectada, o restaura una copia de seguridad de Home Assistant anterior a la creación de la ubicación inválida."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Se han eliminado los sensores de previsión por día",
+      "description": "Pollen Levels ya no crea entidades de previsión separadas que terminan en _d1 o _d2. Los datos de previsión siguen disponibles en los sensores base de polen mediante los atributos forecast, tomorrow_* y d2_*. Actualiza los paneles, automatizaciones, plantillas y tarjetas personalizadas que todavía hagan referencia a las entidades antiguas."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configuración de Niveles de Polen",
-        "description": "Introduce tu clave API de Google ([consíguela aquí]({api_key_url})) y revisa las buenas prácticas ([buenas prácticas]({restricting_api_keys_url})). Selecciona tu ubicación en el mapa, el intervalo de actualización (horas) y el código de idioma de la respuesta de la API. También puedes configurar los días de previsión y el alcance de los sensores por día (TIPOS).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Clave API",
           "name": "Nombre",
           "location": "Ubicación",
           "update_interval": "Intervalo de actualización (horas)",
-          "language_code": "Código de idioma de la respuesta de la API",
-          "forecast_days": "Días de previsión (1–5)",
-          "create_forecast_sensors": "Alcance de sensores por día (TIPOS)"
+          "language_code": "Código de idioma de la respuesta de la API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Cuota excedida\n\n{error_message}",
       "invalid_language_format": "Usa un código BCP-47 canónico como \"en\" o \"es-ES\".",
       "empty": "Este campo no puede estar vacío",
-      "invalid_option_combo": "Aumenta 'Días de previsión' para cubrir los sensores por día seleccionados.",
       "invalid_coordinates": "Selecciona una ubicación válida en el mapa.",
       "unknown": "Error desconocido",
       "invalid_update_interval": "El intervalo de actualización debe estar entre 1 y 24 horas.",
-      "invalid_forecast_days": "Los días de previsión deben estar entre 1 y 5.",
       "already_configured": "Esta ubicación ya está configurada.",
       "api_key_already_configured": "Esta clave API ya está configurada."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opciones",
-        "description": "Cambia el intervalo de actualización, el idioma de respuesta de la API, los días de previsión y los sensores por día para {title}.\nOpciones de sensores por día (TIPOS): Solo hoy (none), Hasta mañana (D+1), Hasta pasado mañana (D+2; crea sensores D+1 y D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Intervalo de actualización (horas)",
-          "language_code": "Código de idioma de la respuesta de la API",
-          "forecast_days": "Días de previsión (1–5)",
-          "create_forecast_sensors": "Alcance de sensores por día (TIPOS)"
+          "language_code": "Código de idioma de la respuesta de la API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Usa un código BCP-47 canónico como \"en\" o \"es-ES\".",
-      "empty": "Este campo no puede estar vacío",
-      "invalid_option_combo": "Aumenta 'Días de previsión' para cubrir los sensores por día seleccionados.",
       "unknown": "Error desconocido",
-      "invalid_update_interval": "El intervalo de actualización debe estar entre 1 y 24 horas.",
-      "invalid_forecast_days": "Los días de previsión deben estar entre 1 y 5."
+      "invalid_update_interval": "El intervalo de actualización debe estar entre 1 y 24 horas."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ubicación almacenada inválida en Pollen Levels",
       "description": "Pollen Levels ha encontrado datos de ubicación almacenados inválidos para {entry_title}: {location_title}. Elimina y vuelve a crear la ubicación afectada, o restaura una copia de seguridad de Home Assistant anterior a la creación de la ubicación inválida."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Siitepölytason asetukset",
-        "description": "Syötä Google API -avaimesi ([hanki se täältä]({api_key_url})) ja tutustu parhaisiin käytäntöihin ([parhaat käytännöt]({restricting_api_keys_url})). Valitse sijainti kartalta, päivitysväli (tunteina) ja API-vastauksen kielikoodi. Voit myös määrittää ennustepäivät ja päiväsensorien laajuuden (TYYPIT).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-avain",
           "name": "Nimi",
           "location": "Sijainti",
           "update_interval": "Päivitysväli (tunnit)",
-          "language_code": "API-vastauksen kielikoodi",
-          "forecast_days": "Ennustepäivät (1–5)",
-          "create_forecast_sensors": "Päiväsensorien laajuus (TYYPIT)"
+          "language_code": "API-vastauksen kielikoodi"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kiintiö ylitetty\n\n{error_message}",
       "invalid_language_format": "Käytä kanonista BCP-47-koodia, esimerkiksi \"en\" tai \"es-ES\".",
       "empty": "Tämä kenttä ei voi olla tyhjä",
-      "invalid_option_combo": "Lisää \"Ennustepäiviä\", jotta valitut päiväsensorit katetaan.",
       "invalid_coordinates": "Valitse kartalta kelvollinen sijainti.",
       "unknown": "Tuntematon virhe",
       "invalid_update_interval": "Päivitysvälin on oltava 1–24 tuntia.",
-      "invalid_forecast_days": "Ennustepäivien on oltava välillä 1–5.",
       "already_configured": "Tämä sijainti on jo määritetty.",
       "api_key_already_configured": "Tämä API-avain on jo määritetty."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Asetukset",
-        "description": "Muuta päivitysväliä, API-kieltä, ennustepäiviä ja päiväsensoreita TYYPEILLE kohteelle {title}.\nPäiväsensorien vaihtoehdot (TYYPIT): Vain tänään (none), Huomiseen asti (D+1), Ylihuomiseen asti (D+2; luo sekä D+1- että D+2-sensorit).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Päivitysväli (tunnit)",
-          "language_code": "API-vastauksen kielikoodi",
-          "forecast_days": "Ennustepäivät (1–5)",
-          "create_forecast_sensors": "Päiväsensorien laajuus (TYYPIT)"
+          "language_code": "API-vastauksen kielikoodi"
         }
       }
     },
     "error": {
       "invalid_language_format": "Käytä kanonista BCP-47-koodia, esimerkiksi \"en\" tai \"es-ES\".",
-      "empty": "Tämä kenttä ei voi olla tyhjä",
-      "invalid_option_combo": "Lisää \"Ennustepäiviä\", jotta valitut päiväsensorit katetaan.",
       "unknown": "Tuntematon virhe",
-      "invalid_update_interval": "Päivitysvälin on oltava 1–24 tuntia.",
-      "invalid_forecast_days": "Ennustepäivien on oltava välillä 1–5."
+      "invalid_update_interval": "Päivitysvälin on oltava 1–24 tuntia."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Virheellinen tallennettu Pollen Levels -sijainti",
       "description": "Pollen Levels löysi virheellisiä tallennettuja sijaintitietoja kohteelle {entry_title}: {location_title}. Poista ja luo kyseinen sijainti uudelleen tai palauta Home Assistant -varmuuskopio ajalta ennen virheellisen sijainnin luomista."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Siitepölytason asetukset",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Anna Google API Key ([hanki se täältä]({api_key_url})) ja tarkista parhaat käytännöt ([parhaat käytännöt]({restricting_api_keys_url})). Valitse sijainti kartalta, päivitysväli (tunteina) ja API-vastauksen kielikoodi. Pollen Levels pyytää aina enimmäismäärän eli 5 päivän ennustehorisontin.",
         "data": {
           "api_key": "API-avain",
           "name": "Nimi",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Asetukset",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Muuta kohteen {title} päivitysväliä ja API-kieltä. Pollen Levels pyytää aina enimmäismäärän eli 5 päivän ennustehorisontin.",
         "data": {
           "update_interval": "Päivitysväli (tunnit)",
           "language_code": "API-vastauksen kielikoodi"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels löysi virheellisiä tallennettuja sijaintitietoja kohteelle {entry_title}: {location_title}. Poista ja luo kyseinen sijainti uudelleen tai palauta Home Assistant -varmuuskopio ajalta ennen virheellisen sijainnin luomista."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Päiväkohtaiset ennustesensorit poistettiin",
+      "description": "Pollen Levels ei enää luo erillisiä ennuste-entiteettejä, joiden loppu on _d1 tai _d2. Ennustetiedot ovat edelleen saatavilla perussiitepölysensoreissa attribuuttien forecast, tomorrow_* ja d2_* kautta. Päivitä koontinäytöt, automaatiot, mallit ja mukautetut kortit, jotka viittaavat vielä vanhoihin entiteetteihin."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Configuration",
-        "description": "Saisissez votre clé API Google ([l’obtenir ici]({api_key_url})) et consultez les bonnes pratiques ([bonnes pratiques]({restricting_api_keys_url})). Sélectionnez votre emplacement sur la carte, l’intervalle de mise à jour (heures) et le code de langue de la réponse de l’API. Vous pouvez aussi définir les jours de prévision et la portée des capteurs par jour (TYPES).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Clé API",
           "name": "Nom",
           "location": "Emplacement",
           "update_interval": "Intervalle de mise à jour (heures)",
-          "language_code": "Code de langue pour la réponse de l’API",
-          "forecast_days": "Jours de prévision (1–5)",
-          "create_forecast_sensors": "Portée des capteurs par jour (TYPES)"
+          "language_code": "Code de langue pour la réponse de l’API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Quota dépassé\n\n{error_message}",
       "invalid_language_format": "Utilisez un code BCP-47 canonique tel que \"en\" ou \"es-ES\".",
       "empty": "Ce champ ne peut pas être vide",
-      "invalid_option_combo": "Augmentez le nombre de « Jours de prévision » afin de couvrir les capteurs par jour sélectionnés.",
       "invalid_coordinates": "Sélectionnez un emplacement valide sur la carte.",
       "unknown": "Erreur inconnue",
       "invalid_update_interval": "L’intervalle de mise à jour doit être compris entre 1 et 24 heures.",
-      "invalid_forecast_days": "Les jours de prévision doivent être compris entre 1 et 5.",
       "already_configured": "Cet emplacement est déjà configuré.",
       "api_key_already_configured": "Cette clé API est déjà configurée."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Options",
-        "description": "Modifiez l’intervalle de mise à jour, la langue de l’API, les jours de prévision et les capteurs par jour pour {title}.\nOptions des capteurs par jour (TYPES) : Aujourd’hui uniquement (none), Jusqu’à demain (D+1), Jusqu’au surlendemain (D+2 ; crée les capteurs D+1 et D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Intervalle de mise à jour (heures)",
-          "language_code": "Code de langue pour la réponse de l’API",
-          "forecast_days": "Jours de prévision (1–5)",
-          "create_forecast_sensors": "Portée des capteurs par jour (TYPES)"
+          "language_code": "Code de langue pour la réponse de l’API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Utilisez un code BCP-47 canonique tel que \"en\" ou \"es-ES\".",
-      "empty": "Ce champ ne peut pas être vide",
-      "invalid_option_combo": "Augmentez le nombre de « Jours de prévision » afin de couvrir les capteurs par jour sélectionnés.",
       "unknown": "Erreur inconnue",
-      "invalid_update_interval": "L’intervalle de mise à jour doit être compris entre 1 et 24 heures.",
-      "invalid_forecast_days": "Les jours de prévision doivent être compris entre 1 et 5."
+      "invalid_update_interval": "L’intervalle de mise à jour doit être compris entre 1 et 24 heures."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Emplacement stocké invalide dans Pollen Levels",
       "description": "Pollen Levels a trouvé des données de localisation stockées invalides pour {entry_title} : {location_title}. Supprimez et recréez l'emplacement concerné, ou restaurez une sauvegarde Home Assistant antérieure à la création de l'emplacement invalide."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Configuration",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Saisissez votre Google API Key ([l’obtenir ici]({api_key_url})) et consultez les bonnes pratiques ([bonnes pratiques]({restricting_api_keys_url})). Sélectionnez votre emplacement sur la carte, l’intervalle de mise à jour (heures) et le code de langue de la réponse API. Pollen Levels demande toujours l’horizon de prévision maximal de 5 jours.",
         "data": {
           "api_key": "Clé API",
           "name": "Nom",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Options",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Modifiez l’intervalle de mise à jour et la langue de l’API pour {title}. Pollen Levels demande toujours l’horizon de prévision maximal de 5 jours.",
         "data": {
           "update_interval": "Intervalle de mise à jour (heures)",
           "language_code": "Code de langue pour la réponse de l’API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels a trouvé des données de localisation stockées invalides pour {entry_title} : {location_title}. Supprimez et recréez l'emplacement concerné, ou restaurez une sauvegarde Home Assistant antérieure à la création de l'emplacement invalide."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Les capteurs de prévision par jour ont été supprimés",
+      "description": "Pollen Levels ne crée plus d’entités de prévision séparées se terminant par _d1 ou _d2. Les données de prévision restent disponibles sur les capteurs de pollen de base via les attributs forecast, tomorrow_* et d2_*. Mettez à jour les tableaux de bord, automatisations, modèles et cartes personnalisées qui font encore référence aux anciennes entités."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Pollen szintek – beállítás",
-        "description": "Add meg a Google API-kulcsodat ([itt szerezhető be]({api_key_url})) és nézd át a bevált gyakorlatokat ([bevált gyakorlatok]({restricting_api_keys_url})). Válaszd ki a helyszínt a térképen, a frissítési időközt (órában) és az API-válasz nyelvi kódját. Beállíthatod az előrejelzési napokat és a napi szenzorok tartományát (TÍPUSOK).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-kulcs",
           "name": "Név",
           "location": "Helyszín",
           "update_interval": "Frissítési időköz (óra)",
-          "language_code": "API-válasz nyelvi kódja",
-          "forecast_days": "Előrejelzési napok (1–5)",
-          "create_forecast_sensors": "Napi TÍPUS szenzorok tartománya"
+          "language_code": "API-válasz nyelvi kódja"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kvóta túllépve\n\n{error_message}",
       "invalid_language_format": "Használjon kanonikus BCP-47 kódot, például \"en\" vagy \"es-ES\".",
       "empty": "A mező nem lehet üres",
-      "invalid_option_combo": "Növeld a \"Előrejelzési napok\" értéket a kiválasztott napi szenzorok lefedéséhez.",
       "invalid_coordinates": "Válassz érvényes helyet a térképen.",
       "unknown": "Ismeretlen hiba",
       "invalid_update_interval": "A frissítési időköznek 1 és 24 óra között kell lennie.",
-      "invalid_forecast_days": "Az előrejelzési napoknak 1 és 5 között kell lenniük.",
       "already_configured": "Ez a hely már be van állítva.",
       "api_key_already_configured": "Ez az API-kulcs már be van állítva."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Beállítások",
-        "description": "Módosítsd a frissítési időközt, az API nyelvét, az előrejelzési napokat és a napi TÍPUS szenzorokat a(z) {title} bejegyzéshez.\nNapi TÍPUS szenzorok: Csak ma (none), Holnapig (D+1), Holnaputánig (D+2; létrehozza a D+1 és D+2 szenzorokat is).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Frissítési időköz (óra)",
-          "language_code": "API-válasz nyelvi kódja",
-          "forecast_days": "Előrejelzési napok (1–5)",
-          "create_forecast_sensors": "Napi TÍPUS szenzorok tartománya"
+          "language_code": "API-válasz nyelvi kódja"
         }
       }
     },
     "error": {
       "invalid_language_format": "Használjon kanonikus BCP-47 kódot, például \"en\" vagy \"es-ES\".",
-      "empty": "A mező nem lehet üres",
-      "invalid_option_combo": "Növeld a \"Előrejelzési napok\" értéket a kiválasztott napi szenzorok lefedéséhez.",
       "unknown": "Ismeretlen hiba",
-      "invalid_update_interval": "A frissítési időköznek 1 és 24 óra között kell lennie.",
-      "invalid_forecast_days": "Az előrejelzési napoknak 1 és 5 között kell lenniük."
+      "invalid_update_interval": "A frissítési időköznek 1 és 24 óra között kell lennie."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Érvénytelen tárolt Pollen Levels hely",
       "description": "A Pollen Levels érvénytelen tárolt helyadatokat talált a következőhöz: {entry_title}: {location_title}. Törölje és hozza létre újra az érintett helyet, vagy állítson vissza egy Home Assistant biztonsági mentést az érvénytelen hely létrehozása előtti időből."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Pollen szintek – beállítás",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Add meg a Google API Key értékét ([itt szerezheted be]({api_key_url})), és nézd át a bevált gyakorlatokat ([bevált gyakorlatok]({restricting_api_keys_url})). Válaszd ki a helyet a térképen, a frissítési időközt (órában) és az API-válasz nyelvi kódját. A Pollen Levels mindig a maximális, 5 napos előrejelzési időtávot kéri le.",
         "data": {
           "api_key": "API-kulcs",
           "name": "Név",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Beállítások",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Módosítsd a frissítési időközt és az API nyelvét ehhez: {title}. A Pollen Levels mindig a maximális, 5 napos előrejelzési időtávot kéri le.",
         "data": {
           "update_interval": "Frissítési időköz (óra)",
           "language_code": "API-válasz nyelvi kódja"
@@ -158,8 +158,8 @@
       "description": "A Pollen Levels érvénytelen tárolt helyadatokat talált a következőhöz: {entry_title}: {location_title}. Törölje és hozza létre újra az érintett helyet, vagy állítson vissza egy Home Assistant biztonsági mentést az érvénytelen hely létrehozása előtti időből."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "A napi előrejelzési szenzorok eltávolításra kerültek",
+      "description": "A Pollen Levels már nem hoz létre külön előrejelzési entitásokat _d1 vagy _d2 végződéssel. Az előrejelzési adatok továbbra is elérhetők az alap pollenszenzorokon a forecast, tomorrow_* és d2_* attribútumokon keresztül. Frissítsd azokat az irányítópultokat, automatizálásokat, sablonokat és egyéni kártyákat, amelyek még a régi entitásokra hivatkoznak."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configurazione Livelli di polline",
-        "description": "Inserisci la tua chiave API di Google ([ottienila qui]({api_key_url})) e consulta le best practice ([best practice]({restricting_api_keys_url})). Seleziona la posizione sulla mappa, l’intervallo di aggiornamento (ore) e il codice lingua della risposta dell’API. Puoi anche impostare i giorni di previsione e l'ambito dei sensori per giorno (TIPI).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Chiave API",
           "name": "Nome",
           "location": "Posizione",
           "update_interval": "Intervallo di aggiornamento (ore)",
-          "language_code": "Codice lingua per la risposta dell'API",
-          "forecast_days": "Giorni di previsione (1–5)",
-          "create_forecast_sensors": "Ambito dei sensori per giorno (TIPI)"
+          "language_code": "Codice lingua per la risposta dell'API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Quota superata\n\n{error_message}",
       "invalid_language_format": "Usa un codice BCP-47 canonico come \"en\" o \"es-ES\".",
       "empty": "Questo campo non può essere vuoto",
-      "invalid_option_combo": "Aumenta 'Giorni di previsione' per coprire i sensori giornalieri selezionati.",
       "invalid_coordinates": "Seleziona una posizione valida sulla mappa.",
       "unknown": "Errore sconosciuto",
       "invalid_update_interval": "L’intervallo di aggiornamento deve essere compreso tra 1 e 24 ore.",
-      "invalid_forecast_days": "I giorni di previsione devono essere compresi tra 1 e 5.",
       "already_configured": "Questa posizione è già configurata.",
       "api_key_already_configured": "Questa chiave API è già configurata."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opzioni",
-        "description": "Modifica l’intervallo di aggiornamento, la lingua della risposta dell’API, i giorni di previsione e i sensori giornalieri per i TIPI per {title}.\nOpzioni dei sensori giornalieri (TIPI): Solo oggi (none), Fino a domani (D+1), Fino a dopodomani (D+2; crea sia i sensori D+1 che D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Intervallo di aggiornamento (ore)",
-          "language_code": "Codice lingua per la risposta dell'API",
-          "forecast_days": "Giorni di previsione (1–5)",
-          "create_forecast_sensors": "Ambito dei sensori per giorno (TIPI)"
+          "language_code": "Codice lingua per la risposta dell'API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Usa un codice BCP-47 canonico come \"en\" o \"es-ES\".",
-      "empty": "Questo campo non può essere vuoto",
-      "invalid_option_combo": "Aumenta 'Giorni di previsione' per coprire i sensori giornalieri selezionati.",
       "unknown": "Errore sconosciuto",
-      "invalid_update_interval": "L’intervallo di aggiornamento deve essere compreso tra 1 e 24 ore.",
-      "invalid_forecast_days": "I giorni di previsione devono essere compresi tra 1 e 5."
+      "invalid_update_interval": "L’intervallo di aggiornamento deve essere compreso tra 1 e 24 ore."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Posizione memorizzata non valida in Pollen Levels",
       "description": "Pollen Levels ha trovato dati di posizione memorizzati non validi per {entry_title}: {location_title}. Elimina e ricrea la posizione interessata o ripristina un backup di Home Assistant precedente alla creazione della posizione non valida."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurazione Livelli di polline",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Inserisci la tua Google API Key ([ottienila qui]({api_key_url})) e consulta le buone pratiche ([buone pratiche]({restricting_api_keys_url})). Seleziona la posizione sulla mappa, l’intervallo di aggiornamento (ore) e il codice lingua della risposta API. Pollen Levels richiede sempre l’orizzonte massimo di previsione di 5 giorni.",
         "data": {
           "api_key": "Chiave API",
           "name": "Nome",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opzioni",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Modifica l’intervallo di aggiornamento e la lingua API per {title}. Pollen Levels richiede sempre l’orizzonte massimo di previsione di 5 giorni.",
         "data": {
           "update_interval": "Intervallo di aggiornamento (ore)",
           "language_code": "Codice lingua per la risposta dell'API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha trovato dati di posizione memorizzati non validi per {entry_title}: {location_title}. Elimina e ricrea la posizione interessata o ripristina un backup di Home Assistant precedente alla creazione della posizione non valida."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "I sensori di previsione per giorno sono stati rimossi",
+      "description": "Pollen Levels non crea più entità di previsione separate che terminano con _d1 o _d2. I dati di previsione restano disponibili sui sensori polline di base tramite gli attributi forecast, tomorrow_* e d2_*. Aggiorna dashboard, automazioni, modelli e schede personalizzate che fanno ancora riferimento alle vecchie entità."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfigurasjon av pollennivåer",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Skriv inn din Google API Key ([hent den her]({api_key_url})) og se gjennom anbefalte fremgangsmåter ([anbefalte fremgangsmåter]({restricting_api_keys_url})). Velg plassering på kartet, oppdateringsintervall (timer) og språkkode for API-svaret. Pollen Levels ber alltid om den maksimale prognosehorisonten på 5 dager.",
         "data": {
           "api_key": "API-nøkkel",
           "name": "Navn",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Innstillinger",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Endre oppdateringsintervallet og API-språket for {title}. Pollen Levels ber alltid om den maksimale prognosehorisonten på 5 dager.",
         "data": {
           "update_interval": "Oppdateringsintervall (timer)",
           "language_code": "Språkkode for API-svar"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels fant ugyldige lagrede plasseringsdata for {entry_title}: {location_title}. Slett og opprett den berørte plasseringen på nytt, eller gjenopprett en Home Assistant-sikkerhetskopi fra før den ugyldige plasseringen ble opprettet."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Prognosesensorer per dag ble fjernet",
+      "description": "Pollen Levels oppretter ikke lenger separate prognoseentiteter som slutter på _d1 eller _d2. Prognosedata er fortsatt tilgjengelige på de grunnleggende pollensensorene via attributtene forecast, tomorrow_* og d2_*. Oppdater dashbord, automatiseringer, maler og egendefinerte kort som fortsatt viser til de gamle entitetene."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Konfigurasjon av pollennivåer",
-        "description": "Oppgi Google API-nøkkelen din ([få den her]({api_key_url})) og les beste praksis ([beste praksis]({restricting_api_keys_url})). Velg posisjonen din på kartet, oppdateringsintervallet (timer) og språkkoden for API-svaret. Du kan også angi prognosedager og omfanget av sensorer per dag (TYPER).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-nøkkel",
           "name": "Navn",
           "location": "Posisjon",
           "update_interval": "Oppdateringsintervall (timer)",
-          "language_code": "Språkkode for API-svar",
-          "forecast_days": "Prognosedager (1–5)",
-          "create_forecast_sensors": "Omfang av sensorer per dag (TYPER)"
+          "language_code": "Språkkode for API-svar"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kvote overskredet\n\n{error_message}",
       "invalid_language_format": "Bruk en kanonisk BCP-47-kode som \"en\" eller \"es-ES\".",
       "empty": "Dette feltet kan ikke være tomt",
-      "invalid_option_combo": "Øk «Prognosedager» for å dekke valgte sensorer per dag.",
       "invalid_coordinates": "Velg en gyldig posisjon på kartet.",
       "unknown": "Ukjent feil",
       "invalid_update_interval": "Oppdateringsintervallet må være mellom 1 og 24 timer.",
-      "invalid_forecast_days": "Prognosedager må være mellom 1 og 5.",
       "already_configured": "Denne plasseringen er allerede konfigurert.",
       "api_key_already_configured": "Denne API-nøkkelen er allerede konfigurert."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Innstillinger",
-        "description": "Endre oppdateringsintervall, API-språk, prognosedager og sensorer per dag for {title}.\nAlternativer for sensorer per dag (TYPER): Kun i dag (none), Til og med i morgen (D+1), Til og med i overmorgen (D+2; oppretter både D+1- og D+2-sensorer).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Oppdateringsintervall (timer)",
-          "language_code": "Språkkode for API-svar",
-          "forecast_days": "Prognosedager (1–5)",
-          "create_forecast_sensors": "Omfang av sensorer per dag (TYPER)"
+          "language_code": "Språkkode for API-svar"
         }
       }
     },
     "error": {
       "invalid_language_format": "Bruk en kanonisk BCP-47-kode som \"en\" eller \"es-ES\".",
-      "empty": "Dette feltet kan ikke være tomt",
-      "invalid_option_combo": "Øk «Prognosedager» for å dekke valgte sensorer per dag.",
       "unknown": "Ukjent feil",
-      "invalid_update_interval": "Oppdateringsintervallet må være mellom 1 og 24 timer.",
-      "invalid_forecast_days": "Prognosedager må være mellom 1 og 5."
+      "invalid_update_interval": "Oppdateringsintervallet må være mellom 1 og 24 timer."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ugyldig lagret Pollen Levels-plassering",
       "description": "Pollen Levels fant ugyldige lagrede plasseringsdata for {entry_title}: {location_title}. Slett og opprett den berørte plasseringen på nytt, eller gjenopprett en Home Assistant-sikkerhetskopi fra før den ugyldige plasseringen ble opprettet."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Configuratie",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Voer je Google API Key in ([hier ophalen]({api_key_url})) en bekijk de best practices ([best practices]({restricting_api_keys_url})). Selecteer je locatie op de kaart, het update-interval (uren) en de taalcode voor het API-antwoord. Pollen Levels vraagt altijd de maximale voorspellingsperiode van 5 dagen op.",
         "data": {
           "api_key": "API-sleutel",
           "name": "Naam",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opties",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Wijzig het update-interval en de API-taal voor {title}. Pollen Levels vraagt altijd de maximale voorspellingsperiode van 5 dagen op.",
         "data": {
           "update_interval": "Update-interval (uren)",
           "language_code": "Taalcode voor API-respons"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels heeft ongeldige opgeslagen locatiegegevens gevonden voor {entry_title}: {location_title}. Verwijder en maak de betreffende locatie opnieuw aan, of herstel een Home Assistant-backup van vóór het aanmaken van de ongeldige locatie."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Voorspellingssensoren per dag zijn verwijderd",
+      "description": "Pollen Levels maakt geen afzonderlijke voorspellingsentiteiten meer aan die eindigen op _d1 of _d2. Voorspellingsgegevens blijven beschikbaar op de basispollensensoren via de attributen forecast, tomorrow_* en d2_*. Werk dashboards, automatiseringen, sjablonen en aangepaste kaarten bij die nog naar de oude entiteiten verwijzen."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Pollen Levels – Configuratie",
-        "description": "Voer je Google API-sleutel in ([haal hem hier]({api_key_url})) en bekijk de best practices ([best practices]({restricting_api_keys_url})). Selecteer je locatie op de kaart, het update-interval (uren) en de taalcode van de API-respons. Je kunt ook voorspellingsdagen en het bereik van per-dag TYPE-sensoren instellen.",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-sleutel",
           "name": "Naam",
           "location": "Locatie",
           "update_interval": "Update-interval (uren)",
-          "language_code": "Taalcode voor API-respons",
-          "forecast_days": "Voorspellingsdagen (1–5)",
-          "create_forecast_sensors": "Bereik van per-dag TYPE-sensoren"
+          "language_code": "Taalcode voor API-respons"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Limiet overschreden\n\n{error_message}",
       "invalid_language_format": "Gebruik een canonieke BCP-47-code zoals \"en\" of \"es-ES\".",
       "empty": "Dit veld mag niet leeg zijn",
-      "invalid_option_combo": "Verhoog 'Voorspellingsdagen' om de geselecteerde per-dag sensoren te dekken.",
       "invalid_coordinates": "Selecteer een geldige locatie op de kaart.",
       "unknown": "Onbekende fout",
       "invalid_update_interval": "Het update-interval moet tussen 1 en 24 uur liggen.",
-      "invalid_forecast_days": "Voorspellingsdagen moeten tussen 1 en 5 liggen.",
       "already_configured": "Deze locatie is al geconfigureerd.",
       "api_key_already_configured": "Deze API-sleutel is al geconfigureerd."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opties",
-        "description": "Wijzig het update-interval, de API-taal, het aantal voorspellingsdagen en de per-dag TYPE-sensoren voor {title}.\nOpties voor per-dag TYPE-sensoren: Alleen vandaag (none), Tot en met morgen (D+1), Tot en met overmorgen (D+2; maakt zowel D+1- als D+2-sensoren aan).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Update-interval (uren)",
-          "language_code": "Taalcode voor API-respons",
-          "forecast_days": "Voorspellingsdagen (1–5)",
-          "create_forecast_sensors": "Bereik van per-dag TYPE-sensoren"
+          "language_code": "Taalcode voor API-respons"
         }
       }
     },
     "error": {
       "invalid_language_format": "Gebruik een canonieke BCP-47-code zoals \"en\" of \"es-ES\".",
-      "empty": "Dit veld mag niet leeg zijn",
-      "invalid_option_combo": "Verhoog 'Voorspellingsdagen' om de geselecteerde per-dag sensoren te dekken.",
       "unknown": "Onbekende fout",
-      "invalid_update_interval": "Het update-interval moet tussen 1 en 24 uur liggen.",
-      "invalid_forecast_days": "Voorspellingsdagen moeten tussen 1 en 5 liggen."
+      "invalid_update_interval": "Het update-interval moet tussen 1 en 24 uur liggen."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ongeldige opgeslagen Pollen Levels-locatie",
       "description": "Pollen Levels heeft ongeldige opgeslagen locatiegegevens gevonden voor {entry_title}: {location_title}. Verwijder en maak de betreffende locatie opnieuw aan, of herstel een Home Assistant-backup van vóór het aanmaken van de ongeldige locatie."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguracja poziomów pyłku",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Wprowadź swój Google API Key ([pobierz tutaj]({api_key_url})) i zapoznaj się z dobrymi praktykami ([dobre praktyki]({restricting_api_keys_url})). Wybierz lokalizację na mapie, interwał aktualizacji (godziny) oraz kod języka odpowiedzi API. Pollen Levels zawsze pobiera maksymalny 5-dniowy horyzont prognozy.",
         "data": {
           "api_key": "Klucz API",
           "name": "Nazwa",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opcje",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Zmień interwał aktualizacji i język API dla {title}. Pollen Levels zawsze pobiera maksymalny 5-dniowy horyzont prognozy.",
         "data": {
           "update_interval": "Interwał aktualizacji (godziny)",
           "language_code": "Kod języka odpowiedzi API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels znalazł nieprawidłowe zapisane dane lokalizacji dla {entry_title}: {location_title}. Usuń i utwórz ponownie dotkniętą lokalizację lub przywróć kopię zapasową Home Assistant sprzed utworzenia nieprawidłowej lokalizacji."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Usunięto dzienne sensory prognozy",
+      "description": "Pollen Levels nie tworzy już oddzielnych encji prognozy kończących się na _d1 lub _d2. Dane prognozy nadal są dostępne w podstawowych sensorach pyłków przez atrybuty forecast, tomorrow_* i d2_*. Zaktualizuj pulpity, automatyzacje, szablony i niestandardowe karty, które nadal odwołują się do starych encji."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Konfiguracja poziomów pyłku",
-        "description": "Wprowadź swój klucz Google API ([uzyskaj go tutaj]({api_key_url})) i zapoznaj się z dobrymi praktykami ([dobre praktyki]({restricting_api_keys_url})). Wybierz lokalizację na mapie, interwał aktualizacji (godziny) oraz kod języka odpowiedzi API. Możesz także ustawić dni prognozy oraz zakres czujników dziennych (TYPY).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Klucz API",
           "name": "Nazwa",
           "location": "Lokalizacja",
           "update_interval": "Interwał aktualizacji (godziny)",
-          "language_code": "Kod języka odpowiedzi API",
-          "forecast_days": "Dni prognozy (1–5)",
-          "create_forecast_sensors": "Zakres czujników dziennych (TYPY)"
+          "language_code": "Kod języka odpowiedzi API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Przekroczono limit\n\n{error_message}",
       "invalid_language_format": "Użyj kanonicznego kodu BCP-47, np. \"en\" lub \"es-ES\".",
       "empty": "To pole nie może być puste",
-      "invalid_option_combo": "Zwiększ 'Dni prognozy', aby objąć wybrane czujniki dzienne.",
       "invalid_coordinates": "Wybierz prawidłową lokalizację na mapie.",
       "unknown": "Nieznany błąd",
       "invalid_update_interval": "Interwał aktualizacji musi wynosić od 1 do 24 godzin.",
-      "invalid_forecast_days": "Dni prognozy muszą mieścić się w zakresie 1–5.",
       "already_configured": "Ta lokalizacja jest już skonfigurowana.",
       "api_key_already_configured": "Ten klucz API jest już skonfigurowany."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opcje",
-        "description": "Zmień interwał aktualizacji, język odpowiedzi API, liczbę dni prognozy oraz czujniki dzienne dla TYPÓW dla {title}.\nOpcje czujników dziennych (TYPY): Tylko dziś (none), Do jutra (D+1), Do pojutrza (D+2; tworzy czujniki D+1 i D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Interwał aktualizacji (godziny)",
-          "language_code": "Kod języka odpowiedzi API",
-          "forecast_days": "Dni prognozy (1–5)",
-          "create_forecast_sensors": "Zakres czujników dziennych (TYPY)"
+          "language_code": "Kod języka odpowiedzi API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Użyj kanonicznego kodu BCP-47, np. \"en\" lub \"es-ES\".",
-      "empty": "To pole nie może być puste",
-      "invalid_option_combo": "Zwiększ 'Dni prognozy', aby objąć wybrane czujniki dzienne.",
       "unknown": "Nieznany błąd",
-      "invalid_update_interval": "Interwał aktualizacji musi wynosić od 1 do 24 godzin.",
-      "invalid_forecast_days": "Dni prognozy muszą mieścić się w zakresie 1–5."
+      "invalid_update_interval": "Interwał aktualizacji musi wynosić od 1 do 24 godzin."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Nieprawidłowa zapisana lokalizacja Pollen Levels",
       "description": "Pollen Levels znalazł nieprawidłowe zapisane dane lokalizacji dla {entry_title}: {location_title}. Usuń i utwórz ponownie dotkniętą lokalizację lub przywróć kopię zapasową Home Assistant sprzed utworzenia nieprawidłowej lokalizacji."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configuração dos Níveis de Pólen",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Insira sua Google API Key ([obtenha aqui]({api_key_url})) e revise as práticas recomendadas ([práticas recomendadas]({restricting_api_keys_url})). Selecione sua localização no mapa, o intervalo de atualização (horas) e o código de idioma da resposta da API. Pollen Levels sempre solicita o horizonte máximo de previsão de 5 dias.",
         "data": {
           "api_key": "Chave da API",
           "name": "Nome",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opções",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Altere o intervalo de atualização e o idioma da API para {title}. Pollen Levels sempre solicita o horizonte máximo de previsão de 5 dias.",
         "data": {
           "update_interval": "Intervalo de atualização (horas)",
           "language_code": "Código de idioma da resposta da API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Exclua e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Os sensores de previsão por dia foram removidos",
+      "description": "Pollen Levels não cria mais entidades de previsão separadas terminadas em _d1 ou _d2. Os dados de previsão continuam disponíveis nos sensores base de pólen por meio dos atributos forecast, tomorrow_* e d2_*. Atualize painéis, automações, modelos e cartões personalizados que ainda referenciam as entidades antigas."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configuração dos Níveis de Pólen",
-        "description": "Insira sua chave de API do Google ([obtenha aqui]({api_key_url})) e consulte as melhores práticas ([melhores práticas]({restricting_api_keys_url})). Selecione sua localização no mapa, o intervalo de atualização (horas) e o código de idioma da resposta da API. Você também pode definir os dias de previsão e o escopo dos sensores por dia (TIPOS).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Chave da API",
           "name": "Nome",
           "location": "Localização",
           "update_interval": "Intervalo de atualização (horas)",
-          "language_code": "Código de idioma da resposta da API",
-          "forecast_days": "Dias de previsão (1–5)",
-          "create_forecast_sensors": "Escopo dos sensores por dia (TIPOS)"
+          "language_code": "Código de idioma da resposta da API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Cota excedida\n\n{error_message}",
       "invalid_language_format": "Use um código BCP-47 canônico, como \"en\" ou \"es-ES\".",
       "empty": "Este campo não pode ficar vazio",
-      "invalid_option_combo": "Aumente \"Dias de previsão\" para cobrir os sensores por dia selecionados.",
       "invalid_coordinates": "Selecione um local válido no mapa.",
       "unknown": "Erro desconhecido",
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
-      "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
       "already_configured": "Este local já está configurado.",
       "api_key_already_configured": "Esta chave de API já está configurada."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opções",
-        "description": "Altere o intervalo de atualização, o idioma da API, os dias de previsão e os sensores por dia para {title}.\nOpções de sensores por dia (TIPOS): Apenas hoje (none), Até amanhã (D+1), Até depois de amanhã (D+2; cria sensores D+1 e D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Intervalo de atualização (horas)",
-          "language_code": "Código de idioma da resposta da API",
-          "forecast_days": "Dias de previsão (1–5)",
-          "create_forecast_sensors": "Escopo dos sensores por dia (TIPOS)"
+          "language_code": "Código de idioma da resposta da API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Use um código BCP-47 canônico, como \"en\" ou \"es-ES\".",
-      "empty": "Este campo não pode ficar vazio",
-      "invalid_option_combo": "Aumente \"Dias de previsão\" para cobrir os sensores por dia selecionados.",
       "unknown": "Erro desconhecido",
-      "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
-      "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5."
+      "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Localização armazenada inválida no Pollen Levels",
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Exclua e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configuração dos Níveis de Pólen",
-        "description": "Introduza a sua chave de API do Google ([obtenha-a aqui]({api_key_url})) e reveja as melhores práticas ([melhores práticas]({restricting_api_keys_url})). Selecione a sua localização no mapa, o intervalo de atualização (horas) e o código de idioma da resposta da API. Também pode definir os dias de previsão e o âmbito dos sensores por dia (TIPOS).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Chave da API",
           "name": "Nome",
           "location": "Localização",
           "update_interval": "Intervalo de atualização (horas)",
-          "language_code": "Código de idioma da resposta da API",
-          "forecast_days": "Dias de previsão (1–5)",
-          "create_forecast_sensors": "Âmbito dos sensores por dia (TIPOS)"
+          "language_code": "Código de idioma da resposta da API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Quota excedida\n\n{error_message}",
       "invalid_language_format": "Use um código BCP-47 canónico, como \"en\" ou \"es-ES\".",
       "empty": "Este campo não pode estar vazio",
-      "invalid_option_combo": "Aumente \"Dias de previsão\" para cobrir os sensores por dia selecionados.",
       "invalid_coordinates": "Selecione uma localização válida no mapa.",
       "unknown": "Erro desconhecido",
       "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
-      "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5.",
       "already_configured": "Esta localização já está configurada.",
       "api_key_already_configured": "Esta chave de API já está configurada."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opções",
-        "description": "Altere o intervalo de atualização, o idioma da API, os dias de previsão e os sensores por dia para {title}.\nOpções de sensores por dia (TIPOS): Apenas hoje (none), Até amanhã (D+1), Até depois de amanhã (D+2; cria sensores D+1 e D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Intervalo de atualização (horas)",
-          "language_code": "Código de idioma da resposta da API",
-          "forecast_days": "Dias de previsão (1–5)",
-          "create_forecast_sensors": "Âmbito dos sensores por dia (TIPOS)"
+          "language_code": "Código de idioma da resposta da API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Use um código BCP-47 canónico, como \"en\" ou \"es-ES\".",
-      "empty": "Este campo não pode estar vazio",
-      "invalid_option_combo": "Aumente \"Dias de previsão\" para cobrir os sensores por dia selecionados.",
       "unknown": "Erro desconhecido",
-      "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas.",
-      "invalid_forecast_days": "Os dias de previsão devem estar entre 1 e 5."
+      "invalid_update_interval": "O intervalo de atualização deve estar entre 1 e 24 horas."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Localização armazenada inválida no Pollen Levels",
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Elimine e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configuração dos Níveis de Pólen",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Introduza a sua Google API Key ([obtenha-a aqui]({api_key_url})) e reveja as boas práticas ([boas práticas]({restricting_api_keys_url})). Selecione a localização no mapa, o intervalo de atualização (horas) e o código de idioma da resposta da API. Pollen Levels solicita sempre o horizonte máximo de previsão de 5 dias.",
         "data": {
           "api_key": "Chave da API",
           "name": "Nome",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opções",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Altere o intervalo de atualização e o idioma da API para {title}. Pollen Levels solicita sempre o horizonte máximo de previsão de 5 dias.",
         "data": {
           "update_interval": "Intervalo de atualização (horas)",
           "language_code": "Código de idioma da resposta da API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Elimine e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Os sensores de previsão por dia foram removidos",
+      "description": "Pollen Levels já não cria entidades de previsão separadas terminadas em _d1 ou _d2. Os dados de previsão continuam disponíveis nos sensores base de pólen através dos atributos forecast, tomorrow_* e d2_*. Atualize painéis, automatizações, modelos e cartões personalizados que ainda referenciem as entidades antigas."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Configurare Niveluri de Polen",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Introdu Google API Key ([obține-o aici]({api_key_url})) și consultă bunele practici ([bune practici]({restricting_api_keys_url})). Selectează locația pe hartă, intervalul de actualizare (ore) și codul de limbă al răspunsului API. Pollen Levels solicită întotdeauna orizontul maxim de prognoză de 5 zile.",
         "data": {
           "api_key": "Cheie API",
           "name": "Nume",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opțiuni",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Schimbă intervalul de actualizare și limba API pentru {title}. Pollen Levels solicită întotdeauna orizontul maxim de prognoză de 5 zile.",
         "data": {
           "update_interval": "Interval de actualizare (ore)",
           "language_code": "Codul limbii pentru răspunsul API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels a găsit date de locație stocate invalide pentru {entry_title}: {location_title}. Ștergeți și recreați locația afectată sau restaurați o copie de rezervă Home Assistant dinaintea creării locației invalide."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Senzorii de prognoză pe zi au fost eliminați",
+      "description": "Pollen Levels nu mai creează entități de prognoză separate care se termină în _d1 sau _d2. Datele de prognoză rămân disponibile pe senzorii de polen de bază prin atributele forecast, tomorrow_* și d2_*. Actualizează tablourile de bord, automatizările, șabloanele și cardurile personalizate care încă fac referire la entitățile vechi."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Configurare Niveluri de Polen",
-        "description": "Introdu cheia ta API Google ([obține-o aici]({api_key_url})) și consultă cele mai bune practici ([cele mai bune practici]({restricting_api_keys_url})). Selectează locația pe hartă, intervalul de actualizare (ore) și codul de limbă al răspunsului API. Poți seta și zilele de prognoză și domeniul senzorilor pe zile (TIPURI).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Cheie API",
           "name": "Nume",
           "location": "Locație",
           "update_interval": "Interval de actualizare (ore)",
-          "language_code": "Codul limbii pentru răspunsul API",
-          "forecast_days": "Zile de prognoză (1–5)",
-          "create_forecast_sensors": "Domeniul senzorilor pe zile (TIPURI)"
+          "language_code": "Codul limbii pentru răspunsul API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Cota depășită\n\n{error_message}",
       "invalid_language_format": "Folosiți un cod BCP-47 canonic, de exemplu \"en\" sau \"es-ES\".",
       "empty": "Acest câmp nu poate fi gol",
-      "invalid_option_combo": "Măriți \"Zilele de prognoză\" pentru a acoperi senzorii selectați pe zile.",
       "invalid_coordinates": "Selectează o locație validă pe hartă.",
       "unknown": "Eroare necunoscută",
       "invalid_update_interval": "Intervalul de actualizare trebuie să fie între 1 și 24 de ore.",
-      "invalid_forecast_days": "Zilele de prognoză trebuie să fie între 1 și 5.",
       "already_configured": "Această locație este deja configurată.",
       "api_key_already_configured": "Această cheie API este deja configurată."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Opțiuni",
-        "description": "Modificați intervalul de actualizare, limba API, zilele de prognoză și senzorii pe zile pentru {title}.\nOpțiuni pentru senzorii pe zile (TIPURI): Doar azi (none), Până mâine (D+1), Până poimâine (D+2; creează atât senzori D+1, cât și D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Interval de actualizare (ore)",
-          "language_code": "Codul limbii pentru răspunsul API",
-          "forecast_days": "Zile de prognoză (1–5)",
-          "create_forecast_sensors": "Domeniul senzorilor pe zile (TIPURI)"
+          "language_code": "Codul limbii pentru răspunsul API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Folosiți un cod BCP-47 canonic, de exemplu \"en\" sau \"es-ES\".",
-      "empty": "Acest câmp nu poate fi gol",
-      "invalid_option_combo": "Măriți \"Zilele de prognoză\" pentru a acoperi senzorii selectați pe zile.",
       "unknown": "Eroare necunoscută",
-      "invalid_update_interval": "Intervalul de actualizare trebuie să fie între 1 și 24 de ore.",
-      "invalid_forecast_days": "Zilele de prognoză trebuie să fie între 1 și 5."
+      "invalid_update_interval": "Intervalul de actualizare trebuie să fie între 1 și 24 de ore."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Locație stocată invalidă în Pollen Levels",
       "description": "Pollen Levels a găsit date de locație stocate invalide pentru {entry_title}: {location_title}. Ștergeți și recreați locația afectată sau restaurați o copie de rezervă Home Assistant dinaintea creării locației invalide."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Настройка уровней пыльцы",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Введите свой Google API Key ([получить здесь]({api_key_url})) и ознакомьтесь с рекомендациями ([рекомендации]({restricting_api_keys_url})). Выберите местоположение на карте, интервал обновления (в часах) и код языка ответа API. Pollen Levels всегда запрашивает максимальный 5-дневный горизонт прогноза.",
         "data": {
           "api_key": "Ключ API",
           "name": "Имя",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Параметры",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Измените интервал обновления и язык API для {title}. Pollen Levels всегда запрашивает максимальный 5-дневный горизонт прогноза.",
         "data": {
           "update_interval": "Интервал обновления (в часах)",
           "language_code": "Код языка ответа API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels обнаружил недействительные сохранённые данные местоположения для {entry_title}: {location_title}. Удалите и создайте затронутое местоположение заново или восстановите резервную копию Home Assistant, созданную до появления недействительного местоположения."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Дневные датчики прогноза были удалены",
+      "description": "Pollen Levels больше не создает отдельные сущности прогноза, оканчивающиеся на _d1 или _d2. Данные прогноза по-прежнему доступны в базовых датчиках пыльцы через атрибуты forecast, tomorrow_* и d2_*. Обновите панели, автоматизации, шаблоны и пользовательские карточки, которые все еще ссылаются на старые сущности."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Настройка уровней пыльцы",
-        "description": "Введите ключ Google API ([получите его здесь]({api_key_url})) и изучите рекомендации ([лучшие практики]({restricting_api_keys_url})). Выберите местоположение на карте, интервал обновления (часы) и языковой код ответа API. Вы также можете настроить дни прогноза и диапазон дневных датчиков (ТИПЫ).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Ключ API",
           "name": "Имя",
           "location": "Местоположение",
           "update_interval": "Интервал обновления (в часах)",
-          "language_code": "Код языка ответа API",
-          "forecast_days": "Дни прогноза (1–5)",
-          "create_forecast_sensors": "Диапазон дневных датчиков (ТИПЫ)"
+          "language_code": "Код языка ответа API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Превышен лимит запросов\n\n{error_message}",
       "invalid_language_format": "Используйте канонический код BCP-47, например \"en\" или \"es-ES\".",
       "empty": "Это поле не может быть пустым",
-      "invalid_option_combo": "Увеличьте «Дни прогноза», чтобы охватить выбранные датчики по дням.",
       "invalid_coordinates": "Выберите корректное местоположение на карте.",
       "unknown": "Неизвестная ошибка",
       "invalid_update_interval": "Интервал обновления должен быть от 1 до 24 часов.",
-      "invalid_forecast_days": "Дни прогноза должны быть от 1 до 5.",
       "already_configured": "Это местоположение уже настроено.",
       "api_key_already_configured": "Этот API-ключ уже настроен."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Параметры",
-        "description": "Измените интервал обновления, язык ответа API, дни прогноза и дневные датчики для ТИПОВ для {title}.\nВарианты дневных датчиков (ТИПЫ): Только сегодня (none), До завтра (D+1), До послезавтра (D+2; создаёт датчики D+1 и D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Интервал обновления (в часах)",
-          "language_code": "Код языка ответа API",
-          "forecast_days": "Дни прогноза (1–5)",
-          "create_forecast_sensors": "Диапазон дневных датчиков (ТИПЫ)"
+          "language_code": "Код языка ответа API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Используйте канонический код BCP-47, например \"en\" или \"es-ES\".",
-      "empty": "Это поле не может быть пустым",
-      "invalid_option_combo": "Увеличьте «Дни прогноза», чтобы охватить выбранные датчики по дням.",
       "unknown": "Неизвестная ошибка",
-      "invalid_update_interval": "Интервал обновления должен быть от 1 до 24 часов.",
-      "invalid_forecast_days": "Дни прогноза должны быть от 1 до 5."
+      "invalid_update_interval": "Интервал обновления должен быть от 1 до 24 часов."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Недействительное сохранённое местоположение Pollen Levels",
       "description": "Pollen Levels обнаружил недействительные сохранённые данные местоположения для {entry_title}: {location_title}. Удалите и создайте затронутое местоположение заново или восстановите резервную копию Home Assistant, созданную до появления недействительного местоположения."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Konfiguration av pollennivåer",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Ange din Google API Key ([hämta den här]({api_key_url})) och läs igenom bästa praxis ([bästa praxis]({restricting_api_keys_url})). Välj din plats på kartan, uppdateringsintervall (timmar) och språkkod för API-svaret. Pollen Levels begär alltid den maximala prognoshorisonten på 5 dagar.",
         "data": {
           "api_key": "API-nyckel",
           "name": "Namn",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Alternativ",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Ändra uppdateringsintervallet och API-språket för {title}. Pollen Levels begär alltid den maximala prognoshorisonten på 5 dagar.",
         "data": {
           "update_interval": "Uppdateringsintervall (timmar)",
           "language_code": "Språkkod för API-svar"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels hittade ogiltiga lagrade platsdata för {entry_title}: {location_title}. Ta bort och återskapa den berörda platsen eller återställ en Home Assistant-säkerhetskopia från före den ogiltiga platsen skapades."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Prognossensorer per dag har tagits bort",
+      "description": "Pollen Levels skapar inte längre separata prognosenheter som slutar på _d1 eller _d2. Prognosdata är fortfarande tillgängliga på de grundläggande pollensensorerna via attributen forecast, tomorrow_* och d2_*. Uppdatera instrumentpaneler, automatiseringar, mallar och anpassade kort som fortfarande refererar till de gamla enheterna."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Konfiguration av pollennivåer",
-        "description": "Ange din Google API-nyckel ([hämta den här]({api_key_url})) och läs bästa praxis ([bästa praxis]({restricting_api_keys_url})). Välj din plats på kartan, uppdateringsintervallet (timmar) och språkkoden för API-svaret. Du kan också ange prognosdagar och omfånget för sensorer per dag (TYPER).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API-nyckel",
           "name": "Namn",
           "location": "Plats",
           "update_interval": "Uppdateringsintervall (timmar)",
-          "language_code": "Språkkod för API-svar",
-          "forecast_days": "Prognosdagar (1–5)",
-          "create_forecast_sensors": "Omfång för sensorer per dag (TYPER)"
+          "language_code": "Språkkod för API-svar"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Kvoten har överskridits\n\n{error_message}",
       "invalid_language_format": "Använd en kanonisk BCP-47-kod som \"en\" eller \"es-ES\".",
       "empty": "Detta fält får inte vara tomt",
-      "invalid_option_combo": "Öka \"Prognosdagar\" för att täcka valda sensorer per dag.",
       "invalid_coordinates": "Välj en giltig plats på kartan.",
       "unknown": "Okänt fel",
       "invalid_update_interval": "Uppdateringsintervallet måste vara mellan 1 och 24 timmar.",
-      "invalid_forecast_days": "Prognosdagar måste vara mellan 1 och 5.",
       "already_configured": "Den här platsen är redan konfigurerad.",
       "api_key_already_configured": "Den här API-nyckeln är redan konfigurerad."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Alternativ",
-        "description": "Ändra uppdateringsintervall, API-språk, prognosdagar och sensorer per dag för {title}.\nAlternativ för sensorer per dag (TYPER): Endast idag (none), Till och med i morgon (D+1), Till och med i övermorgon (D+2; skapar både D+1- och D+2-sensorer).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Uppdateringsintervall (timmar)",
-          "language_code": "Språkkod för API-svar",
-          "forecast_days": "Prognosdagar (1–5)",
-          "create_forecast_sensors": "Omfång för sensorer per dag (TYPER)"
+          "language_code": "Språkkod för API-svar"
         }
       }
     },
     "error": {
       "invalid_language_format": "Använd en kanonisk BCP-47-kod som \"en\" eller \"es-ES\".",
-      "empty": "Detta fält får inte vara tomt",
-      "invalid_option_combo": "Öka \"Prognosdagar\" för att täcka valda sensorer per dag.",
       "unknown": "Okänt fel",
-      "invalid_update_interval": "Uppdateringsintervallet måste vara mellan 1 och 24 timmar.",
-      "invalid_forecast_days": "Prognosdagar måste vara mellan 1 och 5."
+      "invalid_update_interval": "Uppdateringsintervallet måste vara mellan 1 och 24 timmar."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Ogiltig lagrad Pollen Levels-plats",
       "description": "Pollen Levels hittade ogiltiga lagrade platsdata för {entry_title}: {location_title}. Ta bort och återskapa den berörda platsen eller återställ en Home Assistant-säkerhetskopia från före den ogiltiga platsen skapades."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Налаштування рівнів пилку",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Введіть свій Google API Key ([отримати тут]({api_key_url})) і перегляньте найкращі практики ([найкращі практики]({restricting_api_keys_url})). Виберіть місцезнаходження на мапі, інтервал оновлення (у годинах) і код мови відповіді API. Pollen Levels завжди запитує максимальний 5-денний горизонт прогнозу.",
         "data": {
           "api_key": "Ключ API",
           "name": "Ім'я",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Параметри",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "Змініть інтервал оновлення та мову API для {title}. Pollen Levels завжди запитує максимальний 5-денний горизонт прогнозу.",
         "data": {
           "update_interval": "Інтервал оновлення (у годинах)",
           "language_code": "Код мови відповіді API"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels виявив недійсні збережені дані розташування для {entry_title}: {location_title}. Видаліть і створіть заново відповідне розташування або відновіть резервну копію Home Assistant, створену до появи недійсного розташування."
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "Денні сенсори прогнозу було видалено",
+      "description": "Pollen Levels більше не створює окремі сутності прогнозу, що закінчуються на _d1 або _d2. Дані прогнозу й надалі доступні в базових сенсорах пилку через атрибути forecast, tomorrow_* і d2_*. Оновіть панелі, автоматизації, шаблони та користувацькі картки, які все ще посилаються на старі сутності."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "Налаштування рівнів пилку",
-        "description": "Введіть свій ключ Google API ([отримайте його тут]({api_key_url})) та ознайомтеся з найкращими практиками ([найкращі практики]({restricting_api_keys_url})). Виберіть місце на карті, інтервал оновлення (години) і код мови відповіді API. Ви також можете налаштувати дні прогнозу та діапазон денних датчиків (ТИПИ).",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "Ключ API",
           "name": "Ім'я",
           "location": "Місцезнаходження",
           "update_interval": "Інтервал оновлення (у годинах)",
-          "language_code": "Код мови відповіді API",
-          "forecast_days": "Дні прогнозу (1–5)",
-          "create_forecast_sensors": "Діапазон денних датчиків (ТИПИ)"
+          "language_code": "Код мови відповіді API"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "Перевищено ліміт запитів\n\n{error_message}",
       "invalid_language_format": "Використовуйте канонічний код BCP-47, наприклад \"en\" або \"es-ES\".",
       "empty": "Це поле не може бути порожнім",
-      "invalid_option_combo": "Збільшіть «Дні прогнозу», щоб охопити вибрані денні датчики.",
       "invalid_coordinates": "Виберіть дійсне місце на карті.",
       "unknown": "Невідома помилка",
       "invalid_update_interval": "Інтервал оновлення має бути між 1 і 24 годинами.",
-      "invalid_forecast_days": "Дні прогнозу мають бути від 1 до 5.",
       "already_configured": "Це місце вже налаштовано.",
       "api_key_already_configured": "Цей API-ключ уже налаштовано."
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – Параметри",
-        "description": "Змініть інтервал оновлення, мову відповіді API, кількість днів прогнозу та денні датчики для ТИПІВ для {title}.\nПараметри денних датчиків (ТИПИ): Лише сьогодні (none), До завтра (D+1), До післязавтра (D+2; створює датчики D+1 і D+2).",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "Інтервал оновлення (у годинах)",
-          "language_code": "Код мови відповіді API",
-          "forecast_days": "Дні прогнозу (1–5)",
-          "create_forecast_sensors": "Діапазон денних датчиків (ТИПИ)"
+          "language_code": "Код мови відповіді API"
         }
       }
     },
     "error": {
       "invalid_language_format": "Використовуйте канонічний код BCP-47, наприклад \"en\" або \"es-ES\".",
-      "empty": "Це поле не може бути порожнім",
-      "invalid_option_combo": "Збільшіть «Дні прогнозу», щоб охопити вибрані денні датчики.",
       "unknown": "Невідома помилка",
-      "invalid_update_interval": "Інтервал оновлення має бути між 1 і 24 годинами.",
-      "invalid_forecast_days": "Дні прогнозу мають бути від 1 до 5."
+      "invalid_update_interval": "Інтервал оновлення має бути між 1 і 24 годинами."
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Недійсне збережене розташування Pollen Levels",
       "description": "Pollen Levels виявив недійсні збережені дані розташування для {entry_title}: {location_title}. Видаліть і створіть заново відповідне розташування або відновіть резервну копію Home Assistant, створену до появи недійсного розташування."
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "花粉水平配置",
-        "description": "输入你的 Google API 密钥（[在此获取]({api_key_url})）并查看最佳实践（[最佳实践]({restricting_api_keys_url})）。在地图上选择位置、更新间隔（小时）以及 API 响应的语言代码。你还可以设置预测天数以及逐日类型传感器的范围。",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API 密钥",
           "name": "名称",
           "location": "位置",
           "update_interval": "更新间隔（小时）",
-          "language_code": "API 响应语言代码",
-          "forecast_days": "预测天数（1–5）",
-          "create_forecast_sensors": "逐日类型传感器范围"
+          "language_code": "API 响应语言代码"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "配额已用尽\n\n{error_message}",
       "invalid_language_format": "请使用规范的 BCP-47 代码，例如 \"en\" 或 \"es-ES\"。",
       "empty": "此字段不能为空",
-      "invalid_option_combo": "请增加“预测天数”，以覆盖所选的逐日类型传感器。",
       "invalid_coordinates": "请在地图上选择有效的位置。",
       "unknown": "未知错误",
       "invalid_update_interval": "更新间隔必须在 1 到 24 小时之间。",
-      "invalid_forecast_days": "预测天数必须在 1 到 5 之间。",
       "already_configured": "此位置已配置。",
       "api_key_already_configured": "此 API 密钥已配置。"
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – 选项",
-        "description": "修改更新间隔、API 语言、预测天以及逐日类型传感器，适用于 {title}。\n逐日类型传感器选项：仅今日（none）、至明日（D+1）、至后日（D+2；会同时创建 D+1 和 D+2 传感器）。",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "更新间隔（小时）",
-          "language_code": "API 响应语言代码",
-          "forecast_days": "预测天数（1–5）",
-          "create_forecast_sensors": "逐日类型传感器范围"
+          "language_code": "API 响应语言代码"
         }
       }
     },
     "error": {
       "invalid_language_format": "请使用规范的 BCP-47 代码，例如 \"en\" 或 \"es-ES\"。",
-      "empty": "此字段不能为空",
-      "invalid_option_combo": "请增加“预测天数”，以覆盖所选的逐日类型传感器。",
       "unknown": "未知错误",
-      "invalid_update_interval": "更新间隔必须在 1 到 24 小时之间。",
-      "invalid_forecast_days": "预测天数必须在 1 到 5 之间。"
+      "invalid_update_interval": "更新间隔必须在 1 到 24 小时之间。"
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Pollen Levels 中无效的存储位置",
       "description": "Pollen Levels 发现 {entry_title}：{location_title} 的存储位置数据无效。请删除并重新创建受影响的设置，或恢复在创建无效位置之前的 Home Assistant 备份。"
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "花粉水平配置",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "输入你的 Google API Key（[在此获取]({api_key_url})），并查看最佳实践（[最佳实践]({restricting_api_keys_url})）。在地图上选择位置、更新间隔（小时）以及 API 响应语言代码。Pollen Levels 始终请求最长 5 天的预报范围。",
         "data": {
           "api_key": "API 密钥",
           "name": "名称",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – 选项",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "更改 {title} 的更新间隔和 API 语言。Pollen Levels 始终请求最长 5 天的预报范围。",
         "data": {
           "update_interval": "更新间隔（小时）",
           "language_code": "API 响应语言代码"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels 发现 {entry_title}：{location_title} 的存储位置数据无效。请删除并重新创建受影响的设置，或恢复在创建无效位置之前的 Home Assistant 备份。"
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "已移除按天预报传感器",
+      "description": "Pollen Levels 不再创建以 _d1 或 _d2 结尾的独立预报实体。预报数据仍可通过基础花粉传感器上的 forecast、tomorrow_* 和 d2_* 属性获得。请更新仍引用旧实体的仪表板、自动化、模板和自定义卡片。"
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -3,15 +3,13 @@
     "step": {
       "user": {
         "title": "花粉水平設定",
-        "description": "輸入你的 Google API 金鑰（[在此取得]({api_key_url})）並查看最佳實務（[最佳實務]({restricting_api_keys_url})）。在地圖上選擇位置、更新間隔（小時）以及 API 回應的語言代碼。你也可以設定預測天數與逐日類型感測器的範圍。",
+        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "api_key": "API 金鑰",
           "name": "名稱",
           "location": "位置",
           "update_interval": "更新間隔（小時）",
-          "language_code": "API 回應語言代碼",
-          "forecast_days": "預測天數（1–5）",
-          "create_forecast_sensors": "逐日類型感測器範圍"
+          "language_code": "API 回應語言代碼"
         }
       },
       "reauth_confirm": {
@@ -35,11 +33,9 @@
       "quota_exceeded": "超出配額\n\n{error_message}",
       "invalid_language_format": "請使用標準的 BCP-47 代碼，例如 \"en\" 或 \"es-ES\"。",
       "empty": "此欄位不得為空",
-      "invalid_option_combo": "請增加「預測天數」以涵蓋所選的逐日類型感測器。",
       "invalid_coordinates": "請在地圖上選擇有效的位置。",
       "unknown": "未知錯誤",
       "invalid_update_interval": "更新間隔必須在 1 到 24 小時之間。",
-      "invalid_forecast_days": "預測天數必須在 1 到 5 之間。",
       "already_configured": "此位置已設定。",
       "api_key_already_configured": "此 API 金鑰已設定。"
     },
@@ -56,22 +52,17 @@
     "step": {
       "init": {
         "title": "Pollen Levels – 選項",
-        "description": "修改更新間隔、API 語言、預測天數與逐日類型感測器，適用於 {title}。\n逐日類型感測器選項：僅今日（none）、至明日（D+1）、至後日（D+2；會同時建立 D+1 與 D+2 感測器）。",
+        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
         "data": {
           "update_interval": "更新間隔（小時）",
-          "language_code": "API 回應語言代碼",
-          "forecast_days": "預測天數（1–5）",
-          "create_forecast_sensors": "逐日類型感測器範圍"
+          "language_code": "API 回應語言代碼"
         }
       }
     },
     "error": {
       "invalid_language_format": "請使用標準的 BCP-47 代碼，例如 \"en\" 或 \"es-ES\"。",
-      "empty": "此欄位不得為空",
-      "invalid_option_combo": "請增加「預測天數」以涵蓋所選的逐日類型感測器。",
       "unknown": "未知錯誤",
-      "invalid_update_interval": "更新間隔必須在 1 到 24 小時之間。",
-      "invalid_forecast_days": "預測天數必須在 1 到 5 之間。"
+      "invalid_update_interval": "更新間隔必須在 1 到 24 小時之間。"
     }
   },
   "device": {
@@ -165,6 +156,10 @@
     "invalid_stored_location": {
       "title": "Pollen Levels 中無效的儲存位置",
       "description": "Pollen Levels 發現 {entry_title}：{location_title} 的儲存位置資料無效。請刪除並重新建立受影響的位置，或還原建立無效位置之前的 Home Assistant 備份。"
+    },
+    "per_day_forecast_sensors_removed": {
+      "title": "Per-day forecast sensors were removed",
+      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
     }
   }
 }

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "花粉水平設定",
-        "description": "Enter your Google API Key ([get it here]({api_key_url})) and review best practices ([best practices]({restricting_api_keys_url})). Select your location on the map, update interval (hours) and API response language code. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "輸入你的 Google API Key（[在此取得]({api_key_url})），並查看最佳做法（[最佳做法]({restricting_api_keys_url})）。在地圖上選擇位置、更新間隔（小時）以及 API 回應語言代碼。Pollen Levels 一律請求最長 5 天的預報範圍。",
         "data": {
           "api_key": "API 金鑰",
           "name": "名稱",
@@ -52,7 +52,7 @@
     "step": {
       "init": {
         "title": "Pollen Levels – 選項",
-        "description": "Change the update interval and API language for {title}. Pollen Levels always requests the maximum 5-day forecast horizon.",
+        "description": "變更 {title} 的更新間隔和 API 語言。Pollen Levels 一律請求最長 5 天的預報範圍。",
         "data": {
           "update_interval": "更新間隔（小時）",
           "language_code": "API 回應語言代碼"
@@ -158,8 +158,8 @@
       "description": "Pollen Levels 發現 {entry_title}：{location_title} 的儲存位置資料無效。請刪除並重新建立受影響的位置，或還原建立無效位置之前的 Home Assistant 備份。"
     },
     "per_day_forecast_sensors_removed": {
-      "title": "Per-day forecast sensors were removed",
-      "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."
+      "title": "已移除按日預報感測器",
+      "description": "Pollen Levels 不再建立以 _d1 或 _d2 結尾的獨立預報實體。預報資料仍可透過基礎花粉感測器上的 forecast、tomorrow_* 和 d2_* 屬性取得。請更新仍參照舊實體的儀表板、自動化、範本和自訂卡片。"
     }
   }
 }

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -31,6 +31,7 @@ LEGACY_FORECAST_OPTION_KEYS = frozenset(
         CONF_CREATE_FORECAST_SENSORS,
     }
 )
+LEGACY_ACTIVE_PER_DAY_SENSOR_MODES = frozenset({"D+1", "D+1+2"})
 
 
 def strip_legacy_forecast_options(
@@ -45,8 +46,12 @@ def strip_legacy_forecast_options(
 
 
 def has_legacy_per_day_option(*mappings: Mapping[str, Any] | None) -> bool:
-    """Return whether any mapping stores the removed per-day sensor option."""
-    return any(CONF_CREATE_FORECAST_SENSORS in (mapping or {}) for mapping in mappings)
+    """Return whether any mapping stores an active removed per-day sensor mode."""
+    return any(
+        (mapping or {}).get(CONF_CREATE_FORECAST_SENSORS)
+        in LEGACY_ACTIVE_PER_DAY_SENSOR_MODES
+        for mapping in mappings
+    )
 
 
 def coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
-import logging
 import math
 import re
+from collections.abc import Mapping
 from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from .const import (
     CONF_API_KEY,
+    CONF_CREATE_FORECAST_SENSORS,
+    CONF_FORECAST_DAYS,
     CONF_LATITUDE,
     CONF_LONGITUDE,
-    FORECAST_SENSORS_CHOICES,
     SUBENTRY_TYPE_LOCATION,
 )
 
@@ -22,6 +23,30 @@ if TYPE_CHECKING:  # pragma: no cover - typing-only import
     from .coordinator import PollenDataUpdateCoordinator
 else:  # pragma: no cover - runtime fallback for test environments without aiohttp
     ClientResponse = Any
+
+
+LEGACY_FORECAST_OPTION_KEYS = frozenset(
+    {
+        CONF_FORECAST_DAYS,
+        CONF_CREATE_FORECAST_SENSORS,
+    }
+)
+
+
+def strip_legacy_forecast_options(
+    mapping: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return *mapping* without obsolete forecast configuration keys."""
+    return {
+        key: value
+        for key, value in dict(mapping or {}).items()
+        if key not in LEGACY_FORECAST_OPTION_KEYS
+    }
+
+
+def has_legacy_per_day_option(*mappings: Mapping[str, Any] | None) -> bool:
+    """Return whether any mapping stores the removed per-day sensor option."""
+    return any(CONF_CREATE_FORECAST_SENSORS in (mapping or {}) for mapping in mappings)
 
 
 def coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:
@@ -285,30 +310,6 @@ def validate_location_pair(latitude: Any, longitude: Any) -> tuple[float, float]
     return parsed_latitude, parsed_longitude
 
 
-def normalize_sensor_mode(mode: Any, logger: logging.Logger) -> str:
-    """Normalize sensor mode, defaulting and logging a warning if invalid."""
-    raw_mode = getattr(mode, "value", mode)
-    mode_str = None if raw_mode is None else str(raw_mode).strip()
-    if not mode_str:
-        mode_str = None
-    if mode_str in FORECAST_SENSORS_CHOICES:
-        return mode_str
-
-    if "none" in FORECAST_SENSORS_CHOICES:
-        default_mode = "none"
-    else:
-        default_mode = (
-            FORECAST_SENSORS_CHOICES[0] if FORECAST_SENSORS_CHOICES else "none"
-        )
-    if mode_str is not None:
-        logger.warning(
-            "Invalid stored per-day sensor mode '%s'; defaulting to '%s'",
-            mode_str,
-            default_mode,
-        )
-    return default_mode
-
-
 def safe_parse_int(value: Any) -> int | None:
     """Parse an integer-like value, rejecting non-finite and decimal numbers."""
     if value is None or isinstance(value, bool):
@@ -335,12 +336,14 @@ __all__ = [
     "entry_api_key",
     "extract_error_message",
     "format_location_unique_id",
-    "normalize_sensor_mode",
+    "has_legacy_per_day_option",
+    "LEGACY_FORECAST_OPTION_KEYS",
     "parse_finite_float",
     "redact_api_key",
     "redact_sensitive_values",
     "safe_parse_int",
     "stale_runtime_location_filter",
+    "strip_legacy_forecast_options",
     "validate_latitude",
     "validate_location_pair",
     "validate_longitude",

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -278,7 +278,7 @@ def parse_finite_float(value: Any) -> float | None:
 
     try:
         parsed = float(value)
-    except TypeError, ValueError, OverflowError:
+    except (TypeError, ValueError, OverflowError):
         return None
 
     if not math.isfinite(parsed):
@@ -322,7 +322,7 @@ def safe_parse_int(value: Any) -> int | None:
 
     try:
         parsed_float = float(value)
-    except TypeError, ValueError, OverflowError:
+    except (TypeError, ValueError, OverflowError):
         return None
 
     if not math.isfinite(parsed_float) or not parsed_float.is_integer():

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -47,11 +47,14 @@ def strip_legacy_forecast_options(
 
 def has_legacy_per_day_option(*mappings: Mapping[str, Any] | None) -> bool:
     """Return whether any mapping stores an active removed per-day sensor mode."""
-    return any(
-        (mapping or {}).get(CONF_CREATE_FORECAST_SENSORS)
-        in LEGACY_ACTIVE_PER_DAY_SENSOR_MODES
-        for mapping in mappings
-    )
+    for mapping in mappings:
+        value = (mapping or {}).get(CONF_CREATE_FORECAST_SENSORS)
+        raw = getattr(value, "value", value)
+        if raw is None:
+            continue
+        if str(raw).strip() in LEGACY_ACTIVE_PER_DAY_SENSOR_MODES:
+            return True
+    return False
 
 
 def coordinator_identity_id(coordinator: PollenDataUpdateCoordinator) -> str:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -278,7 +278,7 @@ def parse_finite_float(value: Any) -> float | None:
 
     try:
         parsed = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
 
     if not math.isfinite(parsed):
@@ -322,7 +322,7 @@ def safe_parse_int(value: Any) -> int | None:
 
     try:
         parsed_float = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
 
     if not math.isfinite(parsed_float) or not parsed_float.is_integer():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0rc1"
+version = "3.0.0b4"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0b4"
+version = "3.0.0rc1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -232,7 +232,7 @@ def stub_util_dt_module(*, monkeypatch: pytest.MonkeyPatch | None = None) -> Mod
 
         try:
             parsed = parsedate_to_datetime(value) if value is not None else None
-        except (TypeError, ValueError, IndexError, OverflowError):
+        except TypeError, ValueError, IndexError, OverflowError:
             return None
 
         if parsed is None:

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -232,7 +232,7 @@ def stub_util_dt_module(*, monkeypatch: pytest.MonkeyPatch | None = None) -> Mod
 
         try:
             parsed = parsedate_to_datetime(value) if value is not None else None
-        except TypeError, ValueError, IndexError, OverflowError:
+        except (TypeError, ValueError, IndexError, OverflowError):
             return None
 
         if parsed is None:

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -314,6 +314,7 @@ class StubIssueRegistry:
 
 class StubIssueSeverity:
     ERROR = "error"
+    WARNING = "warning"
 
 
 def stub_issue_registry_module(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -246,7 +246,7 @@ class _StubSchema:
 def _latitude(value=None):
     try:
         lat = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # Mirror Home Assistant's cv.latitude behavior for invalid types.
         raise _StubInvalid("latitude_type") from None
     if lat < -90 or lat > 90:
@@ -257,7 +257,7 @@ def _latitude(value=None):
 def _longitude(value=None):
     try:
         lon = float(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # Mirror Home Assistant's cv.longitude behavior for invalid types.
         raise _StubInvalid("longitude_type") from None
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -246,7 +246,7 @@ class _StubSchema:
 def _latitude(value=None):
     try:
         lat = float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         # Mirror Home Assistant's cv.latitude behavior for invalid types.
         raise _StubInvalid("latitude_type") from None
     if lat < -90 or lat > 90:
@@ -257,7 +257,7 @@ def _latitude(value=None):
 def _longitude(value=None):
     try:
         lon = float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         # Mirror Home Assistant's cv.longitude behavior for invalid types.
         raise _StubInvalid("longitude_type") from None
 
@@ -1605,7 +1605,9 @@ def test_validate_input_http_429_whitespace_redacted_uses_quota_fallback(
         error=config_flow_stubs.config_flow.PollenQuotaExceededError("HTTP 429"),
     )
     monkeypatch.setattr(
-        config_flow_stubs.config_flow, "redact_api_key", lambda *_args, **_kwargs: "   "
+        config_flow_stubs.config_flow,
+        "_redact_validation_error",
+        lambda *_args, **_kwargs: "   ",
     )
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()
@@ -1636,7 +1638,9 @@ def test_validate_input_update_failed_whitespace_redacted_uses_connect_fallback(
         config_flow_stubs, monkeypatch, error=config_flow_stubs.UpdateFailed("HTTP 500")
     )
     monkeypatch.setattr(
-        config_flow_stubs.config_flow, "redact_api_key", lambda *_args, **_kwargs: "   "
+        config_flow_stubs.config_flow,
+        "_redact_validation_error",
+        lambda *_args, **_kwargs: "   ",
     )
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()
@@ -1671,7 +1675,9 @@ def test_validate_input_http_429_empty_redacted_uses_quota_fallback(
         error=config_flow_stubs.config_flow.PollenQuotaExceededError("HTTP 429"),
     )
     monkeypatch.setattr(
-        config_flow_stubs.config_flow, "redact_api_key", lambda *_args, **_kwargs: ""
+        config_flow_stubs.config_flow,
+        "_redact_validation_error",
+        lambda *_args, **_kwargs: "",
     )
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -375,12 +375,9 @@ class ConfigFlowStubs:
     CONF_LANGUAGE_CODE: str
     CONF_UPDATE_INTERVAL: str
     DEFAULT_ENTRY_TITLE: str
-    DEFAULT_FORECAST_DAYS: int
     DEFAULT_UPDATE_INTERVAL: int
-    FORECAST_SENSORS_CHOICES: tuple[str, ...]
-    MAX_FORECAST_DAYS: int
     MAX_UPDATE_INTERVAL_HOURS: int
-    MIN_FORECAST_DAYS: int
+    FORECAST_DAYS: int
 
 
 @pytest.fixture(name="config_flow_stubs", autouse=True)
@@ -414,12 +411,9 @@ def config_flow_stubs_fixture(monkeypatch: pytest.MonkeyPatch) -> ConfigFlowStub
         CONF_LANGUAGE_CODE=const.CONF_LANGUAGE_CODE,
         CONF_UPDATE_INTERVAL=const.CONF_UPDATE_INTERVAL,
         DEFAULT_ENTRY_TITLE=const.DEFAULT_ENTRY_TITLE,
-        DEFAULT_FORECAST_DAYS=const.DEFAULT_FORECAST_DAYS,
         DEFAULT_UPDATE_INTERVAL=const.DEFAULT_UPDATE_INTERVAL,
-        FORECAST_SENSORS_CHOICES=const.FORECAST_SENSORS_CHOICES,
-        MAX_FORECAST_DAYS=const.MAX_FORECAST_DAYS,
         MAX_UPDATE_INTERVAL_HOURS=const.MAX_UPDATE_INTERVAL_HOURS,
-        MIN_FORECAST_DAYS=const.MIN_FORECAST_DAYS,
+        FORECAST_DAYS=const.FORECAST_DAYS,
     )
 
     return stubs
@@ -614,7 +608,7 @@ def test_language_error_to_form_key_mapping(config_flow_stubs: ConfigFlowStubs) 
         config_flow_stubs.config_flow._language_error_to_form_key(
             config_flow_stubs.config_flow.vol.Invalid("empty")
         )
-        == "empty"
+        == "invalid_language_format"
     )
     assert (
         config_flow_stubs.config_flow._language_error_to_form_key(
@@ -828,11 +822,7 @@ def _build_options_flow(
     """Build an options flow with simple form/create-entry callbacks."""
 
     entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(
-        data=data
-        or {
-            config_flow_stubs.CONF_FORECAST_DAYS: 3,
-            config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "none",
-        }
+        data=data or {config_flow_stubs.CONF_LANGUAGE_CODE: "en"}
     )
     flow = config_flow_stubs.config_flow.PollenLevelsOptionsFlow()
     flow.config_entry = entry
@@ -885,68 +875,19 @@ def test_setup_schema_update_interval_default_is_sanitized(
     assert captured_defaults == [expected]
 
 
-@pytest.mark.parametrize(
-    ("raw_value", "expected"),
-    [
-        ("999", "5"),
-        (-5, "1"),
-        ("abc", "2"),
-    ],
-)
-def test_setup_schema_forecast_days_default_is_sanitized(
+def test_setup_schema_omits_removed_forecast_options(
     config_flow_stubs: ConfigFlowStubs,
-    monkeypatch: pytest.MonkeyPatch,
-    raw_value: object,
-    expected: str,
 ) -> None:
-    """Forecast days defaults should be sanitized for form rendering."""
-
-    captured_defaults: list[str | None] = []
-
-    def _capture_optional(key, **kwargs):
-        if key == config_flow_stubs.CONF_FORECAST_DAYS:
-            captured_defaults.append(kwargs.get("default"))
-        return key
-
-    monkeypatch.setattr(
-        config_flow_stubs.config_flow.vol, "Optional", _capture_optional
-    )
+    """Initial setup no longer exposes forecast days or per-day sensors."""
 
     hass = SimpleNamespace(
         config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en")
     )
-    config_flow_stubs.config_flow._build_step_user_schema(
-        hass, {config_flow_stubs.CONF_FORECAST_DAYS: raw_value}
-    )
+    schema = config_flow_stubs.config_flow._build_step_user_schema(hass, {})
+    keys = {str(getattr(key, "schema", key)) for key in schema.schema}
 
-    assert captured_defaults == [expected]
-
-
-def test_setup_schema_sensor_mode_default_is_sanitized(
-    config_flow_stubs: ConfigFlowStubs,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Per-day sensor defaults should fall back to a valid selector choice."""
-
-    captured_defaults: list[str | None] = []
-
-    def _capture_optional(key, **kwargs):
-        if key == config_flow_stubs.CONF_CREATE_FORECAST_SENSORS:
-            captured_defaults.append(kwargs.get("default"))
-        return key
-
-    monkeypatch.setattr(
-        config_flow_stubs.config_flow.vol, "Optional", _capture_optional
-    )
-
-    hass = SimpleNamespace(
-        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en")
-    )
-    config_flow_stubs.config_flow._build_step_user_schema(
-        hass, {config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "bad"}
-    )
-
-    assert captured_defaults == [config_flow_stubs.FORECAST_SENSORS_CHOICES[0]]
+    assert config_flow_stubs.CONF_FORECAST_DAYS not in keys
+    assert config_flow_stubs.CONF_CREATE_FORECAST_SENSORS not in keys
 
 
 def test_step_user_schema_masks_api_key_field(
@@ -1429,11 +1370,11 @@ def test_validate_input_clears_error_message_placeholder_on_validation_error(
     assert "error_message" not in placeholders
 
 
-def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
+def test_validate_input_connection_error_sets_error_message_placeholder(
     config_flow_stubs: ConfigFlowStubs,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """invalid_option_combo should clear stale error_message placeholders."""
+    """Connection errors should keep a safe error_message placeholder."""
 
     calls = _patch_client_fetch(
         config_flow_stubs,
@@ -1458,71 +1399,14 @@ def test_validate_input_invalid_option_combo_clears_error_message_placeholder(
     assert normalized is None
     assert placeholders.get("error_message")
 
-    _patch_client_fetch(
-        config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
-    )
-
-    errors, normalized = asyncio.run(
-        flow._async_validate_input(
-            {
-                **_base_user_input(config_flow_stubs),
-                config_flow_stubs.CONF_FORECAST_DAYS: 1,
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1",
-            },
-            check_unique_id=False,
-            description_placeholders=placeholders,
-        )
-    )
-
-    assert errors == {
-        config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"
-    }
-    assert normalized is None
-    assert "error_message" not in placeholders
+    assert "error_message" in placeholders
 
 
-@pytest.mark.parametrize(
-    ("forecast_days", "mode"),
-    [(1, "D+1"), (2, "D+1+2")],
-)
-def test_validate_input_invalid_forecast_mode_combinations(
-    config_flow_stubs: ConfigFlowStubs,
-    forecast_days: int,
-    mode: str,
-) -> None:
-    """User flow should reject forecast modes requiring more forecast days."""
-
-    flow = config_flow_stubs.PollenLevelsConfigFlow()
-    flow.hass = SimpleNamespace()
-
-    errors, normalized = asyncio.run(
-        flow._async_validate_input(
-            {
-                **_base_user_input(config_flow_stubs),
-                config_flow_stubs.CONF_FORECAST_DAYS: forecast_days,
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: mode,
-            },
-            check_unique_id=False,
-        )
-    )
-
-    assert errors == {
-        config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"
-    }
-    assert normalized is None
-
-
-@pytest.mark.parametrize(
-    ("forecast_days", "mode"),
-    [(2, "D+1"), (3, "D+1+2"), (1, "none")],
-)
-def test_validate_input_valid_forecast_mode_combinations_are_accepted(
+def test_validate_input_ignores_removed_forecast_options_and_uses_fixed_days(
     config_flow_stubs: ConfigFlowStubs,
     monkeypatch: pytest.MonkeyPatch,
-    forecast_days: int,
-    mode: str,
 ) -> None:
-    """User flow should accept forecast mode combinations that have enough days."""
+    """Removed forecast options are not saved and validation calls days=5."""
 
     calls = _patch_client_fetch(
         config_flow_stubs, monkeypatch, result=_valid_daily_info_payload()
@@ -1535,8 +1419,8 @@ def test_validate_input_valid_forecast_mode_combinations_are_accepted(
         flow._async_validate_input(
             {
                 **_base_user_input(config_flow_stubs),
-                config_flow_stubs.CONF_FORECAST_DAYS: forecast_days,
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: mode,
+                config_flow_stubs.CONF_FORECAST_DAYS: "bad",
+                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
             },
             check_unique_id=False,
         )
@@ -1545,103 +1429,43 @@ def test_validate_input_valid_forecast_mode_combinations_are_accepted(
     assert calls
     assert errors == {}
     assert normalized is not None
-    assert normalized[config_flow_stubs.CONF_FORECAST_DAYS] == forecast_days
-    assert normalized[config_flow_stubs.CONF_CREATE_FORECAST_SENSORS] == mode
+    assert calls[0]["days"] == config_flow_stubs.FORECAST_DAYS
+    assert config_flow_stubs.CONF_FORECAST_DAYS not in normalized
+    assert config_flow_stubs.CONF_CREATE_FORECAST_SENSORS not in normalized
 
 
-def test_validate_input_invalid_forecast_days_returns_error(
+def test_options_flow_drops_removed_forecast_options(
     config_flow_stubs: ConfigFlowStubs,
 ) -> None:
-    """Invalid forecast days should keep the dedicated field error key."""
+    """Options flow preserves supported options and drops legacy forecast keys."""
 
-    flow = config_flow_stubs.PollenLevelsConfigFlow()
-    flow.hass = SimpleNamespace()
-
-    errors, normalized = asyncio.run(
-        flow._async_validate_input(
-            {
-                **_base_user_input(config_flow_stubs),
-                config_flow_stubs.CONF_FORECAST_DAYS: "not-a-number",
-            },
-            check_unique_id=False,
-        )
+    flow = _build_options_flow(
+        config_flow_stubs,
+        {
+            config_flow_stubs.CONF_LANGUAGE_CODE: "en",
+        },
     )
-
-    assert errors == {config_flow_stubs.CONF_FORECAST_DAYS: "invalid_forecast_days"}
-    assert normalized is None
-
-
-@pytest.mark.parametrize(
-    ("forecast_days", "mode"),
-    [(1, "D+1"), (2, "D+1+2")],
-)
-def test_options_flow_invalid_forecast_mode_combinations(
-    config_flow_stubs: ConfigFlowStubs,
-    forecast_days: int,
-    mode: str,
-) -> None:
-    """Options flow should reject forecast modes requiring more forecast days."""
-
-    flow = _build_options_flow(config_flow_stubs)
-
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                config_flow_stubs.CONF_FORECAST_DAYS: forecast_days,
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: mode,
-            }
-        )
-    )
-
-    assert result["type"] == "form"
-    assert result["errors"] == {
-        config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"
+    flow.config_entry.options = {
+        config_flow_stubs.CONF_UPDATE_INTERVAL: 12,
+        config_flow_stubs.CONF_FORECAST_DAYS: 1,
+        config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1",
     }
 
-
-@pytest.mark.parametrize(
-    ("forecast_days", "mode"),
-    [(2, "D+1"), (3, "D+1+2"), (1, "none")],
-)
-def test_options_flow_valid_forecast_mode_combinations_are_accepted(
-    config_flow_stubs: ConfigFlowStubs,
-    forecast_days: int,
-    mode: str,
-) -> None:
-    """Options flow should accept forecast mode combinations with enough days."""
-
-    flow = _build_options_flow(config_flow_stubs)
-
     result = asyncio.run(
         flow.async_step_init(
             {
-                config_flow_stubs.CONF_FORECAST_DAYS: forecast_days,
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: mode,
+                config_flow_stubs.CONF_UPDATE_INTERVAL: 6,
+                config_flow_stubs.CONF_LANGUAGE_CODE: "es",
+                config_flow_stubs.CONF_FORECAST_DAYS: "bad",
+                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
             }
         )
     )
 
     assert result["type"] == "create_entry"
-    assert result["data"][config_flow_stubs.CONF_FORECAST_DAYS] == forecast_days
-    assert result["data"][config_flow_stubs.CONF_CREATE_FORECAST_SENSORS] == mode
-
-
-def test_options_flow_invalid_forecast_days_returns_error(
-    config_flow_stubs: ConfigFlowStubs,
-) -> None:
-    """Options flow should keep the dedicated invalid forecast days field error."""
-
-    flow = _build_options_flow(
-        config_flow_stubs, {config_flow_stubs.CONF_FORECAST_DAYS: 3}
-    )
-
-    result = asyncio.run(
-        flow.async_step_init({config_flow_stubs.CONF_FORECAST_DAYS: "not-a-number"})
-    )
-
-    assert result["type"] == "form"
-    assert result["errors"] == {
-        config_flow_stubs.CONF_FORECAST_DAYS: "invalid_forecast_days"
+    assert result["data"] == {
+        config_flow_stubs.CONF_UPDATE_INTERVAL: 6,
+        config_flow_stubs.CONF_LANGUAGE_CODE: "es",
     }
 
 
@@ -3056,7 +2880,7 @@ def test_location_subentry_user_step_creates_entry_without_premature_reload(
         {
             "latitude": 12.34567,
             "longitude": -98.76543,
-            "days": 1,
+            "days": config_flow_stubs.FORECAST_DAYS,
             "language_code": "es-ES",
         }
     ]
@@ -3276,7 +3100,7 @@ def test_location_subentry_reconfigure_updates_entry_and_schedules_reload(
         {
             "latitude": 3.0,
             "longitude": 4.0,
-            "days": 1,
+            "days": config_flow_stubs.FORECAST_DAYS,
             "language_code": None,
         }
     ]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -25,7 +25,6 @@ class DiagnosticsModules(NamedTuple):
     PollenLevelsRuntimeData: type[object]
     PollenLocationRuntime: type[object]
     CONF_API_KEY: str
-    CONF_FORECAST_DAYS: str
     CONF_LANGUAGE_CODE: str
     CONF_LATITUDE: str
     CONF_LONGITUDE: str
@@ -97,7 +96,6 @@ def diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> DiagnosticsModules:
     from custom_components.pollenlevels import diagnostics as imported_diag
     from custom_components.pollenlevels.const import (
         CONF_API_KEY as imported_conf_api_key,
-        CONF_FORECAST_DAYS as imported_conf_forecast_days,
         CONF_LANGUAGE_CODE as imported_conf_language_code,
         CONF_LATITUDE as imported_conf_latitude,
         CONF_LONGITUDE as imported_conf_longitude,
@@ -112,7 +110,6 @@ def diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> DiagnosticsModules:
         PollenLevelsRuntimeData=ImportedRuntimeData,
         PollenLocationRuntime=ImportedLocationRuntime,
         CONF_API_KEY=imported_conf_api_key,
-        CONF_FORECAST_DAYS=imported_conf_forecast_days,
         CONF_LANGUAGE_CODE=imported_conf_language_code,
         CONF_LATITUDE=imported_conf_latitude,
         CONF_LONGITUDE=imported_conf_longitude,
@@ -135,16 +132,13 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys(
         diagnostics_modules.CONF_LONGITUDE: 78.987654,
         diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
+    options = {}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
     coordinator = SimpleNamespace(
         entry_id="entry",
-        forecast_days=3,
         language="en",
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={f"type_{idx}": {} for idx in range(60)},
     )
@@ -161,6 +155,12 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys(
     assert diagnostics_modules.CONF_LONGITUDE not in diagnostics["entry"]["data"]
     assert diagnostics["request_params_example"]["location.latitude"] == 12.3
     assert diagnostics["request_params_example"]["location.longitude"] == 79.0
+    assert (
+        diagnostics["coordinator"]["forecast_days"]
+        == diagnostics_modules.diag.FORECAST_DAYS
+    )
+    assert "create_d1" not in diagnostics["coordinator"]
+    assert "create_d2" not in diagnostics["coordinator"]
     assert diagnostics["coordinator"]["data_keys_total"] == 60
     assert len(diagnostics["coordinator"]["data_keys"]) == 50
     serialized = json.dumps(diagnostics, sort_keys=True)
@@ -178,7 +178,7 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
         diagnostics_modules.CONF_API_KEY: "secret-token",
         diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
+    options = {}
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
     entry.subentries = {
         "subentry-1": SimpleNamespace(
@@ -194,10 +194,7 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
         subentry_id="subentry-1",
         legacy_entry_id="legacy-entry",
         entity_identity_id="legacy-entry",
-        forecast_days=3,
         language="en",
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=12.3456,
         lon=78.9876,
@@ -209,10 +206,7 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
         subentry_id="subentry-2",
         legacy_entry_id=None,
         entity_identity_id="entry_subentry-2",
-        forecast_days=3,
         language="en",
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=40.7128,
         lon=-74.0060,
@@ -285,10 +279,7 @@ async def test_diagnostics_redacts_multi_location_titles(
     casa_coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="casa",
-        forecast_days=2,
         language=None,
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=12.345678,
         lon=-98.765432,
@@ -298,10 +289,7 @@ async def test_diagnostics_redacts_multi_location_titles(
     trabajo_coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="trabajo",
-        forecast_days=2,
         language=None,
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=40.7128,
         lon=-74.006,
@@ -359,10 +347,7 @@ async def test_diagnostics_includes_fallback_location_without_subentries(
     coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="entry",
-        forecast_days=2,
         language=None,
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=12.345678,
         lon=-98.765432,
@@ -467,10 +452,7 @@ async def test_diagnostics_summarizes_runtime_locations_when_parent_has_no_locat
     coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="deleted-location",
-        forecast_days=2,
         language=None,
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         lat=12.345678,
         lon=-98.765432,
@@ -521,10 +503,7 @@ async def test_diagnostics_summarizes_stale_runtime_locations(
         return SimpleNamespace(
             entry_id="entry",
             subentry_id=subentry_id,
-            forecast_days=2,
             language="en",
-            create_d1=True,
-            create_d2=False,
             last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
             lat=lat,
             lon=lon,
@@ -568,34 +547,23 @@ async def test_diagnostics_summarizes_stale_runtime_locations(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("raw_days", "expected_days"),
-    [
-        (999, 5),
-        (-3, 1),
-        ("nan", 2),
-    ],
-)
-async def test_diagnostics_clamps_request_days(
-    diagnostics_modules: DiagnosticsModules, raw_days: Any, expected_days: int
+async def test_diagnostics_request_days_are_fixed(
+    diagnostics_modules: DiagnosticsModules,
 ) -> None:
-    """Diagnostics request params should always show a supported day count."""
+    """Diagnostics request params should always show the fixed Google API limit."""
 
     data = {
         diagnostics_modules.CONF_LATITUDE: 12.3,
         diagnostics_modules.CONF_LONGITUDE: 45.6,
         diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {diagnostics_modules.CONF_FORECAST_DAYS: raw_days}
+    options = {}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
     coordinator = SimpleNamespace(
         entry_id="entry",
-        forecast_days=3,
         language="en",
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={"type_grass": {"source": "type"}},
     )
@@ -607,7 +575,10 @@ async def test_diagnostics_clamps_request_days(
         None, entry
     )
 
-    assert diagnostics["request_params_example"]["days"] == expected_days
+    assert (
+        diagnostics["request_params_example"]["days"]
+        == diagnostics_modules.diag.FORECAST_DAYS
+    )
 
 
 @pytest.mark.asyncio
@@ -621,7 +592,7 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
         diagnostics_modules.CONF_LONGITUDE: float("inf"),
         diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {diagnostics_modules.CONF_FORECAST_DAYS: 2}
+    options = {}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
     entry.subentries = {
@@ -631,10 +602,7 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
     coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="entry",
-        forecast_days=2,
         language="en",
-        create_d1=True,
-        create_d2=False,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={"type_grass": {"source": "type"}},
     )
@@ -663,16 +631,13 @@ async def test_diagnostics_includes_daily_summary_sensor_snapshot(
         diagnostics_modules.CONF_LONGITUDE: 45.6,
         diagnostics_modules.CONF_LANGUAGE_CODE: "en",
     }
-    options = {diagnostics_modules.CONF_FORECAST_DAYS: 3}
+    options = {}
 
     entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
 
     coordinator = SimpleNamespace(
         entry_id="entry",
-        forecast_days=3,
         language="en",
-        create_d1=True,
-        create_d2=True,
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
         data={
             "plants_oak": {
@@ -773,10 +738,7 @@ async def test_diagnostics_daily_summary_uses_empty_states_without_data(
     coordinator = SimpleNamespace(
         entry_id="entry",
         subentry_id="entry",
-        forecast_days=1,
         language=None,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
         data={},
     )
@@ -853,10 +815,7 @@ async def test_diagnostics_includes_registry_summary_without_sensitive_values(
     entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
     coordinator = SimpleNamespace(
         entry_id="entry",
-        forecast_days=1,
         language=None,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
         lat=12.345678,
         lon=-98.765432,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -248,8 +248,69 @@ async def test_diagnostics_includes_all_locations_with_top_level_first_location(
     assert first_payload["approximate_location"]["longitude_rounded"] == 79.0
     assert second_payload["approximate_location"]["latitude_rounded"] == 40.7
     assert second_payload["approximate_location"]["longitude_rounded"] == -74.0
-    assert first_payload["coordinator"]["legacy_entry_id"] == "legacy-entry"
+    assert first_payload["coordinator"]["has_legacy_entry_id"] is True
+    assert first_payload["coordinator"]["has_entity_identity_id"] is True
+    assert second_payload["coordinator"]["has_legacy_entry_id"] is False
+    assert second_payload["coordinator"]["has_entity_identity_id"] is True
+    assert "legacy_entry_id" not in first_payload["coordinator"]
+    assert "entity_identity_id" not in first_payload["coordinator"]
     assert second_payload["coordinator"]["subentry_id"] == "subentry-2"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_do_not_expose_coordinate_derived_identity_strings(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should summarize identity presence without raw identity values."""
+
+    coordinate_identity = "39.1234_-0.1234"
+    entry = _ConfigEntry(
+        data={diagnostics_modules.CONF_API_KEY: "secret-token"},
+        options={},
+        entry_id="entry",
+        title="Home",
+    )
+    entry.subentries = {
+        "subentry-1": SimpleNamespace(
+            subentry_id="subentry-1", subentry_type="location"
+        )
+    }
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="subentry-1",
+        legacy_entry_id=coordinate_identity,
+        entity_identity_id=coordinate_identity,
+        language="en",
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=39.1234,
+        lon=-0.1234,
+        entry_title="Home",
+        data={},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "subentry-1": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="subentry-1",
+                coordinator=coordinator,
+                legacy_entry_id=coordinate_identity,
+            )
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    coord = diagnostics["locations"]["subentry-1"]["coordinator"]
+    assert coord["has_legacy_entry_id"] is True
+    assert coord["has_entity_identity_id"] is True
+    assert "legacy_entry_id" not in coord
+    assert "entity_identity_id" not in coord
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert coordinate_identity not in serialized
+    assert "39.1234" not in serialized
+    assert "-0.1234" not in serialized
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -894,11 +894,11 @@ def test_setup_entry_auth_failure_still_fails_parent(
     assert hass.config_entries.forward_calls == []
 
 
-def test_setup_entry_decimal_numeric_options_fallback_to_defaults(
+def test_setup_entry_decimal_update_interval_falls_back_and_drops_forecast_days(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Decimal options should not be truncated silently during setup."""
+    """Decimal interval falls back while legacy forecast-days is removed silently."""
     integration = integration_modules.integration
     base_data_update_coordinator = integration_modules.base_data_update_coordinator
 
@@ -921,7 +921,9 @@ def test_setup_entry_decimal_numeric_options_fallback_to_defaults(
     class _StubCoordinator(base_data_update_coordinator):
         def __init__(self, *args, **kwargs):
             seen["hours"] = kwargs["hours"]
-            seen["forecast_days"] = kwargs["forecast_days"]
+            assert "forecast_days" not in kwargs
+            assert "create_d1" not in kwargs
+            assert "create_d2" not in kwargs
             self.data = {"region": {"source": "meta"}, "date": {"source": "meta"}}
 
         async def async_config_entry_first_refresh(self):
@@ -931,7 +933,11 @@ def test_setup_entry_decimal_numeric_options_fallback_to_defaults(
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert seen["hours"] == integration.DEFAULT_UPDATE_INTERVAL
-    assert seen["forecast_days"] == integration.DEFAULT_FORECAST_DAYS
+    assert integration.CONF_FORECAST_DAYS not in entry.options
+    assert (
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        not in integration.issue_helpers.ir.registry.issues
+    )
 
 
 def test_setup_entry_wraps_generic_error(integration_modules: _InitModules) -> None:
@@ -972,10 +978,10 @@ def test_setup_entry_success_and_unload(
             self.api_key = kwargs["api_key"]
             self.lat = kwargs["lat"]
             self.lon = kwargs["lon"]
-            self.forecast_days = kwargs["forecast_days"]
+            assert "forecast_days" not in kwargs
             self.language = kwargs["language"]
-            self.create_d1 = kwargs["create_d1"]
-            self.create_d2 = kwargs["create_d2"]
+            assert "create_d1" not in kwargs
+            assert "create_d2" not in kwargs
             self.entry_id = kwargs["entry_id"]
             self.entry_title = kwargs.get("entry_title")
             self.last_updated = None
@@ -1002,17 +1008,27 @@ def test_setup_entry_success_and_unload(
     assert entry.runtime_data is None
 
 
-def test_setup_entry_normalizes_forecast_sensor_mode(
+def test_setup_entry_drops_legacy_per_day_option_and_creates_repair_issue(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Setup should normalize stored forecast mode values before coordinator flags."""
+    """Setup should drop legacy per-day options and create a Repair warning."""
     integration = integration_modules.integration
     base_data_update_coordinator = integration_modules.base_data_update_coordinator
 
     hass = _FakeHass()
     entry = _FakeEntry(
-        integration, options={integration.CONF_CREATE_FORECAST_SENSORS: " D+1 "}
+        integration,
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_CREATE_FORECAST_SENSORS: "D+1",
+        },
+        options={
+            integration.CONF_FORECAST_DAYS: 3,
+            integration.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
+        },
     )
 
     class _StubClient:
@@ -1025,8 +1041,9 @@ def test_setup_entry_normalizes_forecast_sensor_mode(
 
     class _StubCoordinator(base_data_update_coordinator):
         def __init__(self, *args, **kwargs):
-            self.create_d1 = kwargs["create_d1"]
-            self.create_d2 = kwargs["create_d2"]
+            assert "forecast_days" not in kwargs
+            assert "create_d1" not in kwargs
+            assert "create_d2" not in kwargs
             self.entry_id = kwargs["entry_id"]
             self.entry_title = kwargs.get("entry_title")
             self.lat = kwargs["lat"]
@@ -1042,23 +1059,32 @@ def test_setup_entry_normalizes_forecast_sensor_mode(
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator.create_d1 is True
-    assert entry.runtime_data.coordinator.create_d2 is False
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_FORECAST_DAYS not in entry.options
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
+    issue = integration.issue_helpers.ir.registry.issues[
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    ]
+    assert issue["severity"] == integration.issue_helpers.ir.IssueSeverity.WARNING
+    assert issue["is_fixable"] is False
+    assert issue["is_persistent"] is True
 
 
-def test_setup_entry_disables_d1_when_forecast_days_is_one(
+def test_setup_entry_drops_legacy_forecast_days_from_data(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Setup should disable D+1/D+2 creation when forecast days disallow them."""
+    """Setup should remove obsolete forecast-days data without a Repair warning."""
     integration = integration_modules.integration
     base_data_update_coordinator = integration_modules.base_data_update_coordinator
 
     hass = _FakeHass()
     entry = _FakeEntry(
         integration,
-        options={
-            integration.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
             integration.CONF_FORECAST_DAYS: 1,
         },
     )
@@ -1073,8 +1099,9 @@ def test_setup_entry_disables_d1_when_forecast_days_is_one(
 
     class _StubCoordinator(base_data_update_coordinator):
         def __init__(self, *args, **kwargs):
-            self.create_d1 = kwargs["create_d1"]
-            self.create_d2 = kwargs["create_d2"]
+            assert "forecast_days" not in kwargs
+            assert "create_d1" not in kwargs
+            assert "create_d2" not in kwargs
             self.entry_id = kwargs["entry_id"]
             self.entry_title = kwargs.get("entry_title")
             self.lat = kwargs["lat"]
@@ -1090,8 +1117,11 @@ def test_setup_entry_disables_d1_when_forecast_days_is_one(
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator.create_d1 is False
-    assert entry.runtime_data.coordinator.create_d2 is False
+    assert integration.CONF_FORECAST_DAYS not in entry.data
+    assert (
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        not in integration.issue_helpers.ir.registry.issues
+    )
 
 
 def test_force_update_service_is_registered_with_empty_schema(
@@ -1599,8 +1629,10 @@ def test_force_update_parent_without_locations_is_noop(
     assert "No coordinators available for force_update" in caplog.text
 
 
-def test_migrate_entry_moves_mode_to_options(integration_modules: _InitModules) -> None:
-    """Migration should copy per-day sensor mode from data to options."""
+def test_migrate_entry_removes_legacy_mode_and_creates_issue(
+    integration_modules: _InitModules,
+) -> None:
+    """Migration should drop per-day mode storage and create a Repair warning."""
     integration = integration_modules.integration
 
     entry = _FakeEntry(
@@ -1618,11 +1650,15 @@ def test_migrate_entry_moves_mode_to_options(integration_modules: _InitModules) 
     hass = _FakeHass(entries=[entry])
 
     assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert entry.options[integration.CONF_CREATE_FORECAST_SENSORS] == "D+1"
     assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
     assert "http_referer" not in entry.data
     assert "http_referer" not in entry.options
     assert entry.version == integration.TARGET_ENTRY_VERSION
+    assert (
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        in integration.issue_helpers.ir.registry.issues
+    )
 
 
 def test_migrate_entry_v3_legacy_creates_location_subentry(
@@ -1659,8 +1695,6 @@ def test_migrate_entry_v3_legacy_creates_location_subentry(
     assert entry.options == {
         integration.CONF_UPDATE_INTERVAL: 12,
         integration.CONF_LANGUAGE_CODE: "en",
-        integration.CONF_FORECAST_DAYS: 3,
-        integration.CONF_CREATE_FORECAST_SENSORS: "D+1",
     }
     assert len(entry.subentries) == 1
     subentry = next(iter(entry.subentries.values()))
@@ -1673,6 +1707,10 @@ def test_migrate_entry_v3_legacy_creates_location_subentry(
         integration.CONF_LEGACY_ENTRY_ID: "legacy-entry",
     }
     assert hass.config_entries.added_subentries == [(entry, subentry)]
+    assert (
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        in integration.issue_helpers.ir.registry.issues
+    )
 
 
 def test_migrate_single_legacy_entry_attaches_registries_to_created_subentry(
@@ -2012,7 +2050,6 @@ def test_migrate_legacy_entries_with_same_api_key_group_under_one_parent(
     assert parent.options == {
         integration.CONF_UPDATE_INTERVAL: 12,
         integration.CONF_LANGUAGE_CODE: "en",
-        integration.CONF_FORECAST_DAYS: 3,
     }
     assert len(parent.subentries) == 2
     subentries_by_legacy_id = {
@@ -3964,97 +4001,6 @@ def test_setup_entry_skips_entries_already_marked_as_merged(
     assert hass.config_entries.forward_calls == []
 
 
-def test_migrate_entry_normalizes_invalid_mode(
-    integration_modules: _InitModules,
-) -> None:
-    """Migration should normalize invalid per-day sensor mode values."""
-    integration = integration_modules.integration
-    const = integration_modules.const
-
-    entry = _FakeEntry(
-        integration,
-        data={
-            integration.CONF_API_KEY: "key",
-            integration.CONF_LATITUDE: 1.0,
-            integration.CONF_LONGITUDE: 2.0,
-            integration.CONF_CREATE_FORECAST_SENSORS: "bad-value",
-        },
-        options={},
-        version=1,
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert (
-        entry.options[integration.CONF_CREATE_FORECAST_SENSORS]
-        == const.FORECAST_SENSORS_CHOICES[0]
-    )
-    assert entry.version == integration.TARGET_ENTRY_VERSION
-
-
-def test_migrate_entry_normalizes_invalid_mode_in_options(
-    integration_modules: _InitModules,
-) -> None:
-    """Migration should normalize invalid per-day sensor mode values in options."""
-    integration = integration_modules.integration
-    const = integration_modules.const
-
-    entry = _FakeEntry(
-        integration,
-        data={},
-        options={integration.CONF_CREATE_FORECAST_SENSORS: "bad-value"},
-        version=1,
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert (
-        entry.options[integration.CONF_CREATE_FORECAST_SENSORS]
-        == const.FORECAST_SENSORS_CHOICES[0]
-    )
-    assert entry.version == integration.TARGET_ENTRY_VERSION
-
-
-def test_migrate_entry_normalizes_invalid_mode_in_options_when_version_current(
-    integration_modules: _InitModules,
-) -> None:
-    """Migration should normalize invalid mode values even at the target version."""
-    integration = integration_modules.integration
-
-    entry = _FakeEntry(
-        integration,
-        data={
-            integration.CONF_API_KEY: "key",
-            integration.CONF_LATITUDE: 1.0,
-            integration.CONF_LONGITUDE: 2.0,
-        },
-        options={integration.CONF_CREATE_FORECAST_SENSORS: "invalid-value"},
-        version=integration.TARGET_ENTRY_VERSION,
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert entry.options[integration.CONF_CREATE_FORECAST_SENSORS] == "none"
-    assert entry.version == integration.TARGET_ENTRY_VERSION
-
-
-def test_migrate_entry_marks_version_when_no_changes(
-    integration_modules: _InitModules,
-) -> None:
-    """Migration should still bump the version when no changes are needed."""
-    integration = integration_modules.integration
-
-    entry = _FakeEntry(
-        integration,
-        options={integration.CONF_CREATE_FORECAST_SENSORS: "D+1"},
-        version=1,
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert entry.version == integration.TARGET_ENTRY_VERSION
-
-
 def test_migrate_entry_cleans_legacy_keys_when_version_current(
     integration_modules: _InitModules,
 ) -> None:
@@ -4079,6 +4025,7 @@ def test_migrate_entry_cleans_legacy_keys_when_version_current(
     assert "http_referer" not in entry.data
     assert "http_referer" not in entry.options
     assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
     assert entry.version == integration.TARGET_ENTRY_VERSION
 
 
@@ -4107,10 +4054,10 @@ def test_migrate_entry_does_not_downgrade_version(
     assert entry.version == integration.TARGET_ENTRY_VERSION + 1
 
 
-def test_migrate_entry_removes_mode_from_data_when_in_options(
+def test_migrate_entry_removes_mode_from_data_and_options(
     integration_modules: _InitModules,
 ) -> None:
-    """Migration should remove per-day sensor mode from data when already in options."""
+    """Migration should remove per-day sensor mode from both data and options."""
     integration = integration_modules.integration
 
     entry = _FakeEntry(
@@ -4128,7 +4075,11 @@ def test_migrate_entry_removes_mode_from_data_when_in_options(
 
     assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
     assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
-    assert entry.options[integration.CONF_CREATE_FORECAST_SENSORS] == "D+1"
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
+    assert (
+        integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        in integration.issue_helpers.ir.registry.issues
+    )
 
 
 @pytest.mark.parametrize("version", [None, "x"])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1070,11 +1070,11 @@ def test_setup_entry_drops_legacy_per_day_option_and_creates_repair_issue(
     assert issue["is_persistent"] is True
 
 
-def test_setup_entry_drops_legacy_forecast_days_from_data(
+def test_setup_entry_drops_inactive_legacy_forecast_options_without_issue(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Setup should remove obsolete forecast-days data without a Repair warning."""
+    """Setup should remove inactive legacy forecast options without a Repair warning."""
     integration = integration_modules.integration
     base_data_update_coordinator = integration_modules.base_data_update_coordinator
 
@@ -1086,7 +1086,9 @@ def test_setup_entry_drops_legacy_forecast_days_from_data(
             integration.CONF_LATITUDE: 1.0,
             integration.CONF_LONGITUDE: 2.0,
             integration.CONF_FORECAST_DAYS: 1,
+            integration.CONF_CREATE_FORECAST_SENSORS: "none",
         },
+        options={integration.CONF_CREATE_FORECAST_SENSORS: "none"},
     )
 
     class _StubClient:
@@ -1118,6 +1120,8 @@ def test_setup_entry_drops_legacy_forecast_days_from_data(
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert entry.runtime_data is not None
     assert integration.CONF_FORECAST_DAYS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
     assert (
         integration.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
         not in integration.issue_helpers.ir.registry.issues

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -401,6 +401,94 @@ def test_migration_removes_per_day_option_and_creates_repair_issue(
     assert issue["severity"] == migration_modules.issue_helpers.ir.IssueSeverity.WARNING
 
 
+def test_grouped_migration_removes_inactive_per_day_options_without_repair_issue(
+    migration_modules: _MigrateModules,
+) -> None:
+    """Grouped migration should remove inactive per-day options silently."""
+    integration = migration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        title="Home",
+        data={
+            integration.CONF_API_KEY: "shared-key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_CREATE_FORECAST_SENSORS: "none",
+        },
+        options={integration.CONF_CREATE_FORECAST_SENSORS: "none"},
+        version=3,
+        subentries={},
+    )
+    duplicate = _FakeEntry(
+        integration,
+        entry_id="legacy-office",
+        title="Office",
+        data={
+            integration.CONF_API_KEY: "shared-key",
+            integration.CONF_LATITUDE: 3.0,
+            integration.CONF_LONGITUDE: 4.0,
+        },
+        options={integration.CONF_CREATE_FORECAST_SENSORS: "none"},
+        version=3,
+        subentries={},
+    )
+    hass = _FakeHass(entries=[parent, duplicate])
+
+    assert asyncio.run(integration.async_migrate_entry(hass, parent)) is True
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in parent.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in parent.options
+    assert (
+        migration_modules.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        not in registry.issues
+    )
+
+
+def test_grouped_migration_creates_repair_issue_for_active_per_day_option(
+    migration_modules: _MigrateModules,
+) -> None:
+    """Grouped migration should warn when any source used per-day sensors."""
+    integration = migration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    parent = _FakeEntry(
+        integration,
+        entry_id="legacy-home",
+        title="Home",
+        data={
+            integration.CONF_API_KEY: "shared-key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_CREATE_FORECAST_SENSORS: "none",
+        },
+        version=3,
+        subentries={},
+    )
+    duplicate = _FakeEntry(
+        integration,
+        entry_id="legacy-office",
+        title="Office",
+        data={
+            integration.CONF_API_KEY: "shared-key",
+            integration.CONF_LATITUDE: 3.0,
+            integration.CONF_LONGITUDE: 4.0,
+        },
+        options={integration.CONF_CREATE_FORECAST_SENSORS: "D+1+2"},
+        version=3,
+        subentries={},
+    )
+    hass = _FakeHass(entries=[parent, duplicate])
+
+    assert asyncio.run(integration.async_migrate_entry(hass, parent)) is True
+    issue = registry.issues[
+        migration_modules.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    ]
+    assert issue["domain"] == integration.DOMAIN
+    assert issue["translation_key"] == "per_day_forecast_sensors_removed"
+
+
 def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
     migration_modules: _MigrateModules,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -329,10 +329,10 @@ def migration_modules(
     )
 
 
-def test_migration_removes_forecast_days_without_repair_issue(
+def test_migration_removes_inactive_legacy_forecast_options_without_repair_issue(
     migration_modules: _MigrateModules,
 ) -> None:
-    """Legacy forecast-day storage should be removed silently."""
+    """Inactive legacy forecast options should be removed silently."""
     integration = migration_modules.integration
     registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
@@ -343,8 +343,12 @@ def test_migration_removes_forecast_days_without_repair_issue(
             integration.CONF_LATITUDE: 1.0,
             integration.CONF_LONGITUDE: 2.0,
             integration.CONF_FORECAST_DAYS: 3,
+            integration.CONF_CREATE_FORECAST_SENSORS: "none",
         },
-        options={integration.CONF_FORECAST_DAYS: 3},
+        options={
+            integration.CONF_FORECAST_DAYS: 3,
+            integration.CONF_CREATE_FORECAST_SENSORS: "none",
+        },
         version=3,
     )
     hass = _FakeHass(entries=[entry])
@@ -352,6 +356,8 @@ def test_migration_removes_forecast_days_without_repair_issue(
     assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
     assert integration.CONF_FORECAST_DAYS not in entry.data
     assert integration.CONF_FORECAST_DAYS not in entry.options
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
     assert (
         migration_modules.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
         not in registry.issues

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -329,6 +329,72 @@ def migration_modules(
     )
 
 
+def test_migration_removes_forecast_days_without_repair_issue(
+    migration_modules: _MigrateModules,
+) -> None:
+    """Legacy forecast-day storage should be removed silently."""
+    integration = migration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    entry = _FakeEntry(
+        integration,
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_FORECAST_DAYS: 3,
+        },
+        options={integration.CONF_FORECAST_DAYS: 3},
+        version=3,
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
+    assert integration.CONF_FORECAST_DAYS not in entry.data
+    assert integration.CONF_FORECAST_DAYS not in entry.options
+    assert (
+        migration_modules.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+        not in registry.issues
+    )
+
+
+def test_migration_removes_per_day_option_and_creates_repair_issue(
+    migration_modules: _MigrateModules,
+) -> None:
+    """Legacy per-day sensor storage should be removed with a Repair warning."""
+    integration = migration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    entry = _FakeEntry(
+        integration,
+        data={
+            integration.CONF_API_KEY: "key",
+            integration.CONF_LATITUDE: 1.0,
+            integration.CONF_LONGITUDE: 2.0,
+            integration.CONF_CREATE_FORECAST_SENSORS: "D+1",
+        },
+        options={
+            integration.CONF_FORECAST_DAYS: 3,
+            integration.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
+        },
+        version=3,
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
+    assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
+    assert integration.CONF_FORECAST_DAYS not in entry.options
+    issue = registry.issues[
+        migration_modules.issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    ]
+    assert issue["domain"] == integration.DOMAIN
+    assert issue["translation_key"] == "per_day_forecast_sensors_removed"
+    assert issue["is_fixable"] is False
+    assert issue["is_persistent"] is True
+    assert issue["severity"] == migration_modules.issue_helpers.ir.IssueSeverity.WARNING
+
+
 def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
     migration_modules: _MigrateModules,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -40,12 +40,8 @@ class OptionsFlowEnv:
     CONF_LATITUDE: str
     CONF_LONGITUDE: str
     CONF_UPDATE_INTERVAL: str
-    DEFAULT_FORECAST_DAYS: int
     DEFAULT_UPDATE_INTERVAL: int
-    FORECAST_SENSORS_CHOICES: list[str]
-    MAX_FORECAST_DAYS: int
     MAX_UPDATE_INTERVAL_HOURS: int
-    MIN_FORECAST_DAYS: int
     MIN_UPDATE_INTERVAL_HOURS: int
 
 
@@ -171,24 +167,21 @@ def options_flow_env(monkeypatch: pytest.MonkeyPatch) -> OptionsFlowEnv:
     monkeypatch.setitem(sys_modules, "voluptuous", vol_mod)
 
     cf = importlib.import_module("custom_components.pollenlevels.config_flow")
+    const = importlib.import_module("custom_components.pollenlevels.const")
 
     return OptionsFlowEnv(
         config_flow=cf,
         PollenLevelsOptionsFlow=cf.PollenLevelsOptionsFlow,
         StubConfigEntry=StubConfigEntry,
         CONF_API_KEY=cf.CONF_API_KEY,
-        CONF_CREATE_FORECAST_SENSORS=cf.CONF_CREATE_FORECAST_SENSORS,
-        CONF_FORECAST_DAYS=cf.CONF_FORECAST_DAYS,
+        CONF_CREATE_FORECAST_SENSORS=const.CONF_CREATE_FORECAST_SENSORS,
+        CONF_FORECAST_DAYS=const.CONF_FORECAST_DAYS,
         CONF_LANGUAGE_CODE=cf.CONF_LANGUAGE_CODE,
         CONF_LATITUDE=cf.CONF_LATITUDE,
         CONF_LONGITUDE=cf.CONF_LONGITUDE,
         CONF_UPDATE_INTERVAL=cf.CONF_UPDATE_INTERVAL,
-        DEFAULT_FORECAST_DAYS=cf.DEFAULT_FORECAST_DAYS,
         DEFAULT_UPDATE_INTERVAL=cf.DEFAULT_UPDATE_INTERVAL,
-        FORECAST_SENSORS_CHOICES=cf.FORECAST_SENSORS_CHOICES,
-        MAX_FORECAST_DAYS=cf.MAX_FORECAST_DAYS,
         MAX_UPDATE_INTERVAL_HOURS=cf.MAX_UPDATE_INTERVAL_HOURS,
-        MIN_FORECAST_DAYS=cf.MIN_FORECAST_DAYS,
         MIN_UPDATE_INTERVAL_HOURS=cf.MIN_UPDATE_INTERVAL_HOURS,
     )
 
@@ -206,8 +199,6 @@ def _flow(
             env.CONF_LONGITUDE: 2.0,
             env.CONF_LANGUAGE_CODE: "en",
             env.CONF_UPDATE_INTERVAL: 6,
-            env.CONF_FORECAST_DAYS: 2,
-            env.CONF_CREATE_FORECAST_SENSORS: "none",
         },
         options=options,
     )
@@ -241,8 +232,6 @@ def test_options_flow_invalid_language_sets_error(
         flow.async_step_init(
             {
                 options_flow_env.CONF_LANGUAGE_CODE: "bad code",
-                options_flow_env.CONF_FORECAST_DAYS: 2,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
                 options_flow_env.CONF_UPDATE_INTERVAL: 6,
             }
         )
@@ -264,8 +253,6 @@ def test_options_flow_invalid_language_code_not_logged_raw(
             flow.async_step_init(
                 {
                     options_flow_env.CONF_LANGUAGE_CODE: "bad code",
-                    options_flow_env.CONF_FORECAST_DAYS: 2,
-                    options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
                     options_flow_env.CONF_UPDATE_INTERVAL: 6,
                 }
             )
@@ -277,70 +264,50 @@ def test_options_flow_invalid_language_code_not_logged_raw(
     }
 
 
-def test_options_flow_forecast_days_below_min_sets_error(
+def test_options_flow_drops_removed_forecast_options(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
-    """Forecast days below allowed range should error."""
+    """Legacy forecast option keys should be ignored and removed on save."""
 
-    flow = _flow(options_flow_env)
+    flow = _flow(
+        options_flow_env,
+        options={
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+            options_flow_env.CONF_UPDATE_INTERVAL: 6,
+            options_flow_env.CONF_FORECAST_DAYS: 2,
+            options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1",
+        },
+    )
 
     result = asyncio.run(
         flow.async_step_init(
             {
-                options_flow_env.CONF_LANGUAGE_CODE: "en",
+                options_flow_env.CONF_LANGUAGE_CODE: " es ",
+                options_flow_env.CONF_UPDATE_INTERVAL: 8,
                 options_flow_env.CONF_FORECAST_DAYS: 0,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
-                options_flow_env.CONF_UPDATE_INTERVAL: 6,
+                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
             }
         )
     )
 
-    assert result["errors"] == {
-        options_flow_env.CONF_FORECAST_DAYS: "invalid_forecast_days",
-        options_flow_env.CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo",
-    }
-
-
-@pytest.mark.parametrize(
-    "mode,days",
-    [("D+1", 1), ("D+1+2", 2)],
-)
-def test_options_flow_per_day_sensor_requires_enough_days(
-    options_flow_env: OptionsFlowEnv,
-    mode: str,
-    days: int,
-) -> None:
-    """Per-day sensor modes should enforce minimum forecast days."""
-
-    flow = _flow(options_flow_env)
-
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_FORECAST_DAYS: days,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: mode,
-                options_flow_env.CONF_UPDATE_INTERVAL: 6,
-            }
-        )
-    )
-
-    assert result["errors"] == {
-        options_flow_env.CONF_CREATE_FORECAST_SENSORS: "invalid_option_combo"
+    assert result == {
+        "title": "",
+        "data": {
+            options_flow_env.CONF_LANGUAGE_CODE: "es",
+            options_flow_env.CONF_UPDATE_INTERVAL: 8,
+        },
     }
 
 
 def test_options_flow_valid_submission_returns_entry_data(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
-    """A valid options submission should return the data unchanged."""
+    """A valid options submission should return supported options only."""
 
     flow = _flow(options_flow_env)
 
     user_input = {
         options_flow_env.CONF_LANGUAGE_CODE: " es ",
-        options_flow_env.CONF_FORECAST_DAYS: 3,
-        options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1",
         options_flow_env.CONF_UPDATE_INTERVAL: 8,
     }
 
@@ -349,8 +316,8 @@ def test_options_flow_valid_submission_returns_entry_data(
     assert result == {
         "title": "",
         "data": {
-            **user_input,
             options_flow_env.CONF_LANGUAGE_CODE: "es",
+            options_flow_env.CONF_UPDATE_INTERVAL: 8,
         },
     }
 
@@ -366,8 +333,6 @@ def test_options_flow_update_interval_below_min_sets_error(
         flow.async_step_init(
             {
                 options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_FORECAST_DAYS: 2,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
                 options_flow_env.CONF_UPDATE_INTERVAL: 0,
             }
         )
@@ -389,8 +354,6 @@ def test_options_flow_invalid_update_interval_short_circuits(
         flow.async_step_init(
             {
                 options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_FORECAST_DAYS: 0,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
                 options_flow_env.CONF_UPDATE_INTERVAL: "not-a-number",
             }
         )
@@ -412,8 +375,6 @@ def test_options_flow_update_interval_above_max_sets_error(
         flow.async_step_init(
             {
                 options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_FORECAST_DAYS: 2,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "none",
                 options_flow_env.CONF_UPDATE_INTERVAL: 999,
             }
         )
@@ -463,66 +424,28 @@ def test_options_schema_update_interval_default_is_sanitized(
     assert captured_defaults == [expected]
 
 
-@pytest.mark.parametrize(
-    ("raw_value", "expected_name"),
-    [
-        (0, "MIN_FORECAST_DAYS"),
-        (999, "MAX_FORECAST_DAYS"),
-        ("abc", "DEFAULT_FORECAST_DAYS"),
-    ],
-)
-def test_options_schema_forecast_days_default_is_sanitized(
+def test_options_schema_omits_removed_forecast_options(
     monkeypatch: pytest.MonkeyPatch,
     options_flow_env: OptionsFlowEnv,
-    raw_value: object,
-    expected_name: str,
 ) -> None:
-    """Options form should clamp invalid forecast day defaults."""
+    """Removed forecast options should not be exposed in the options schema."""
 
-    expected = str(
-        {
-            "MIN_FORECAST_DAYS": options_flow_env.MIN_FORECAST_DAYS,
-            "MAX_FORECAST_DAYS": options_flow_env.MAX_FORECAST_DAYS,
-            "DEFAULT_FORECAST_DAYS": options_flow_env.DEFAULT_FORECAST_DAYS,
-        }[expected_name]
-    )
-    captured_defaults: list[str | None] = []
+    captured_keys: list[str] = []
 
     def _capture_optional(key, **kwargs):
-        if key == options_flow_env.CONF_FORECAST_DAYS:
-            captured_defaults.append(kwargs.get("default"))
+        captured_keys.append(key)
         return key
 
     monkeypatch.setattr(options_flow_env.config_flow.vol, "Optional", _capture_optional)
 
     flow = _flow(
         options_flow_env,
-        options={options_flow_env.CONF_FORECAST_DAYS: raw_value},
+        options={
+            options_flow_env.CONF_FORECAST_DAYS: 0,
+            options_flow_env.CONF_CREATE_FORECAST_SENSORS: "bad",
+        },
     )
     asyncio.run(flow.async_step_init(user_input=None))
 
-    assert captured_defaults == [expected]
-
-
-def test_options_schema_sensor_mode_default_is_sanitized(
-    monkeypatch: pytest.MonkeyPatch,
-    options_flow_env: OptionsFlowEnv,
-) -> None:
-    """Options form should fall back to a valid sensor mode default."""
-
-    captured_defaults: list[str | None] = []
-
-    def _capture_optional(key, **kwargs):
-        if key == options_flow_env.CONF_CREATE_FORECAST_SENSORS:
-            captured_defaults.append(kwargs.get("default"))
-        return key
-
-    monkeypatch.setattr(options_flow_env.config_flow.vol, "Optional", _capture_optional)
-
-    flow = _flow(
-        options_flow_env,
-        options={options_flow_env.CONF_CREATE_FORECAST_SENSORS: "bad"},
-    )
-    asyncio.run(flow.async_step_init(user_input=None))
-
-    assert captured_defaults == [options_flow_env.FORECAST_SENSORS_CHOICES[0]]
+    assert options_flow_env.CONF_FORECAST_DAYS not in captured_keys
+    assert options_flow_env.CONF_CREATE_FORECAST_SENSORS not in captured_keys

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2026,12 +2026,12 @@ def test_remove_legacy_per_day_entities_removes_only_matching_legacy_entities(
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
     try:
-        removed = loop.run_until_complete(
+        found, removed = loop.run_until_complete(
             sensor_modules.sensor._remove_legacy_per_day_entities(
                 hass, "entry", "entry"
             )
         )
-        removed_again = loop.run_until_complete(
+        found_again, removed_again = loop.run_until_complete(
             sensor_modules.sensor._remove_legacy_per_day_entities(
                 hass, "entry", "entry"
             )
@@ -2039,7 +2039,9 @@ def test_remove_legacy_per_day_entities_removes_only_matching_legacy_entities(
     finally:
         loop.close()
 
+    assert found == 2
     assert removed == 2
+    assert found_again == 0
     assert removed_again == 0
     assert registry.removals == [
         "sensor.pollen_type_grass_d1",
@@ -2084,7 +2086,7 @@ def test_remove_legacy_per_day_entities_logs_failed_removal_without_raising(
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
     try:
-        removed = loop.run_until_complete(
+        found, removed = loop.run_until_complete(
             sensor_modules.sensor._remove_legacy_per_day_entities(
                 hass, "entry", "entry"
             )
@@ -2092,6 +2094,7 @@ def test_remove_legacy_per_day_entities_logs_failed_removal_without_raising(
     finally:
         loop.close()
 
+    assert found == 2
     assert removed == 1
     assert registry.removals == ["sensor.pollen_type_grass_d2"]
     assert "Failed to remove legacy per-day entity from registry" in caplog.text
@@ -2559,6 +2562,50 @@ def test_coordinator_retries_then_wraps_client_error(
     assert delays == [0.8]
 
 
+def test_coordinator_redacts_coordinates_in_unexpected_api_errors(
+    sensor_modules: SensorModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected API errors should not log exact coordinates or API keys."""
+
+    class _FailingClient:
+        async def async_fetch_pollen_data(self, **_kwargs):
+            msg = (
+                "boom https://pollen.googleapis.com/v1/forecast:lookup?"
+                "key=secret&location.latitude=12.345678"
+                "&location.longitude=-98.765432"
+            )
+            raise RuntimeError(msg)
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="secret",
+        lat=12.345678,
+        lon=-98.765432,
+        hours=12,
+        language=None,
+        entry_id="entry",
+        client=_FailingClient(),
+    )
+    caplog.set_level(logging.ERROR, logger=sensor_modules.coordinator_mod._LOGGER.name)
+
+    try:
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed) as exc_info:
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    rendered_error = str(exc_info.value)
+    assert "secret" not in rendered_error
+    assert "12.345678" not in rendered_error
+    assert "-98.765432" not in rendered_error
+    assert "secret" not in caplog.text
+    assert "12.345678" not in caplog.text
+    assert "-98.765432" not in caplog.text
+
+
 def test_async_setup_entry_raises_not_ready_if_runtime_data_missing(
     sensor_modules: SensorModules,
 ) -> None:
@@ -2668,6 +2715,81 @@ async def test_async_setup_entry_skips_legacy_d1_d2_data_keys(
     assert "entry_type_grass" in unique_ids
     assert all(not uid.endswith("_d1") for uid in unique_ids)
     assert all(not uid.endswith("_d2") for uid in unique_ids)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_repair_when_legacy_removal_fails(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy entity detection should warn even if registry removal fails."""
+
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 1.0,
+            sensor_modules.sensor.CONF_LONGITUDE: 2.0,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+        },
+        entry_id="entry",
+    )
+    entries = [
+        RegistryEntry(
+            "sensor.pollen_type_grass_d1",
+            "entry_type_grass_d1",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.pollen_type_grass_d2",
+            "entry_type_grass_d2",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+    ]
+    registry = _setup_registry_stub(
+        sensor_modules, monkeypatch, entries, entry_id="entry"
+    )
+
+    def _failing_remove(_entity_id: str) -> None:
+        raise RuntimeError("registry removal failed")
+
+    monkeypatch.setattr(registry, "async_remove", _failing_remove)
+
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "key")
+    coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="key",
+        lat=1.0,
+        lon=2.0,
+        hours=sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
+        language=None,
+        entry_id="entry",
+        entry_title=sensor_modules.const.DEFAULT_ENTRY_TITLE,
+        client=client,
+    )
+    coordinator.data = {
+        "date": {"source": "meta"},
+        "region": {"source": "meta"},
+        "type_grass": {"source": "type", "name": "Grass"},
+    }
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        coordinator=coordinator, client=client
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, _update_before_add=False):
+        captured.extend(entities)
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    issue_registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+    issue_helpers = sys.modules["custom_components.pollenlevels.issue_helpers"]
+    issue_id = issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    assert issue_id in issue_registry.issues
+    assert registry.removals == []
+    assert captured
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2894,6 +2894,152 @@ async def test_async_setup_entry_creates_repair_when_legacy_removal_fails(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_cleans_legacy_entities_for_stale_locations(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Legacy cleanup should run even when stale runtime locations are skipped."""
+
+    coordinate_identity = "39.1234_-0.1234"
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={sensor_modules.sensor.CONF_API_KEY: "key"},
+        entry_id="entry",
+    )
+    config_entry.subentries = {
+        "active-location": types.SimpleNamespace(
+            subentry_id="active-location",
+            subentry_type=sensor_modules.const.SUBENTRY_TYPE_LOCATION,
+        )
+    }
+    coordinator = types.SimpleNamespace(
+        data={
+            "date": {"source": "meta", "value": "2026-05-08"},
+            "type_grass": {
+                "source": "type",
+                "displayName": "Grass",
+                "value": 3,
+            },
+        },
+        entry_id="entry",
+        subentry_id="deleted-location",
+        entity_identity_id=coordinate_identity,
+        entry_title="Deleted",
+        lat=39.1234,
+        lon=-0.1234,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "deleted-location": types.SimpleNamespace(
+                subentry_id="deleted-location",
+                coordinator=coordinator,
+            )
+        },
+    )
+    registry = _setup_registry_stub(
+        sensor_modules,
+        monkeypatch,
+        [
+            RegistryEntry(
+                "sensor.pollen_type_grass_d1",
+                f"{coordinate_identity}_type_grass_d1",
+                "sensor",
+                sensor_modules.sensor.DOMAIN,
+            )
+        ],
+        entry_id="entry",
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, **_kwargs):
+        captured.extend(entities)
+
+    caplog.set_level(logging.DEBUG, logger=sensor_modules.sensor._LOGGER.name)
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    issue_registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+    issue_helpers = sys.modules["custom_components.pollenlevels.issue_helpers"]
+    issue_id = issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    assert issue_id in issue_registry.issues
+    assert registry.removals == ["sensor.pollen_type_grass_d1"]
+    assert captured == []
+    assert coordinate_identity not in caplog.text
+    assert f"{coordinate_identity}_type_grass_d1" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_cleans_legacy_entities_before_no_data_error(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy cleanup should happen before no-data setup raises not-ready."""
+
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={sensor_modules.sensor.CONF_API_KEY: "key"},
+        entry_id="entry",
+    )
+    config_entry.subentries = {
+        "active-location": types.SimpleNamespace(
+            subentry_id="active-location",
+            subentry_type=sensor_modules.const.SUBENTRY_TYPE_LOCATION,
+        )
+    }
+    coordinator = types.SimpleNamespace(
+        data={"region": {"source": "meta"}},
+        entry_id="entry",
+        subentry_id="active-location",
+        entity_identity_id="entry",
+        entry_title="Home",
+        lat=1.0,
+        lon=2.0,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "active-location": types.SimpleNamespace(
+                subentry_id="active-location",
+                coordinator=coordinator,
+            )
+        },
+    )
+    registry = _setup_registry_stub(
+        sensor_modules,
+        monkeypatch,
+        [
+            RegistryEntry(
+                "sensor.pollen_type_grass_d2",
+                "entry_type_grass_d2",
+                "sensor",
+                sensor_modules.sensor.DOMAIN,
+            )
+        ],
+        entry_id="entry",
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, **_kwargs):
+        captured.extend(entities)
+
+    with pytest.raises(sensor_modules.sensor.ConfigEntryNotReady):
+        await sensor_modules.sensor.async_setup_entry(
+            hass, config_entry, _capture_entities
+        )
+
+    issue_registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+    issue_helpers = sys.modules["custom_components.pollenlevels.issue_helpers"]
+    issue_id = issue_helpers.PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    assert issue_id in issue_registry.issues
+    assert registry.removals == ["sensor.pollen_type_grass_d2"]
+    assert captured == []
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_stale_runtime_locations(
     sensor_modules: SensorModules,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,6 +20,7 @@ from tests._ha_stubs import (
     stub_custom_components_packages,
     stub_exceptions,
     stub_homeassistant_package,
+    stub_issue_registry_module,
     stub_update_coordinator_module,
     stub_util_dt_module,
 )
@@ -44,6 +45,14 @@ def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     stub_custom_components_packages(root=ROOT, monkeypatch=monkeypatch)
 
     ha = stub_homeassistant_package(monkeypatch=monkeypatch)
+
+    core_mod = types.ModuleType("homeassistant.core")
+
+    class _StubHomeAssistant:  # pragma: no cover - import-time type only
+        pass
+
+    core_mod.HomeAssistant = _StubHomeAssistant
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core_mod)
 
     ha.components = types.ModuleType("homeassistant.components")
     monkeypatch.setitem(sys.modules, "homeassistant.components", ha.components)
@@ -194,6 +203,7 @@ def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     stub_util_dt_module(monkeypatch=monkeypatch)
+    stub_issue_registry_module(monkeypatch=monkeypatch)
 
     stub_aiohttp_module(monkeypatch=monkeypatch)
 
@@ -362,9 +372,6 @@ def _make_coordinator(
     client: Any,
     *,
     hours: int = 12,
-    forecast_days: int = 1,
-    create_d1: bool = False,
-    create_d2: bool = False,
 ) -> Any:
     """Build a coordinator with stable defaults for refresh tests."""
 
@@ -376,9 +383,6 @@ def _make_coordinator(
         hours=hours,
         language=None,
         entry_id="entry",
-        forecast_days=forecast_days,
-        create_d1=create_d1,
-        create_d2=create_d2,
         client=client,
     )
 
@@ -414,6 +418,9 @@ class RegistryStub:
 
     def async_remove(self, entity_id: str) -> None:
         self.removals.append(entity_id)
+        self._entries = [
+            entry for entry in self._entries if entry.entity_id != entity_id
+        ]
 
 
 def _setup_registry_stub(
@@ -465,7 +472,6 @@ def test_sensor_unique_ids_and_devices_use_legacy_identity(
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=2,
     )
 
     entity = sensor_modules.sensor.PollenSensor(coordinator, "type_grass")
@@ -490,7 +496,6 @@ def test_sensor_unique_ids_survive_subentry_title_and_coordinate_changes(
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=2,
     )
     changed = types.SimpleNamespace(
         data=first.data,
@@ -501,7 +506,6 @@ def test_sensor_unique_ids_survive_subentry_title_and_coordinate_changes(
         entry_title="Renamed Home",
         lat=3.0,
         lon=4.0,
-        forecast_days=2,
     )
 
     first_entity = sensor_modules.sensor.PollenSensor(first, "type_grass")
@@ -982,8 +986,8 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing(
     assert second_data == coordinator.data
 
 
-def test_coordinator_clamps_forecast_days_low(sensor_modules: SensorModules) -> None:
-    """Forecast days are clamped to minimum for legacy or invalid values."""
+def test_coordinator_uses_fixed_forecast_days(sensor_modules: SensorModules) -> None:
+    """Coordinator always uses the fixed Google Pollen maximum forecast horizon."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
@@ -998,15 +1002,12 @@ def test_coordinator_clamps_forecast_days_low(sensor_modules: SensorModules) -> 
             hours=12,
             language=None,
             entry_id="entry",
-            forecast_days=0,
-            create_d1=False,
-            create_d2=False,
             client=client,
         )
     finally:
         loop.close()
 
-    assert coordinator.forecast_days == sensor_modules.const.MIN_FORECAST_DAYS
+    assert coordinator.forecast_days == sensor_modules.const.FORECAST_DAYS
 
 
 def test_coordinator_first_refresh_missing_dailyinfo_raises(
@@ -1131,7 +1132,7 @@ def test_coordinator_mixed_dailyinfo_items_keep_last_data(
     client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(sensor_modules, loop, client, forecast_days=2)
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1194,9 +1195,6 @@ def test_coordinator_stale_data_ttl_accounts_for_update_interval(
             hours=6,
             language=None,
             entry_id="entry-6h",
-            forecast_days=1,
-            create_d1=False,
-            create_d2=False,
             client=client,
         )
         twenty_four_hour = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
@@ -1207,9 +1205,6 @@ def test_coordinator_stale_data_ttl_accounts_for_update_interval(
             hours=24,
             language=None,
             entry_id="entry-24h",
-            forecast_days=1,
-            create_d1=False,
-            create_d2=False,
             client=client,
         )
     finally:
@@ -1260,89 +1255,32 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
     assert coordinator.last_updated == second_refresh
 
 
-def test_coordinator_clamps_forecast_days_negative(
+def test_coordinator_rejects_removed_forecast_day_arguments(
     sensor_modules: SensorModules,
 ) -> None:
-    """Negative forecast days are clamped to minimum."""
+    """Removed forecast sensor arguments are no longer part of the constructor."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
     client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
 
     try:
-        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
-            hass=hass,
-            api_key="test",
-            lat=1.0,
-            lon=2.0,
-            hours=12,
-            language=None,
-            entry_id="entry",
-            forecast_days=-5,
-            create_d1=False,
-            create_d2=False,
-            client=client,
-        )
+        with pytest.raises(TypeError):
+            sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+                hass=hass,
+                api_key="test",
+                lat=1.0,
+                lon=2.0,
+                hours=12,
+                language=None,
+                entry_id="entry",
+                forecast_days=1,
+                create_d1=False,
+                create_d2=False,
+                client=client,
+            )
     finally:
         loop.close()
-
-    assert coordinator.forecast_days == sensor_modules.const.MIN_FORECAST_DAYS
-
-
-def test_coordinator_clamps_forecast_days_high(sensor_modules: SensorModules) -> None:
-    """Forecast days are clamped to maximum for legacy or invalid values."""
-
-    loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
-
-    try:
-        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
-            hass=hass,
-            api_key="test",
-            lat=1.0,
-            lon=2.0,
-            hours=12,
-            language=None,
-            entry_id="entry",
-            forecast_days=10,
-            create_d1=False,
-            create_d2=False,
-            client=client,
-        )
-    finally:
-        loop.close()
-
-    assert coordinator.forecast_days == sensor_modules.const.MAX_FORECAST_DAYS
-
-
-def test_coordinator_keeps_forecast_days_within_range(
-    sensor_modules: SensorModules,
-) -> None:
-    """Valid forecast days remain unchanged after initialization."""
-
-    loop = asyncio.new_event_loop()
-    hass = DummyHass(loop)
-    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
-
-    try:
-        coordinator = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
-            hass=hass,
-            api_key="test",
-            lat=1.0,
-            lon=2.0,
-            hours=12,
-            language=None,
-            entry_id="entry",
-            forecast_days=3,
-            create_d1=False,
-            create_d2=False,
-            client=client,
-        )
-    finally:
-        loop.close()
-
-    assert coordinator.forecast_days == 3
 
 
 def test_type_sensor_uses_forecast_metadata_when_today_missing(
@@ -1408,9 +1346,6 @@ def test_type_sensor_uses_forecast_metadata_when_today_missing(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=5,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -1516,9 +1451,6 @@ def test_plant_sensor_includes_forecast_attributes(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=5,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -1546,6 +1478,80 @@ def test_plant_sensor_includes_forecast_attributes(
     assert entry["trend"] == "up"
     assert entry["expected_peak"]["offset"] == 1
     assert entry["expected_peak"]["value"] == 4
+
+
+def test_coordinator_requests_five_days_and_exposes_four_future_offsets(
+    sensor_modules: SensorModules,
+) -> None:
+    """Coordinator requests 5 days and keeps forecast offsets 1 through 4."""
+
+    daily_info = []
+    for offset in range(5):
+        day = offset + 1
+        daily_info.append(
+            {
+                "date": {"year": 2025, "month": 6, "day": day},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": day,
+                            "category": f"TYPE-{day}",
+                            "indexDescription": f"Type day {day}",
+                        },
+                    }
+                ],
+                "plantInfo": [
+                    {
+                        "code": "ragweed",
+                        "displayName": "Ragweed",
+                        "indexInfo": {
+                            "value": day + 10,
+                            "category": f"PLANT-{day}",
+                            "indexDescription": f"Plant day {day}",
+                        },
+                    }
+                ],
+            }
+        )
+
+    payload = {"dailyInfo": daily_info}
+
+    class _CapturingClient:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def async_fetch_pollen_data(self, **kwargs):
+            self.calls.append(kwargs)
+            return payload
+
+    client = _CapturingClient()
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert client.calls[0]["days"] == sensor_modules.const.FORECAST_DAYS
+    assert [item["offset"] for item in data["type_grass"]["forecast"]] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+    assert [item["offset"] for item in data["plants_ragweed"]["forecast"]] == [
+        1,
+        2,
+        3,
+        4,
+    ]
+    assert data["type_grass"]["forecast"][3]["value"] == 5
+    assert data["plants_ragweed"]["forecast"][3]["value"] == 15
+    assert "type_grass_d1" not in data
+    assert "type_grass_d2" not in data
 
 
 def test_plant_sensor_preserves_future_health_recommendations_if_present(
@@ -1698,9 +1704,7 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior(
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
     loop = asyncio.new_event_loop()
-    coordinator = _make_coordinator(
-        sensor_modules, loop, client, forecast_days=3, create_d1=True, create_d2=True
-    )
+    coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
         data = loop.run_until_complete(coordinator._async_update_data())
@@ -1721,19 +1725,8 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior(
     assert type_entry["forecast"][1]["date"] is None
     assert type_entry["forecast"][1]["has_index"] is True
     assert type_entry["forecast"][1]["color_hex"] == "#FF6432"
-    d1_entry = data["type_grass_d1"]
-    assert d1_entry["value"] is None
-    assert d1_entry["category"] is None
-    assert d1_entry["description"] is None
-    assert d1_entry["date"] == "2025-06-02"
-    assert d1_entry["has_index"] is False
-    assert d1_entry["inSeason"] is False
-    assert d1_entry["advice"] == ["Tomorrow advice"]
-
-    d2_entry = data["type_grass_d2"]
-    assert d2_entry["value"] == 5
-    assert d2_entry["date"] is None
-    assert d2_entry["has_index"] is True
+    assert "type_grass_d1" not in data
+    assert "type_grass_d2" not in data
 
     plant_entry = data["plants_oak"]
     assert plant_entry["forecast"][0] == {
@@ -1793,9 +1786,6 @@ def test_plant_forecast_matches_codes_case_insensitively(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=3,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -1973,27 +1963,11 @@ def test_coordinator_type_keys_are_deterministic_sorted(
     assert type_keys == sorted(type_keys)
 
 
-@pytest.mark.parametrize(
-    (
-        "allow_d1",
-        "allow_d2",
-        "expected_removed",
-        "expected_entities",
-    ),
-    [
-        (False, True, 1, ["sensor.pollen_type_grass_d1"]),
-        (True, False, 1, ["sensor.pollen_type_grass_d2"]),
-    ],
-)
-def test_cleanup_per_day_entities_removes_disabled_days(
+def test_remove_legacy_per_day_entities_removes_only_matching_legacy_entities(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
-    allow_d1: bool,
-    allow_d2: bool,
-    expected_removed: int,
-    expected_entities: list[str],
 ) -> None:
-    """D+1/D+2 entities are awaited and removed when disabled."""
+    """Legacy D+1/D+2 registry cleanup only removes matching Pollen Levels sensors."""
 
     entries = [
         RegistryEntry(
@@ -2014,18 +1988,37 @@ def test_cleanup_per_day_entities_removes_disabled_days(
             "sensor",
             sensor_modules.sensor.DOMAIN,
         ),
+        RegistryEntry(
+            "sensor.pollen_plants_oak",
+            "entry_plants_oak",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.pollen_overall",
+            "entry_overall_pollen_risk_today",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.other_grass_d1",
+            "entry_type_grass_d1",
+            "sensor",
+            "other",
+        ),
+        RegistryEntry(
+            "button.pollen_type_grass_d1",
+            "entry_type_grass_d1",
+            "button",
+            sensor_modules.sensor.DOMAIN,
+        ),
+        RegistryEntry(
+            "sensor.other_location_grass_d2",
+            "other_type_grass_d2",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        ),
     ]
-    entity_ids = [entry.entity_id for entry in entries]
-    assert entity_ids == [
-        "sensor.pollen_type_grass",
-        "sensor.pollen_type_grass_d1",
-        "sensor.pollen_type_grass_d2",
-    ]
-    assert all(entity_id.startswith("sensor.") for entity_id in entity_ids)
-    assert all("sensor_modules." not in entity_id for entity_id in entity_ids)
-    assert all(entity_id.startswith("sensor.") for entity_id in expected_entities)
-    assert all("sensor_modules." not in entity_id for entity_id in expected_entities)
-
     registry = _setup_registry_stub(
         sensor_modules, monkeypatch, entries, entry_id="entry"
     )
@@ -2034,18 +2027,27 @@ def test_cleanup_per_day_entities_removes_disabled_days(
     hass = DummyHass(loop)
     try:
         removed = loop.run_until_complete(
-            sensor_modules.sensor._cleanup_per_day_entities(
-                hass, "entry", allow_d1=allow_d1, allow_d2=allow_d2
+            sensor_modules.sensor._remove_legacy_per_day_entities(
+                hass, "entry", "entry"
+            )
+        )
+        removed_again = loop.run_until_complete(
+            sensor_modules.sensor._remove_legacy_per_day_entities(
+                hass, "entry", "entry"
             )
         )
     finally:
         loop.close()
 
-    assert removed == expected_removed
-    assert registry.removals == expected_entities
+    assert removed == 2
+    assert removed_again == 0
+    assert registry.removals == [
+        "sensor.pollen_type_grass_d1",
+        "sensor.pollen_type_grass_d2",
+    ]
 
 
-def test_cleanup_per_day_entities_logs_failed_removal_without_raising(
+def test_remove_legacy_per_day_entities_logs_failed_removal_without_raising(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -2083,8 +2085,8 @@ def test_cleanup_per_day_entities_logs_failed_removal_without_raising(
     hass = DummyHass(loop)
     try:
         removed = loop.run_until_complete(
-            sensor_modules.sensor._cleanup_per_day_entities(
-                hass, "entry", allow_d1=False, allow_d2=False
+            sensor_modules.sensor._remove_legacy_per_day_entities(
+                hass, "entry", "entry"
             )
         )
     finally:
@@ -2092,10 +2094,10 @@ def test_cleanup_per_day_entities_logs_failed_removal_without_raising(
 
     assert removed == 1
     assert registry.removals == ["sensor.pollen_type_grass_d2"]
-    assert "Failed to remove stale per-day entity from registry" in caplog.text
+    assert "Failed to remove legacy per-day entity from registry" in caplog.text
 
 
-def test_cleanup_per_day_entities_propagates_cancelled_removal(
+def test_remove_legacy_per_day_entities_propagates_cancelled_removal(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2131,8 +2133,8 @@ def test_cleanup_per_day_entities_propagates_cancelled_removal(
     try:
         with pytest.raises(asyncio.CancelledError):
             loop.run_until_complete(
-                sensor_modules.sensor._cleanup_per_day_entities(
-                    hass, "entry", allow_d1=False, allow_d2=False
+                sensor_modules.sensor._remove_legacy_per_day_entities(
+                    hass, "entry", "entry"
                 )
             )
     finally:
@@ -2157,9 +2159,6 @@ def test_coordinator_raises_auth_failed(sensor_modules: SensorModules) -> None:
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -2186,9 +2185,6 @@ def test_coordinator_handles_forbidden(sensor_modules: SensorModules) -> None:
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -2218,9 +2214,6 @@ def test_coordinator_invalid_key_message_triggers_reauth(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -2553,9 +2546,6 @@ def test_coordinator_retries_then_wraps_client_error(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 
@@ -2581,7 +2571,6 @@ def test_async_setup_entry_raises_not_ready_if_runtime_data_missing(
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         }
     )
 
@@ -2624,10 +2613,10 @@ async def test_async_setup_entry_without_locations_adds_no_entities(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_skips_disabled_d1_d2_sensors(
+async def test_async_setup_entry_skips_legacy_d1_d2_data_keys(
     sensor_modules: SensorModules,
 ) -> None:
-    """Setup does not recreate D+1/D+2 sensors when forecast days disable them."""
+    """Setup does not recreate legacy D+1/D+2 sensors from accidental data keys."""
 
     hass = DummyHass(asyncio.get_running_loop())
     config_entry = FakeConfigEntry(
@@ -2636,9 +2625,7 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors(
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
-        options={sensor_modules.sensor.CONF_FORECAST_DAYS: 1},
         entry_id="entry",
     )
 
@@ -2652,9 +2639,6 @@ async def test_async_setup_entry_skips_disabled_d1_d2_sensors(
         language=None,
         entry_id="entry",
         entry_title=sensor_modules.const.DEFAULT_ENTRY_TITLE,
-        forecast_days=3,
-        create_d1=True,
-        create_d2=True,
         client=client,
     )
     coordinator.data = {
@@ -2711,9 +2695,6 @@ async def test_async_setup_entry_skips_stale_runtime_locations(
         entry_title="Deleted",
         lat=1.0,
         lon=2.0,
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
@@ -2748,7 +2729,6 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
@@ -2768,9 +2748,6 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
@@ -2811,7 +2788,6 @@ async def test_async_setup_entry_adds_daily_summary_sensors(
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id=entry_id,
     )
@@ -2837,9 +2813,6 @@ async def test_async_setup_entry_adds_daily_summary_sensors(
         entry_title="Home",
         lat=1.0,
         lon=2.0,
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
@@ -2880,7 +2853,6 @@ async def test_device_info_uses_default_title_when_blank(
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
@@ -2897,9 +2869,6 @@ async def test_device_info_uses_default_title_when_blank(
         language=None,
         entry_id="entry",
         entry_title=clean_title,
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
@@ -2938,7 +2907,6 @@ async def test_device_info_trims_custom_title(
             sensor_modules.sensor.CONF_LATITUDE: 1.0,
             sensor_modules.sensor.CONF_LONGITUDE: 2.0,
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL,
-            sensor_modules.sensor.CONF_FORECAST_DAYS: sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
         },
         entry_id="entry",
     )
@@ -2955,9 +2923,6 @@ async def test_device_info_trims_custom_title(
         language=None,
         entry_id="entry",
         entry_title=clean_title,
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
@@ -2996,9 +2961,6 @@ async def test_setup_entry_accepts_current_day_plant_prefix_without_date(
             sensor_modules.sensor.CONF_UPDATE_INTERVAL: (
                 sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL
             ),
-            sensor_modules.sensor.CONF_FORECAST_DAYS: (
-                sensor_modules.sensor.DEFAULT_FORECAST_DAYS
-            ),
         },
         entry_id="entry",
     )
@@ -3017,9 +2979,6 @@ async def test_setup_entry_accepts_current_day_plant_prefix_without_date(
         lat=1.0,
         lon=2.0,
         subentry_id="legacy",
-        forecast_days=sensor_modules.sensor.DEFAULT_FORECAST_DAYS,
-        create_d1=False,
-        create_d2=False,
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -519,6 +519,67 @@ def test_sensor_unique_ids_survive_subentry_title_and_coordinate_changes(
     )
 
 
+def test_pollen_sensor_forecast_attributes_do_not_require_coordinator_field(
+    sensor_modules: SensorModules,
+) -> None:
+    """Fixed forecast attributes should not depend on coordinator.forecast_days."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {
+                "source": "type",
+                "displayName": "Grass",
+                "value": 2,
+                "forecast": [{"offset": 1, "value": 3}],
+                "tomorrow_has_index": True,
+                "tomorrow_value": 3,
+                "tomorrow_category": "Moderate",
+                "tomorrow_description": "Moderate risk",
+                "tomorrow_color_hex": "#ffff00",
+                "d2_has_index": True,
+                "d2_value": 4,
+                "d2_category": "High",
+                "d2_description": "High risk",
+                "d2_color_hex": "#ff0000",
+                "trend": "rising",
+                "expected_peak": {"offset": 2, "value": 4},
+            },
+            "plants_oak": {
+                "source": "plant",
+                "displayName": "Oak",
+                "value": 1,
+                "forecast": [{"offset": 1, "value": 2}],
+                "tomorrow_has_index": True,
+                "tomorrow_value": 2,
+                "d2_has_index": False,
+                "d2_value": None,
+                "trend": "stable",
+                "expected_peak": {"offset": 1, "value": 2},
+            },
+        }
+    )
+    assert not hasattr(coordinator, "forecast_days")
+
+    type_attrs = sensor_modules.sensor.PollenSensor(
+        coordinator, "type_grass"
+    ).extra_state_attributes
+    plant_attrs = sensor_modules.sensor.PollenSensor(
+        coordinator, "plants_oak"
+    ).extra_state_attributes
+
+    assert type_attrs["forecast"] == [{"offset": 1, "value": 3}]
+    assert type_attrs["tomorrow_value"] == 3
+    assert type_attrs["d2_value"] == 4
+    assert type_attrs["trend"] == "rising"
+    assert type_attrs["expected_peak"] == {"offset": 2, "value": 4}
+    assert plant_attrs["forecast"] == [{"offset": 1, "value": 2}]
+    assert plant_attrs["tomorrow_value"] == 2
+    assert plant_attrs["d2_has_index"] is False
+    assert "d2_value" not in plant_attrs
+    assert plant_attrs["trend"] == "stable"
+    assert plant_attrs["expected_peak"] == {"offset": 1, "value": 2}
+
+
 def test_plants_in_season_counts_mixed_boolean_and_unknown_values(
     sensor_modules: SensorModules,
 ) -> None:
@@ -2100,6 +2161,46 @@ def test_remove_legacy_per_day_entities_logs_failed_removal_without_raising(
     assert "Failed to remove legacy per-day entity from registry" in caplog.text
 
 
+def test_remove_legacy_per_day_entities_does_not_log_coordinate_identity(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Legacy cleanup logs should not expose coordinate-derived unique IDs."""
+
+    coordinate_identity = "39.1234_-0.1234"
+    entries = [
+        RegistryEntry(
+            "sensor.pollen_type_grass_d1",
+            f"{coordinate_identity}_type_grass_d1",
+            "sensor",
+            sensor_modules.sensor.DOMAIN,
+        )
+    ]
+    registry = _setup_registry_stub(
+        sensor_modules, monkeypatch, entries, entry_id="entry"
+    )
+    caplog.set_level(logging.DEBUG, logger=sensor_modules.sensor._LOGGER.name)
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    try:
+        found, removed = loop.run_until_complete(
+            sensor_modules.sensor._remove_legacy_per_day_entities(
+                hass, "entry", coordinate_identity
+            )
+        )
+    finally:
+        loop.close()
+
+    assert found == 1
+    assert removed == 1
+    assert registry.removals == ["sensor.pollen_type_grass_d1"]
+    assert coordinate_identity not in caplog.text
+    assert f"{coordinate_identity}_type_grass_d1" not in caplog.text
+    assert "sensor.pollen_type_grass_d1" in caplog.text
+
+
 def test_remove_legacy_per_day_entities_propagates_cancelled_removal(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
@@ -3125,3 +3226,66 @@ async def test_setup_entry_accepts_current_day_plant_prefix_without_date(
         if isinstance(entity, sensor_modules.sensor.PollenSensor)
     }
     assert "plant_oak" in codes
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_debug_logs_do_not_expose_coordinate_identity(
+    sensor_modules: SensorModules,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sensor setup debug previews should not include raw unique IDs."""
+
+    coordinate_identity = "39.1234_-0.1234"
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={
+            sensor_modules.sensor.CONF_API_KEY: "key",
+            sensor_modules.sensor.CONF_LATITUDE: 39.1234,
+            sensor_modules.sensor.CONF_LONGITUDE: -0.1234,
+            sensor_modules.sensor.CONF_UPDATE_INTERVAL: (
+                sensor_modules.sensor.DEFAULT_UPDATE_INTERVAL
+            ),
+        },
+        entry_id="entry",
+    )
+    coordinator = types.SimpleNamespace(
+        data={
+            "type_grass": {
+                "source": "type",
+                "displayName": "Grass",
+                "value": 1,
+            },
+        },
+        entry_id="entry",
+        entity_identity_id=coordinate_identity,
+        entry_title="Home",
+        lat=39.1234,
+        lon=-0.1234,
+        subentry_id="legacy",
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "legacy": types.SimpleNamespace(
+                subentry_id="legacy",
+                coordinator=coordinator,
+            ),
+        },
+    )
+    captured: list[Any] = []
+
+    def _capture_entities(entities, **_kwargs):
+        captured.extend(entities)
+
+    caplog.set_level(logging.DEBUG, logger=sensor_modules.sensor._LOGGER.name)
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    assert any(
+        getattr(entity, "unique_id", None) == f"{coordinate_identity}_type_grass"
+        for entity in captured
+    )
+    assert coordinate_identity not in caplog.text
+    assert f"{coordinate_identity}_type_grass" not in caplog.text
+    assert "type_grass" in caplog.text

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -159,9 +159,6 @@ def _make_coordinator(
         hours=12,
         language=None,
         entry_id="entry",
-        forecast_days=1,
-        create_d1=False,
-        create_d2=False,
         client=client,
     )
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -310,6 +310,41 @@ def test_overall_forecast_three_days() -> None:
     assert overall["expected_peak"]["value"] == 7
 
 
+def test_overall_forecast_five_day_offsets() -> None:
+    """A 5-day type forecast exposes offsets 1 through 4 on the summary."""
+    summary = daily_summary(
+        {
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 1,
+                "category": "Low",
+                "forecast": [
+                    {
+                        "offset": offset,
+                        "date": f"2026-06-1{offset}",
+                        "has_index": True,
+                        "value": offset + 1,
+                        "category": f"Day {offset}",
+                        "description": f"Forecast day {offset}",
+                        "color_hex": "#00FF00",
+                        "color_rgb": [0, 255, 0],
+                    }
+                    for offset in range(1, 5)
+                ],
+            }
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert [item["offset"] for item in overall["forecast"]] == [1, 2, 3, 4]
+    assert overall["tomorrow_value"] == 2
+    assert overall["d2_value"] == 3
+    assert overall["expected_peak"]["offset"] == 4
+    assert overall["expected_peak"]["value"] == 5
+
+
 def test_overall_forecast_tie_handling() -> None:
     """Tied max future values preserve both type codes and names."""
     summary = daily_summary(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -374,6 +374,8 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
 
     english = _load_translation(TRANSLATIONS_DIR / "en.json")
     localized_paths = {
+        "config.step.user.description",
+        "options.step.init.description",
         "config.error.already_configured",
         "config_subentries.location.title",
         "config_subentries.location.entry_type",
@@ -389,6 +391,8 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
         "config_subentries.location.error.quota_exceeded",
         "config_subentries.location.error.unknown",
         "config_subentries.location.abort.reconfigure_successful",
+        "issues.per_day_forecast_sensors_removed.title",
+        "issues.per_day_forecast_sensors_removed.description",
     }
 
     problems: list[str] = []

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -424,8 +424,10 @@ def test_config_flow_extractor_includes_helper_error_keys() -> None:
     keys = _extract_config_flow_keys()
     assert "config.error.invalid_update_interval" in keys
     assert "options.error.invalid_update_interval" in keys
-    assert "config.error.invalid_forecast_days" in keys
-    assert "options.error.invalid_forecast_days" in keys
+    assert "config.error.invalid_language_format" in keys
+    assert "options.error.invalid_language_format" in keys
+    assert "config.error.invalid_forecast_days" not in keys
+    assert "options.error.invalid_forecast_days" not in keys
 
 
 def test_button_translation_keys_present() -> None:
@@ -557,6 +559,37 @@ def test_issues_invalid_stored_location_keys_present() -> None:
                 "missing {{location_title}} placeholder"
             )
     assert not problems, "Issues translation validation failed: " + "; ".join(problems)
+
+
+def test_issues_per_day_forecast_sensors_removed_keys_present() -> None:
+    """Ensure all locales have the per-day sensor removal Repair issue strings."""
+    problems: list[str] = []
+    for translation_path in TRANSLATIONS_DIR.glob("*.json"):
+        data = _load_translation(translation_path)
+        issues = data.get("issues", {})
+        issue = issues.get("per_day_forecast_sensors_removed", {})
+        title = issue.get("title")
+        description = issue.get("description")
+        if not isinstance(title, str) or not title.strip():
+            problems.append(
+                f"{translation_path.name}: "
+                "issues.per_day_forecast_sensors_removed.title is missing or empty"
+            )
+        if not isinstance(description, str) or not description.strip():
+            problems.append(
+                f"{translation_path.name}: "
+                "issues.per_day_forecast_sensors_removed.description "
+                "is missing or empty"
+            )
+        if "{" in (description or "") or "}" in (description or ""):
+            problems.append(
+                f"{translation_path.name}: "
+                "issues.per_day_forecast_sensors_removed.description "
+                "must not contain placeholders"
+            )
+    assert not problems, "Per-day issue translation validation failed: " + "; ".join(
+        problems
+    )
 
 
 def _extract_constant_assignments(tree: ast.AST) -> dict[str, str]:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -55,6 +55,34 @@ def test_redact_sensitive_values_returns_empty_string_for_none(util_module):
     assert util_module.redact_sensitive_values(None, api_key="SECRET") == ""
 
 
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {},
+        {"create_forecast_sensors": None},
+        {"create_forecast_sensors": "none"},
+        {"create_forecast_sensors": "bad"},
+    ],
+)
+def test_has_legacy_per_day_option_ignores_inactive_values(util_module, mapping):
+    """Inactive or invalid legacy modes should not create Repair warnings."""
+
+    assert util_module.has_legacy_per_day_option(mapping) is False
+
+
+@pytest.mark.parametrize("mode", ["D+1", "D+1+2"])
+def test_has_legacy_per_day_option_detects_active_modes(util_module, mode):
+    """Active legacy per-day modes should create Repair warnings."""
+
+    assert (
+        util_module.has_legacy_per_day_option(
+            {"create_forecast_sensors": "none"},
+            {"create_forecast_sensors": mode},
+        )
+        is True
+    )
+
+
 def test_redact_sensitive_values_redacts_exact_api_key(util_module):
     """Exact API key values should be redacted."""
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,6 +61,9 @@ def test_redact_sensitive_values_returns_empty_string_for_none(util_module):
         {},
         {"create_forecast_sensors": None},
         {"create_forecast_sensors": "none"},
+        {"create_forecast_sensors": " none "},
+        {"create_forecast_sensors": ""},
+        {"create_forecast_sensors": " "},
         {"create_forecast_sensors": "bad"},
     ],
 )
@@ -79,6 +82,27 @@ def test_has_legacy_per_day_option_detects_active_modes(util_module, mode):
             {"create_forecast_sensors": "none"},
             {"create_forecast_sensors": mode},
         )
+        is True
+    )
+
+
+@pytest.mark.parametrize("mode", [" D+1 ", " D+1+2 "])
+def test_has_legacy_per_day_option_normalizes_active_strings(util_module, mode):
+    """Whitespace around active legacy modes should not hide Repair warnings."""
+
+    assert (
+        util_module.has_legacy_per_day_option({"create_forecast_sensors": mode}) is True
+    )
+
+
+def test_has_legacy_per_day_option_accepts_enum_like_values(util_module):
+    """Enum-like legacy option values should be read through their value."""
+
+    class _Mode:
+        value = "D+1"
+
+    assert (
+        util_module.has_legacy_per_day_option({"create_forecast_sensors": _Mode()})
         is True
     )
 


### PR DESCRIPTION
## Summary

- Bump the integration release metadata to `3.0.0b4` and update the beta 4 changelog/docs.
- Fix Google Pollen forecast requests to the maximum supported 5-day horizon.
- Remove configurable forecast-day and legacy per-day TYPE sensor runtime paths while preserving base sensor names, unique IDs, and forecast attribute formats.
- Clean legacy `_d1` / `_d2` Pollen Levels entity-registry entries and create a persistent Repair warning when legacy per-day sensor settings/entities are detected.
- Bring the `_d1` / `_d2` cleanup forward in beta 4 so the migration, cleanup, and Repair warning can be tested before the release candidate.
- Synchronize locale keysets and remove obsolete option translations.

## Impact

Forecast data remains available through the base TYPE, PLANT, and summary sensors via `forecast`, `tomorrow_*`, `d2_*`, `trend`, and `expected_peak`. Optional `_d1` / `_d2` entities are removed in beta 4 for validation, with a Repair warning for affected users.

## Validation

- `python -m ruff check --fix --select I`
- `python -m black .`
- `python -m ruff check`
- `python -m pytest tests/` (`438 passed`)
- `git diff --check`
- Live Google Pollen API smoke using local `secrets/pollenlevels.env` without printing the key: 5 `dailyInfo` days returned, coordinator requested `days=5`, TYPE/PLANT forecasts exposed offsets `[1, 2, 3, 4]`, and no `_d1` / `_d2` keys were emitted.
- Latest docs/metadata follow-up: `python -m ruff check .`, `python -m black --check .`, `python -m pytest tests/test_metadata.py`, `git diff --check`.
- Billing FAQ follow-up checked against the official Google Maps Platform global pricing list and the Pollen API usage and billing page, including the current `Pollen Usage` Free Usage Cap of 5,000 monthly billable events; validated with `rg`, `python -m ruff check .`, `python -m black --check .`, and `git diff --check`.

`hassfest` and `hacs validate` were not available as local commands in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Forecast horizon fixed at 5 days for all locations; forecast-day/configuration options removed.
  * Per-day forecast entities (`_d1`, `_d2`) no longer created; forecast data available via base-sensor attributes (`forecast`, `tomorrow_*`, `d2_*`, `trend`, `expected_peak`).
  * Automatic upgrade/cleanup removes legacy per-day settings and registry entries.

* **Bug Fixes**
  * Home Assistant Repair warning added when legacy per-day sensors/options are detected; keep existing fix for invalid stored location.

* **Documentation**
  * README/FAQ updated with migration, quota, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->