### PR TITLE
chore: bump minimum tool versions to black>=26 and ruff>=0.15

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install formatters
         run: |
-          python -m pip install --upgrade "black>=25" "ruff>=0.14"
+          python -m pip install --upgrade "black>=26" "ruff>=0.15"
 
       - name: Ruff --fix
         run: ruff check --fix .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install linters
         run: |
-          python -m pip install --upgrade "black>=25" "ruff>=0.14"
+          python -m pip install --upgrade "black>=26" "ruff>=0.15"
 
       - name: Ruff (check only)
         run: ruff check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Tooling
 - Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
-- Format code with Black (line length 88, target-version `py314`) with minimum `black>=25` (enforced via CI; version pin not stored in `pyproject.toml`).
+- Format code with Black (line length 88, target-version `py314`) with minimum `black>=26` (enforced via CI; version pin not stored in `pyproject.toml`).
 - Black 26+ may format multi-exception handlers as `except A, B:` for Python 3.14; keep the formatter output unless CI changes.
-- Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.14` (enforced via CI), matching the configuration in `pyproject.toml`.
+- Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.15` (enforced via CI), matching the configuration in `pyproject.toml`.
 - Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
 - Run `black .` (or the narrowest possible path) to ensure formatting.
 - Tests run with pytest>=9 on Python 3.14.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 # Tooling aligned to the Home Assistant Python floor (>=3.14.0).
 # NOTE: We purposely DO NOT set [tool.black].required-version; CI installs
 # Black/Ruff from minimum supported versions to keep tooling forward-compatible.
+# Minimums: black>=26, ruff>=0.15 (set in CI workflows).
 # If you ever need an exact lock, set both:
 #   - pyproject: required-version = "<desired black version>"
 #   - CI: pip install "black==<desired black version>" "ruff==<desired ruff version>"


### PR DESCRIPTION
Updates tooling minimums across CI workflows, AGENTS.md, and pyproject.toml:

- black>=25 → black>=26
- ruff>=0.14 → ruff>=0.15

.coderabbit.yaml already referenced Black 26+ — no change needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum versions for Black (to >=26) and Ruff (to >=0.15) across CI workflows, documentation, and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->