### PR TITLE
[codex] Isolate local setup failures per location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
   parent API key can continue loading.
 - Added per-location setup failure runtime metadata exposed through diagnostics
   under `failed_locations`.
-- Added a Home Assistant Repair warning for isolated location setup failures,
-  with privacy-safe details and guidance to reload the parent entry after fixing
-  the affected location.
+- Added a Home Assistant Repair warning for repeated isolated location setup
+  failures, with privacy-safe details and guidance to reload the parent entry
+  after fixing the affected location.
 
 ### Changed
 
@@ -17,6 +17,8 @@
   action now operate only on successfully loaded runtime locations.
 - Runtime diagnostics now distinguish loaded, failed, and stale locations
   through separate summary fields.
+- Retryable partial setup failures now schedule a conservative automatic parent
+  reload before surfacing the per-location Repair warning.
 
 ### Fixed
 
@@ -24,6 +26,10 @@
   blocking other healthy locations under the same parent entry.
 - Cleared location setup failure Repair warnings automatically when the affected
   location loads successfully after a reload.
+- Cleared stale per-location Repair warnings automatically when the affected
+  location subentry has been removed.
+- Corrected failed-location diagnostics so invalid stored locations are not
+  marked as reload-retryable.
 - Kept failed-location registry entries untouched so existing entities and
   recorder history are not removed because of a local setup failure.
 - Localized the new setup failure Repair warning across all supported locales.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   location loads successfully after a reload.
 - Cleared stale per-location Repair warnings automatically when the affected
   location subentry has been removed.
+- Avoided relying on Home Assistant issue registry internals when cleaning stale
+  per-location Repair warnings.
 - Corrected failed-location diagnostics so invalid stored locations are not
   marked as reload-retryable.
 - Kept failed-location registry entries untouched so existing entities and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## [3.0.0b5] - 2026-06-13
+
+### Added
+
+- Added conservative partial setup for v3 location subentries. When one
+  location has a local non-auth setup failure, healthy locations under the same
+  parent API key can continue loading.
+- Added per-location setup failure runtime metadata exposed through diagnostics
+  under `failed_locations`.
+- Added a Home Assistant Repair warning for isolated location setup failures,
+  with privacy-safe details and guidance to reload the parent entry after fixing
+  the affected location.
+
+### Changed
+
+- Sensors, `Update now` buttons, and the global `pollenlevels.force_update`
+  action now operate only on successfully loaded runtime locations.
+- Runtime diagnostics now distinguish loaded, failed, and stale locations
+  through separate summary fields.
+
+### Fixed
+
+- Prevented one invalid or temporarily unavailable location subentry from
+  blocking other healthy locations under the same parent entry.
+- Cleared location setup failure Repair warnings automatically when the affected
+  location loads successfully after a reload.
+- Kept failed-location registry entries untouched so existing entities and
+  recorder history are not removed because of a local setup failure.
+- Localized the new setup failure Repair warning across all supported locales.
+- Removed legacy single-location duplicate fields from diagnostics. In v3,
+  per-location diagnostics are now exposed only under `locations`, avoiding
+  misleading top-level data copied from the first location.
+
 ## [3.0.0b4] - 2026-06-11
 
 ### Changed

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -37,8 +37,11 @@ from .const import (
 from .coordinator import PollenDataUpdateCoordinator
 from .issue_helpers import (
     create_invalid_stored_location_issue,
+    create_location_setup_failed_issue,
     create_per_day_forecast_sensors_removed_issue,
     delete_entry_invalid_stored_location_issue,
+    delete_invalid_stored_location_issue,
+    delete_location_setup_failed_issue,
     invalid_stored_location_issue_id as invalid_stored_location_issue_id,
 )
 from .migration import (
@@ -50,6 +53,7 @@ from .runtime import (
     PollenLevelsConfigEntry,
     PollenLevelsRuntimeData,
     PollenLocationRuntime,
+    PollenLocationSetupFailure,
 )
 from .util import (
     api_key_unique_id as api_key_unique_id,
@@ -67,6 +71,7 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 6
 _FORCE_UPDATE_CONCURRENCY_LIMIT = 1
+_SETUP_FAILURE_REASON_MAX_LENGTH = 240
 PLATFORMS = ["sensor", "button"]
 
 
@@ -126,6 +131,83 @@ def _iter_location_subentries(
             )
         )
     return locations
+
+
+def _location_issue_subentry_id(entry: ConfigEntry, subentry_id: str) -> str | None:
+    """Return the Repair subentry id for a setup location."""
+    subentries = getattr(entry, "subentries", {}) or {}
+    return subentry_id if subentry_id in subentries else None
+
+
+def _truncate_setup_failure_reason(reason: str) -> str:
+    """Return a single-line setup failure reason bounded for Repairs."""
+    cleaned = " ".join(reason.split()).strip()
+    if len(cleaned) <= _SETUP_FAILURE_REASON_MAX_LENGTH:
+        return cleaned
+    return f"{cleaned[: _SETUP_FAILURE_REASON_MAX_LENGTH - 3]}..."
+
+
+def _safe_setup_failure_text(
+    value: Any,
+    *,
+    api_key: str | None,
+    latitude: Any = None,
+    longitude: Any = None,
+    fallback: str,
+) -> str:
+    """Redact sensitive setup failure text before storing or surfacing it."""
+    redacted = redact_sensitive_values(
+        value,
+        api_key=api_key,
+        latitude=latitude,
+        longitude=longitude,
+    )
+    redacted = _truncate_setup_failure_reason(redacted)
+    return redacted or fallback
+
+
+def _coordinator_has_usable_initial_data(coordinator: Any) -> bool:
+    """Return whether a first refresh produced enough data to build sensors."""
+    data = getattr(coordinator, "data", None) or {}
+    if not isinstance(data, dict):
+        return False
+    return ("date" in data) or any(
+        isinstance(key, str) and key.startswith(("type_", "plant_", "plants_"))
+        for key in data
+    )
+
+
+def _location_setup_failure(
+    *,
+    subentry_id: str,
+    title: str,
+    error_type: str,
+    reason: str,
+    api_key: str | None,
+    latitude: Any = None,
+    longitude: Any = None,
+) -> PollenLocationSetupFailure:
+    """Build redacted runtime metadata for an isolated setup failure."""
+    safe_title = _safe_setup_failure_text(
+        title,
+        api_key=api_key,
+        latitude=latitude,
+        longitude=longitude,
+        fallback=DEFAULT_ENTRY_TITLE,
+    )
+    safe_reason = _safe_setup_failure_text(
+        reason,
+        api_key=api_key,
+        latitude=latitude,
+        longitude=longitude,
+        fallback="Location setup failed",
+    )
+    return PollenLocationSetupFailure(
+        subentry_id=subentry_id,
+        title=safe_title,
+        reason=safe_reason,
+        error_type=error_type or "UnknownError",
+    )
 
 
 # ---- Service -------------------------------------------------------------
@@ -290,45 +372,52 @@ async def async_setup_entry(
 
     location_configs = _iter_location_subentries(entry)
 
-    validated_location_configs: list[
-        tuple[str, str, dict[str, Any], str | None, float, float]
-    ] = []
+    locations: dict[str, PollenLocationRuntime] = {}
+    failed_locations: dict[str, PollenLocationSetupFailure] = {}
+    has_legacy_invalid_location_issue = False
     for subentry_id, title, data, legacy_entry_id in location_configs:
         raw_lat = data.get(CONF_LATITUDE)
         raw_lon = data.get(CONF_LONGITUDE)
         latlon = validate_location_pair(raw_lat, raw_lon)
+        issue_subentry_id = _location_issue_subentry_id(entry, subentry_id)
         if latlon is None:
             create_invalid_stored_location_issue(
                 hass,
                 entry_id=entry.entry_id,
                 entry_title=entry.title,
                 location_title=title,
-                subentry_id=None,
+                subentry_id=issue_subentry_id,
+            )
+            if issue_subentry_id is None:
+                has_legacy_invalid_location_issue = True
+            delete_location_setup_failed_issue(
+                hass,
+                entry_id=entry.entry_id,
+                subentry_id=subentry_id,
+            )
+            failed_locations[subentry_id] = _location_setup_failure(
+                subentry_id=subentry_id,
+                title=title,
+                error_type="InvalidStoredLocation",
+                reason="Pollen Levels location has invalid stored coordinates",
+                api_key=api_key,
+                latitude=raw_lat,
+                longitude=raw_lon,
             )
             _LOGGER.warning(
                 "Invalid coordinates for Pollen Levels entry %s subentry %s; "
-                "setup will be retried after the stored location is fixed",
+                "skipping this location until the stored location is fixed",
                 entry.entry_id,
                 subentry_id,
             )
-            raise ConfigEntryNotReady(
-                "Pollen Levels location has invalid stored coordinates"
-            ) from None
-        lat, lon = latlon
-        validated_location_configs.append(
-            (subentry_id, title, data, legacy_entry_id, lat, lon)
-        )
+            continue
 
-    delete_entry_invalid_stored_location_issue(hass, entry)
-    locations: dict[str, PollenLocationRuntime] = {}
-    for (
-        subentry_id,
-        title,
-        _data,
-        legacy_entry_id,
-        lat,
-        lon,
-    ) in validated_location_configs:
+        delete_invalid_stored_location_issue(
+            hass,
+            entry_id=entry.entry_id,
+            subentry_id=issue_subentry_id,
+        )
+        lat, lon = latlon
         coordinator = PollenDataUpdateCoordinator(
             hass=hass,
             api_key=api_key,
@@ -358,9 +447,16 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            raise ConfigEntryNotReady(
-                safe_message or "Pollen Levels location is not ready"
-            ) from None
+            failed_locations[subentry_id] = _location_setup_failure(
+                subentry_id=subentry_id,
+                title=title,
+                error_type=type(err).__name__,
+                reason=safe_message or "Pollen Levels location is not ready",
+                api_key=api_key,
+                latitude=lat,
+                longitude=lon,
+            )
+            continue
         except Exception as err:
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
@@ -372,17 +468,60 @@ async def async_setup_entry(
                 type(err).__name__,
                 safe_message or "no error details",
             )
-            raise ConfigEntryNotReady(
-                safe_message or "Pollen Levels location setup failed"
-            ) from None
+            failed_locations[subentry_id] = _location_setup_failure(
+                subentry_id=subentry_id,
+                title=title,
+                error_type=type(err).__name__,
+                reason=safe_message or "Pollen Levels location setup failed",
+                api_key=api_key,
+                latitude=lat,
+                longitude=lon,
+            )
+            continue
+
+        if not _coordinator_has_usable_initial_data(coordinator):
+            reason = "API response missing usable pollen data"
+            _LOGGER.warning(
+                "Initial data refresh for entry %s subentry %s produced no usable "
+                "pollen data; skipping this location",
+                entry.entry_id,
+                subentry_id,
+            )
+            failed_locations[subentry_id] = _location_setup_failure(
+                subentry_id=subentry_id,
+                title=title,
+                error_type="UpdateFailed",
+                reason=reason,
+                api_key=api_key,
+                latitude=lat,
+                longitude=lon,
+            )
+            continue
 
         locations[subentry_id] = PollenLocationRuntime(
             subentry_id=subentry_id,
             coordinator=coordinator,
             legacy_entry_id=legacy_entry_id,
         )
+        delete_location_setup_failed_issue(
+            hass,
+            entry_id=entry.entry_id,
+            subentry_id=subentry_id,
+        )
 
-    entry.runtime_data = PollenLevelsRuntimeData(client=client, locations=locations)
+    if not has_legacy_invalid_location_issue:
+        delete_entry_invalid_stored_location_issue(hass, entry)
+
+    if location_configs and not locations:
+        raise ConfigEntryNotReady(
+            "No Pollen Levels locations could be loaded"
+        ) from None
+
+    entry.runtime_data = PollenLevelsRuntimeData(
+        client=client,
+        locations=locations,
+        failed_locations=failed_locations,
+    )
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -393,6 +532,19 @@ async def async_setup_entry(
         entry.runtime_data = None
         _LOGGER.exception("Error forwarding entry setups: %s", err)
         raise ConfigEntryNotReady from err
+
+    for failure in failed_locations.values():
+        if failure.error_type == "InvalidStoredLocation":
+            continue
+        create_location_setup_failed_issue(
+            hass,
+            entry_id=entry.entry_id,
+            entry_title=entry.title,
+            location_title=failure.title,
+            subentry_id=failure.subentry_id,
+            error_type=failure.error_type,
+            reason=failure.reason,
+        )
 
     _LOGGER.info("PollenLevels integration loaded successfully")
     return True

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -156,6 +156,8 @@ def _safe_setup_failure_text(
     fallback: str,
 ) -> str:
     """Redact sensitive setup failure text before storing or surfacing it."""
+    if value is None:
+        return fallback
     redacted = redact_sensitive_values(
         value,
         api_key=api_key,

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -42,6 +42,7 @@ from .issue_helpers import (
     delete_entry_invalid_stored_location_issue,
     delete_invalid_stored_location_issue,
     delete_location_setup_failed_issue,
+    delete_stale_location_subentry_issues,
     invalid_stored_location_issue_id as invalid_stored_location_issue_id,
 )
 from .migration import (
@@ -56,6 +57,7 @@ from .runtime import (
     PollenLocationSetupFailure,
 )
 from .util import (
+    active_location_subentry_ids,
     api_key_unique_id as api_key_unique_id,
     has_legacy_per_day_option,
     redact_sensitive_values,
@@ -72,6 +74,8 @@ _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 6
 _FORCE_UPDATE_CONCURRENCY_LIMIT = 1
 _SETUP_FAILURE_REASON_MAX_LENGTH = 240
+_SETUP_RETRY_FAILURES_DATA_KEY = "setup_retry_failures"
+_NON_RETRYABLE_SETUP_FAILURE_TYPES = frozenset({"InvalidStoredLocation"})
 PLATFORMS = ["sensor", "button"]
 
 
@@ -210,6 +214,81 @@ def _location_setup_failure(
         reason=safe_reason,
         error_type=error_type or "UnknownError",
     )
+
+
+def _entry_setup_retry_failures(hass: HomeAssistant, entry_id: str) -> set[str]:
+    """Return setup failures that already received an automatic retry."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    retry_failures = domain_data.setdefault(_SETUP_RETRY_FAILURES_DATA_KEY, {})
+    return retry_failures.setdefault(entry_id, set())
+
+
+def _mark_setup_retry_failure(
+    hass: HomeAssistant, entry_id: str, subentry_id: str
+) -> None:
+    """Remember that a setup failure already received an automatic retry."""
+    _entry_setup_retry_failures(hass, entry_id).add(subentry_id)
+
+
+def _setup_retry_failure_seen(
+    hass: HomeAssistant, entry_id: str, subentry_id: str
+) -> bool:
+    """Return whether this setup failure already received an automatic retry."""
+    return subentry_id in _entry_setup_retry_failures(hass, entry_id)
+
+
+def _clear_setup_retry_failure(
+    hass: HomeAssistant, entry_id: str, subentry_id: str
+) -> None:
+    """Clear retry bookkeeping for a location that no longer needs it."""
+    domain_data = hass.data.get(DOMAIN, {})
+    retry_failures = domain_data.get(_SETUP_RETRY_FAILURES_DATA_KEY, {})
+    entry_failures = retry_failures.get(entry_id)
+    if not entry_failures:
+        return
+    entry_failures.discard(subentry_id)
+    if not entry_failures:
+        retry_failures.pop(entry_id, None)
+
+
+def _prune_setup_retry_failures(
+    hass: HomeAssistant, entry_id: str, active_subentry_ids: set[str]
+) -> None:
+    """Drop retry bookkeeping for locations that are no longer configured."""
+    domain_data = hass.data.get(DOMAIN, {})
+    retry_failures = domain_data.get(_SETUP_RETRY_FAILURES_DATA_KEY, {})
+    entry_failures = retry_failures.get(entry_id)
+    if not entry_failures:
+        return
+    entry_failures.intersection_update(active_subentry_ids)
+    if not entry_failures:
+        retry_failures.pop(entry_id, None)
+
+
+def _setup_failure_is_retryable(failure: PollenLocationSetupFailure) -> bool:
+    """Return whether a local setup failure can be retried by reloading."""
+    return failure.error_type not in _NON_RETRYABLE_SETUP_FAILURE_TYPES
+
+
+def _schedule_parent_reload(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Schedule a parent config entry reload when supported by the runtime."""
+    schedule_reload = getattr(hass.config_entries, "async_schedule_reload", None)
+    if callable(schedule_reload):
+        schedule_reload(entry.entry_id)
+        return True
+
+    async_reload = getattr(hass.config_entries, "async_reload", None)
+    if not callable(async_reload):
+        return False
+
+    result = async_reload(entry.entry_id)
+    if asyncio.iscoroutine(result):
+        create_task = getattr(hass, "async_create_task", None)
+        if not callable(create_task):
+            result.close()
+            return False
+        create_task(result, name=f"pollenlevels setup retry {entry.entry_id}")
+    return True
 
 
 # ---- Service -------------------------------------------------------------
@@ -373,6 +452,13 @@ async def async_setup_entry(
     client = GooglePollenApiClient(session, api_key)
 
     location_configs = _iter_location_subentries(entry)
+    active_subentry_ids = active_location_subentry_ids(entry)
+    delete_stale_location_subentry_issues(
+        hass,
+        entry_id=entry.entry_id,
+        active_subentry_ids=active_subentry_ids,
+    )
+    _prune_setup_retry_failures(hass, entry.entry_id, active_subentry_ids)
 
     locations: dict[str, PollenLocationRuntime] = {}
     failed_locations: dict[str, PollenLocationSetupFailure] = {}
@@ -397,6 +483,7 @@ async def async_setup_entry(
                 entry_id=entry.entry_id,
                 subentry_id=subentry_id,
             )
+            _clear_setup_retry_failure(hass, entry.entry_id, subentry_id)
             failed_locations[subentry_id] = _location_setup_failure(
                 subentry_id=subentry_id,
                 title=title,
@@ -510,6 +597,7 @@ async def async_setup_entry(
             entry_id=entry.entry_id,
             subentry_id=subentry_id,
         )
+        _clear_setup_retry_failure(hass, entry.entry_id, subentry_id)
 
     if not has_legacy_invalid_location_issue:
         delete_entry_invalid_stored_location_issue(hass, entry)
@@ -535,8 +623,15 @@ async def async_setup_entry(
         _LOGGER.exception("Error forwarding entry setups: %s", err)
         raise ConfigEntryNotReady from err
 
+    retry_reload_needed = False
+    first_retry_failures: list[PollenLocationSetupFailure] = []
     for failure in failed_locations.values():
-        if failure.error_type == "InvalidStoredLocation":
+        if not _setup_failure_is_retryable(failure):
+            continue
+        if not _setup_retry_failure_seen(hass, entry.entry_id, failure.subentry_id):
+            _mark_setup_retry_failure(hass, entry.entry_id, failure.subentry_id)
+            first_retry_failures.append(failure)
+            retry_reload_needed = True
             continue
         create_location_setup_failed_issue(
             hass,
@@ -547,6 +642,18 @@ async def async_setup_entry(
             error_type=failure.error_type,
             reason=failure.reason,
         )
+
+    if retry_reload_needed and not _schedule_parent_reload(hass, entry):
+        for failure in first_retry_failures:
+            create_location_setup_failed_issue(
+                hass,
+                entry_id=entry.entry_id,
+                entry_title=entry.title,
+                location_title=failure.title,
+                subentry_id=failure.subentry_id,
+                error_type=failure.error_type,
+                reason=failure.reason,
+            )
 
     _LOGGER.info("PollenLevels integration loaded successfully")
     return True

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -171,20 +171,21 @@ def _failed_location_diagnostics(
     coordinate_pairs: list[tuple[Any, Any]],
 ) -> dict[str, Any]:
     """Return redacted diagnostics for one failed setup location."""
+    error_type = getattr(failure, "error_type", "UnknownError")
     return {
         "title": _redact_diagnostics_text(
             getattr(failure, "title", DEFAULT_ENTRY_TITLE),
             api_key,
             coordinate_pairs,
         ),
-        "error_type": getattr(failure, "error_type", "UnknownError"),
+        "error_type": error_type,
         "reason": _redact_diagnostics_text(
             getattr(failure, "reason", "Location setup failed"),
             api_key,
             coordinate_pairs,
         ),
         "is_auth_error": bool(getattr(failure, "is_auth_error", False)),
-        "will_retry_on_reload": True,
+        "will_retry_on_reload": error_type != "InvalidStoredLocation",
     }
 
 

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -30,7 +30,7 @@ from .const import (
     DOMAIN,
     FORECAST_DAYS,
 )
-from .runtime import PollenLevelsRuntimeData
+from .runtime import PollenLevelsRuntimeData, PollenLocationSetupFailure
 from .summary import daily_summary as _daily_summary
 from .util import (
     active_location_subentry_ids,
@@ -164,6 +164,30 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
     }
 
 
+def _failed_location_diagnostics(
+    failure: PollenLocationSetupFailure,
+    *,
+    api_key: str | None,
+    coordinate_pairs: list[tuple[Any, Any]],
+) -> dict[str, Any]:
+    """Return redacted diagnostics for one failed setup location."""
+    return {
+        "title": _redact_diagnostics_text(
+            getattr(failure, "title", DEFAULT_ENTRY_TITLE),
+            api_key,
+            coordinate_pairs,
+        ),
+        "error_type": getattr(failure, "error_type", "UnknownError"),
+        "reason": _redact_diagnostics_text(
+            getattr(failure, "reason", "Location setup failed"),
+            api_key,
+            coordinate_pairs,
+        ),
+        "is_auth_error": bool(getattr(failure, "is_auth_error", False)),
+        "will_retry_on_reload": True,
+    }
+
+
 def _coordinate_from_coordinator_or_data(
     coordinator: Any, data: dict[str, Any], key: str
 ) -> Any:
@@ -282,6 +306,8 @@ async def async_get_config_entry_diagnostics(
     lang = options.get(CONF_LANGUAGE_CODE, data.get(CONF_LANGUAGE_CODE))
     locations: dict[str, Any] = {}
     stale_location_ids: list[str] = []
+    failed_locations: dict[str, Any] = {}
+    failed_location_ids: list[str] = []
     coordinate_pairs: list[tuple[Any, Any]] = []
     api_key = data.get(CONF_API_KEY)
     api_key_text = api_key if isinstance(api_key, str) else None
@@ -337,6 +363,17 @@ async def async_get_config_entry_diagnostics(
             location_payload["request_params_example"] = request_params_example
             locations[subentry_id] = location_payload
 
+        runtime_failed_locations = getattr(runtime, "failed_locations", {}) or {}
+        for subentry_id, failure in runtime_failed_locations.items():
+            if filter_stale_locations and subentry_id not in active_subentry_ids:
+                continue
+            failed_location_ids.append(subentry_id)
+            failed_locations[subentry_id] = _failed_location_diagnostics(
+                failure,
+                api_key=api_key_text,
+                coordinate_pairs=coordinate_pairs,
+            )
+
     # Final diagnostics payload (with secrets redacted)
     diag: dict[str, Any] = {
         "entry": {
@@ -355,9 +392,12 @@ async def async_get_config_entry_diagnostics(
             },
         },
         "locations": locations,
+        "failed_locations": failed_locations,
         "runtime_summary": {
             "stale_location_count": len(stale_location_ids),
             "stale_location_ids": sorted(stale_location_ids),
+            "failed_location_count": len(failed_location_ids),
+            "failed_location_ids": sorted(failed_location_ids),
         },
         "registry_summary": _registry_summary(hass, entry),
     }

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import issue_registry as ir
 from .const import DEFAULT_ENTRY_TITLE, DOMAIN
 
 PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
+LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
 
 
 def invalid_stored_location_issue_id(
@@ -60,6 +61,44 @@ def create_per_day_forecast_sensors_removed_issue(hass: HomeAssistant) -> None:
     )
 
 
+def location_setup_failed_issue_id(entry_id: str, subentry_id: str) -> str:
+    """Return a deterministic issue ID for a local location setup failure."""
+    return f"location_setup_failed_{entry_id}_{subentry_id}"
+
+
+def create_location_setup_failed_issue(
+    hass: HomeAssistant,
+    *,
+    entry_id: str,
+    entry_title: str | None,
+    location_title: str | None,
+    subentry_id: str,
+    error_type: str,
+    reason: str,
+) -> None:
+    """Create a Repair issue for an isolated location setup failure."""
+    issue_id = location_setup_failed_issue_id(entry_id, subentry_id)
+    entry_title = (entry_title or "").strip() or DEFAULT_ENTRY_TITLE
+    location_title = (location_title or "").strip() or entry_title
+    error_type = (error_type or "").strip() or "UnknownError"
+    reason = (reason or "").strip() or "Location setup failed"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=LOCATION_SETUP_FAILED_TRANSLATION_KEY,
+        translation_placeholders={
+            "entry_title": entry_title,
+            "location_title": location_title,
+            "error_type": error_type,
+            "reason": reason,
+        },
+    )
+
+
 def create_entry_invalid_stored_location_issue(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -95,3 +134,14 @@ def delete_entry_invalid_stored_location_issue(
         entry_id=entry.entry_id,
         subentry_id=None,
     )
+
+
+def delete_location_setup_failed_issue(
+    hass: HomeAssistant,
+    *,
+    entry_id: str,
+    subentry_id: str,
+) -> None:
+    """Delete a Repair issue for an isolated location setup failure if present."""
+    issue_id = location_setup_failed_issue_id(entry_id, subentry_id)
+    ir.async_delete_issue(hass, DOMAIN, issue_id)

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Iterator
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -10,6 +13,40 @@ from .const import DEFAULT_ENTRY_TITLE, DOMAIN
 
 PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
 LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
+
+
+def _issue_id_from_registry_item(key: Any, value: Any) -> str | None:
+    """Return this domain's issue id from HA or test registry storage."""
+    if isinstance(key, tuple) and len(key) == 2:
+        domain, issue_id = key
+        if domain != DOMAIN or not isinstance(issue_id, str):
+            return None
+        return issue_id
+
+    if not isinstance(key, str):
+        return None
+
+    domain = (
+        value.get("domain")
+        if isinstance(value, dict)
+        else getattr(value, "domain", None)
+    )
+    if domain != DOMAIN:
+        return None
+    return key
+
+
+def _iter_domain_issue_ids(hass: HomeAssistant) -> Iterator[str]:
+    """Yield current issue ids for this integration."""
+    registry_getter = getattr(ir, "async_get", None)
+    if not callable(registry_getter):
+        return
+
+    registry = registry_getter(hass)
+    issues = getattr(registry, "issues", {})
+    for key, value in list(issues.items()):
+        if issue_id := _issue_id_from_registry_item(key, value):
+            yield issue_id
 
 
 def invalid_stored_location_issue_id(
@@ -64,6 +101,32 @@ def create_per_day_forecast_sensors_removed_issue(hass: HomeAssistant) -> None:
 def location_setup_failed_issue_id(entry_id: str, subentry_id: str) -> str:
     """Return a deterministic issue ID for a local location setup failure."""
     return f"location_setup_failed_{entry_id}_{subentry_id}"
+
+
+def delete_stale_location_subentry_issues(
+    hass: HomeAssistant,
+    *,
+    entry_id: str,
+    active_subentry_ids: Collection[str],
+) -> None:
+    """Delete location Repair issues for subentries no longer configured."""
+    active_ids = set(active_subentry_ids)
+    legacy_invalid_issue_id = invalid_stored_location_issue_id(entry_id)
+    prefixes = (
+        f"invalid_stored_location_{entry_id}_",
+        f"location_setup_failed_{entry_id}_",
+    )
+
+    for issue_id in _iter_domain_issue_ids(hass):
+        if issue_id == legacy_invalid_issue_id:
+            continue
+        for prefix in prefixes:
+            if (
+                issue_id.startswith(prefix)
+                and issue_id.removeprefix(prefix) not in active_ids
+            ):
+                ir.async_delete_issue(hass, DOMAIN, issue_id)
+                break
 
 
 def create_location_setup_failed_issue(

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterator
-from typing import Any
+from collections.abc import Collection
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,40 +12,55 @@ from .const import DEFAULT_ENTRY_TITLE, DOMAIN
 
 PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
 LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
+_LOCATION_REPAIR_ISSUES_DATA_KEY = "location_repair_issue_ids"
 
 
-def _issue_id_from_registry_item(key: Any, value: Any) -> str | None:
-    """Return this domain's issue id from HA or test registry storage."""
-    if isinstance(key, tuple) and len(key) == 2:
-        domain, issue_id = key
-        if domain != DOMAIN or not isinstance(issue_id, str):
-            return None
-        return issue_id
-
-    if not isinstance(key, str):
-        return None
-
-    domain = (
-        value.get("domain")
-        if isinstance(value, dict)
-        else getattr(value, "domain", None)
-    )
-    if domain != DOMAIN:
-        return None
-    return key
+def _entry_location_issue_ids(hass: HomeAssistant, entry_id: str) -> set[str]:
+    """Return location Repair issue ids owned by this runtime entry."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    issue_ids = domain_data.setdefault(_LOCATION_REPAIR_ISSUES_DATA_KEY, {})
+    return issue_ids.setdefault(entry_id, set())
 
 
-def _iter_domain_issue_ids(hass: HomeAssistant) -> Iterator[str]:
-    """Yield current issue ids for this integration."""
-    registry_getter = getattr(ir, "async_get", None)
-    if not callable(registry_getter):
+def _known_entry_location_issue_ids(
+    hass: HomeAssistant, entry_id: str
+) -> set[str] | None:
+    """Return known location Repair issue ids without creating bookkeeping."""
+    domain_data = hass.data.get(DOMAIN, {})
+    issue_ids = domain_data.get(_LOCATION_REPAIR_ISSUES_DATA_KEY, {})
+    return issue_ids.get(entry_id)
+
+
+def _remember_location_issue(hass: HomeAssistant, entry_id: str, issue_id: str) -> None:
+    """Remember a location Repair issue created by this integration runtime."""
+    _entry_location_issue_ids(hass, entry_id).add(issue_id)
+
+
+def _forget_location_issue(hass: HomeAssistant, entry_id: str, issue_id: str) -> None:
+    """Forget a location Repair issue after it has been cleared."""
+    domain_data = hass.data.get(DOMAIN, {})
+    issue_ids = domain_data.get(_LOCATION_REPAIR_ISSUES_DATA_KEY, {})
+    entry_issue_ids = issue_ids.get(entry_id)
+    if not entry_issue_ids:
         return
+    entry_issue_ids.discard(issue_id)
+    if entry_issue_ids:
+        return
+    issue_ids.pop(entry_id, None)
+    if not issue_ids:
+        domain_data.pop(_LOCATION_REPAIR_ISSUES_DATA_KEY, None)
 
-    registry = registry_getter(hass)
-    issues = getattr(registry, "issues", {})
-    for key, value in list(issues.items()):
-        if issue_id := _issue_id_from_registry_item(key, value):
-            yield issue_id
+
+def _subentry_id_from_location_issue_id(entry_id: str, issue_id: str) -> str | None:
+    """Return the subentry id encoded in a known location Repair issue id."""
+    prefixes = (
+        f"invalid_stored_location_{entry_id}_",
+        f"location_setup_failed_{entry_id}_",
+    )
+    for prefix in prefixes:
+        if issue_id.startswith(prefix):
+            return issue_id.removeprefix(prefix) or None
+    return None
 
 
 def invalid_stored_location_issue_id(
@@ -83,6 +97,8 @@ def create_invalid_stored_location_issue(
             "location_title": location_title,
         },
     )
+    if subentry_id:
+        _remember_location_issue(hass, entry_id, issue_id)
 
 
 def create_per_day_forecast_sensors_removed_issue(hass: HomeAssistant) -> None:
@@ -111,22 +127,16 @@ def delete_stale_location_subentry_issues(
 ) -> None:
     """Delete location Repair issues for subentries no longer configured."""
     active_ids = set(active_subentry_ids)
-    legacy_invalid_issue_id = invalid_stored_location_issue_id(entry_id)
-    prefixes = (
-        f"invalid_stored_location_{entry_id}_",
-        f"location_setup_failed_{entry_id}_",
-    )
+    entry_issue_ids = _known_entry_location_issue_ids(hass, entry_id)
+    if not entry_issue_ids:
+        return
 
-    for issue_id in _iter_domain_issue_ids(hass):
-        if issue_id == legacy_invalid_issue_id:
+    for issue_id in tuple(entry_issue_ids):
+        subentry_id = _subentry_id_from_location_issue_id(entry_id, issue_id)
+        if subentry_id is None or subentry_id in active_ids:
             continue
-        for prefix in prefixes:
-            if (
-                issue_id.startswith(prefix)
-                and issue_id.removeprefix(prefix) not in active_ids
-            ):
-                ir.async_delete_issue(hass, DOMAIN, issue_id)
-                break
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+        _forget_location_issue(hass, entry_id, issue_id)
 
 
 def create_location_setup_failed_issue(
@@ -160,6 +170,7 @@ def create_location_setup_failed_issue(
             "reason": reason,
         },
     )
+    _remember_location_issue(hass, entry_id, issue_id)
 
 
 def create_entry_invalid_stored_location_issue(
@@ -185,6 +196,8 @@ def delete_invalid_stored_location_issue(
     """Delete a Repair issue for an invalid stored location if it exists."""
     issue_id = invalid_stored_location_issue_id(entry_id, subentry_id)
     ir.async_delete_issue(hass, DOMAIN, issue_id)
+    if subentry_id:
+        _forget_location_issue(hass, entry_id, issue_id)
 
 
 def delete_entry_invalid_stored_location_issue(
@@ -208,3 +221,4 @@ def delete_location_setup_failed_issue(
     """Delete a Repair issue for an isolated location setup failure if present."""
     issue_id = location_setup_failed_issue_id(entry_id, subentry_id)
     ir.async_delete_issue(hass, DOMAIN, issue_id)
+    _forget_location_issue(hass, entry_id, issue_id)

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0b4"
+    "version": "3.0.0b5"
 }

--- a/custom_components/pollenlevels/runtime.py
+++ b/custom_components/pollenlevels/runtime.py
@@ -19,22 +19,36 @@ class PollenLocationRuntime:
     legacy_entry_id: str | None = None
 
 
+@dataclass(slots=True)
+class PollenLocationSetupFailure:
+    """Runtime metadata for one location that could not finish setup."""
+
+    subentry_id: str
+    title: str
+    reason: str
+    error_type: str
+    is_auth_error: bool = False
+
+
 @dataclass(slots=True, init=False)
 class PollenLevelsRuntimeData:
     """Runtime container for a Pollen Levels parent config entry."""
 
     client: GooglePollenApiClient
     locations: dict[str, PollenLocationRuntime]
+    failed_locations: dict[str, PollenLocationSetupFailure]
 
     def __init__(
         self,
         *,
         client: GooglePollenApiClient,
         locations: dict[str, PollenLocationRuntime] | None = None,
+        failed_locations: dict[str, PollenLocationSetupFailure] | None = None,
         coordinator: PollenDataUpdateCoordinator | None = None,
     ) -> None:
         """Initialize runtime data with v3 locations or a legacy coordinator."""
         self.client = client
+        self.failed_locations = failed_locations or {}
         if locations is not None:
             self.locations = locations
             return

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -157,6 +157,10 @@
       "title": "Ubicació emmagatzemada no vàlida a Pollen Levels",
       "description": "Pollen Levels ha trobat dades d'ubicació emmagatzemades no vàlides per a {entry_title}: {location_title}. Elimina i torna a crear la ubicació afectada, o restaura una còpia de seguretat de Home Assistant anterior a la creació de la ubicació no vàlida."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "S'han eliminat els sensors de previsió per dia",
       "description": "Pollen Levels ja no crea entitats de previsió separades acabades en _d1 o _d2. Les dades de previsió continuen disponibles als sensors base de pol·len mitjançant els atributs forecast, tomorrow_* i d2_*. Actualitza els taulers, automatitzacions, plantilles i targetes personalitzades que encara facin referència a les entitats antigues."

--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha trobat dades d'ubicació emmagatzemades no vàlides per a {entry_title}: {location_title}. Elimina i torna a crear la ubicació afectada, o restaura una còpia de seguretat de Home Assistant anterior a la creació de la ubicació no vàlida."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "No s'ha pogut carregar la ubicació de Pollen Levels",
+      "description": "Pollen Levels no ha pogut carregar {location_title} per a {entry_title} durant la configuració ({error_type}). Altres ubicacions correctes poden continuar funcionant. Motiu: {reason}. Soluciona el problema indicat i torna a carregar l'entrada de la integració per reintentar aquesta ubicació. Les entitats existents i l'historial no s'eliminen per aquest error local de configuració."
     },
     "per_day_forecast_sensors_removed": {
       "title": "S'han eliminat els sensors de previsió per dia",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels našel neplatná uložená data lokality pro {entry_title}: {location_title}. Odstraňte a znovu vytvořte dotčenou lokalitu nebo obnovte zálohu Home Assistant z doby před vytvořením neplatné lokality."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Umístění Pollen Levels se nepodařilo načíst",
+      "description": "Pollen Levels nemohl během nastavování načíst {location_title} pro {entry_title} ({error_type}). Ostatní funkční umístění mohou dál pracovat. Důvod: {reason}. Opravte nahlášený problém a znovu načtěte položku integrace, aby se toto umístění zkusilo načíst znovu. Existující entity a historie se kvůli tomuto místnímu selhání nastavení neodstraňují."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Senzory denní předpovědi byly odstraněny",

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -157,6 +157,10 @@
       "title": "Neplatná uložená lokalita Pollen Levels",
       "description": "Pollen Levels našel neplatná uložená data lokality pro {entry_title}: {location_title}. Odstraňte a znovu vytvořte dotčenou lokalitu nebo obnovte zálohu Home Assistant z doby před vytvořením neplatné lokality."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Senzory denní předpovědi byly odstraněny",
       "description": "Pollen Levels již nevytváří samostatné entity předpovědi končící na _d1 nebo _d2. Data předpovědi jsou stále dostupná u základních pylových senzorů prostřednictvím atributů forecast, tomorrow_* a d2_*. Aktualizujte nástěnky, automatizace, šablony a vlastní karty, které stále odkazují na staré entity."

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels fandt ugyldige gemte placeringsdata for {entry_title}: {location_title}. Slet og opret den berørte placering igen, eller gendan en Home Assistant-sikkerhedskopi før den ugyldige placering blev oprettet."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels-placeringen kunne ikke indlæses",
+      "description": "Pollen Levels kunne ikke indlæse {location_title} for {entry_title} under opsætning ({error_type}). Andre velfungerende placeringer kan fortsætte med at virke. Årsag: {reason}. Ret det rapporterede problem, og genindlæs integrationsposten for at prøve denne placering igen. Eksisterende entiteter og historik fjernes ikke på grund af denne lokale opsætningsfejl."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Prognosesensorer pr. dag blev fjernet",

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -157,6 +157,10 @@
       "title": "Ugyldig gemt Pollen Levels-placering",
       "description": "Pollen Levels fandt ugyldige gemte placeringsdata for {entry_title}: {location_title}. Slet og opret den berørte placering igen, eller gendan en Home Assistant-sikkerhedskopi før den ugyldige placering blev oprettet."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Prognosesensorer pr. dag blev fjernet",
       "description": "Pollen Levels opretter ikke længere separate prognoseenheder, der slutter på _d1 eller _d2. Prognosedata er stadig tilgængelige på de grundlæggende pollensensorer via attributterne forecast, tomorrow_* og d2_*. Opdater dashboards, automatiseringer, skabeloner og brugerdefinerede kort, der stadig henviser til de gamle enheder."

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -157,6 +157,10 @@
       "title": "Ungültiger gespeicherter Pollen Levels-Standort",
       "description": "Pollen Levels hat ungültige gespeicherte Standortdaten für {entry_title}: {location_title} gefunden. Löschen und erstellen Sie den betroffenen Standort neu oder stellen Sie ein Home Assistant-Backup von vor der Erstellung des ungültigen Standorts wieder her."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Vorhersagesensoren pro Tag wurden entfernt",
       "description": "Pollen Levels erstellt keine separaten Vorhersage-Entitäten mit der Endung _d1 oder _d2 mehr. Vorhersagedaten bleiben über die Attribute forecast, tomorrow_* und d2_* auf den Basis-Pollensensoren verfügbar. Aktualisiere Dashboards, Automationen, Vorlagen und benutzerdefinierte Karten, die noch auf die alten Entitäten verweisen."

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels hat ungültige gespeicherte Standortdaten für {entry_title}: {location_title} gefunden. Löschen und erstellen Sie den betroffenen Standort neu oder stellen Sie ein Home Assistant-Backup von vor der Erstellung des ungültigen Standorts wieder her."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels-Standort konnte nicht geladen werden",
+      "description": "Pollen Levels konnte {location_title} für {entry_title} während der Einrichtung nicht laden ({error_type}). Andere fehlerfreie Standorte können weiter funktionieren. Grund: {reason}. Beheben Sie das gemeldete Problem und laden Sie den Integrationseintrag neu, um diesen Standort erneut zu versuchen. Vorhandene Entitäten und der Verlauf werden wegen dieses lokalen Einrichtungsfehlers nicht entfernt."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Vorhersagesensoren pro Tag wurden entfernt",

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -157,6 +157,10 @@
       "title": "Invalid stored Pollen Levels location",
       "description": "Pollen Levels found invalid stored location data for {entry_title}: {location_title}. Delete and recreate the affected location, or restore a Home Assistant backup from before the invalid location was created."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Per-day forecast sensors were removed",
       "description": "Pollen Levels no longer creates separate forecast entities ending in _d1 or _d2. Forecast data is still available on the base pollen sensors through the forecast, tomorrow_* and d2_* attributes. Update dashboards, automations, templates and custom cards that still reference the old entities."

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha encontrado datos de ubicación almacenados inválidos para {entry_title}: {location_title}. Elimina y vuelve a crear la ubicación afectada, o restaura una copia de seguridad de Home Assistant anterior a la creación de la ubicación inválida."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "No se pudo cargar la ubicación de Pollen Levels",
+      "description": "Pollen Levels no pudo cargar {location_title} para {entry_title} durante la configuración ({error_type}). Otras ubicaciones correctas pueden seguir funcionando. Motivo: {reason}. Corrige el problema indicado y recarga la entrada de la integración para volver a intentar esta ubicación. Las entidades existentes y el historial no se eliminan por este fallo local de configuración."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Se han eliminado los sensores de previsión por día",

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -157,6 +157,10 @@
       "title": "Ubicación almacenada inválida en Pollen Levels",
       "description": "Pollen Levels ha encontrado datos de ubicación almacenados inválidos para {entry_title}: {location_title}. Elimina y vuelve a crear la ubicación afectada, o restaura una copia de seguridad de Home Assistant anterior a la creación de la ubicación inválida."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Se han eliminado los sensores de previsión por día",
       "description": "Pollen Levels ya no crea entidades de previsión separadas que terminan en _d1 o _d2. Los datos de previsión siguen disponibles en los sensores base de polen mediante los atributos forecast, tomorrow_* y d2_*. Actualiza los paneles, automatizaciones, plantillas y tarjetas personalizadas que todavía hagan referencia a las entidades antiguas."

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels löysi virheellisiä tallennettuja sijaintitietoja kohteelle {entry_title}: {location_title}. Poista ja luo kyseinen sijainti uudelleen tai palauta Home Assistant -varmuuskopio ajalta ennen virheellisen sijainnin luomista."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels -sijaintia ei voitu ladata",
+      "description": "Pollen Levels ei voinut ladata sijaintia {location_title} kohteelle {entry_title} määrityksen aikana ({error_type}). Muut kunnossa olevat sijainnit voivat jatkaa toimintaansa. Syy: {reason}. Korjaa ilmoitettu ongelma ja lataa integraatiomerkintä uudelleen, jotta tätä sijaintia yritetään uudestaan. Olemassa olevia entiteettejä ja historiaa ei poisteta tämän paikallisen määritysvirheen vuoksi."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Päiväkohtaiset ennustesensorit poistettiin",

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -157,6 +157,10 @@
       "title": "Virheellinen tallennettu Pollen Levels -sijainti",
       "description": "Pollen Levels löysi virheellisiä tallennettuja sijaintitietoja kohteelle {entry_title}: {location_title}. Poista ja luo kyseinen sijainti uudelleen tai palauta Home Assistant -varmuuskopio ajalta ennen virheellisen sijainnin luomista."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Päiväkohtaiset ennustesensorit poistettiin",
       "description": "Pollen Levels ei enää luo erillisiä ennuste-entiteettejä, joiden loppu on _d1 tai _d2. Ennustetiedot ovat edelleen saatavilla perussiitepölysensoreissa attribuuttien forecast, tomorrow_* ja d2_* kautta. Päivitä koontinäytöt, automaatiot, mallit ja mukautetut kortit, jotka viittaavat vielä vanhoihin entiteetteihin."

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels a trouvé des données de localisation stockées invalides pour {entry_title} : {location_title}. Supprimez et recréez l'emplacement concerné, ou restaurez une sauvegarde Home Assistant antérieure à la création de l'emplacement invalide."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "L'emplacement Pollen Levels n'a pas pu être chargé",
+      "description": "Pollen Levels n'a pas pu charger {location_title} pour {entry_title} pendant la configuration ({error_type}). Les autres emplacements fonctionnels peuvent continuer à fonctionner. Raison : {reason}. Corrigez le problème signalé puis rechargez l'entrée de l'intégration pour réessayer cet emplacement. Les entités existantes et l'historique ne sont pas supprimés à cause de cet échec local de configuration."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Les capteurs de prévision par jour ont été supprimés",

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -157,6 +157,10 @@
       "title": "Emplacement stocké invalide dans Pollen Levels",
       "description": "Pollen Levels a trouvé des données de localisation stockées invalides pour {entry_title} : {location_title}. Supprimez et recréez l'emplacement concerné, ou restaurez une sauvegarde Home Assistant antérieure à la création de l'emplacement invalide."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Les capteurs de prévision par jour ont été supprimés",
       "description": "Pollen Levels ne crée plus d’entités de prévision séparées se terminant par _d1 ou _d2. Les données de prévision restent disponibles sur les capteurs de pollen de base via les attributs forecast, tomorrow_* et d2_*. Mettez à jour les tableaux de bord, automatisations, modèles et cartes personnalisées qui font encore référence aux anciennes entités."

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -158,8 +158,8 @@
       "description": "A Pollen Levels érvénytelen tárolt helyadatokat talált a következőhöz: {entry_title}: {location_title}. Törölje és hozza létre újra az érintett helyet, vagy állítson vissza egy Home Assistant biztonsági mentést az érvénytelen hely létrehozása előtti időből."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "A Pollen Levels helyet nem sikerült betölteni",
+      "description": "A Pollen Levels nem tudta betölteni a(z) {location_title} helyet a(z) {entry_title} beállítása közben ({error_type}). A többi megfelelő hely tovább működhet. Ok: {reason}. Javítsa a jelzett problémát, majd töltse újra az integráció bejegyzését, hogy ez a hely újra próbálkozzon. A meglévő entitások és az előzmények nem törlődnek emiatt a helyi beállítási hiba miatt."
     },
     "per_day_forecast_sensors_removed": {
       "title": "A napi előrejelzési szenzorok eltávolításra kerültek",

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -157,6 +157,10 @@
       "title": "Érvénytelen tárolt Pollen Levels hely",
       "description": "A Pollen Levels érvénytelen tárolt helyadatokat talált a következőhöz: {entry_title}: {location_title}. Törölje és hozza létre újra az érintett helyet, vagy állítson vissza egy Home Assistant biztonsági mentést az érvénytelen hely létrehozása előtti időből."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "A napi előrejelzési szenzorok eltávolításra kerültek",
       "description": "A Pollen Levels már nem hoz létre külön előrejelzési entitásokat _d1 vagy _d2 végződéssel. Az előrejelzési adatok továbbra is elérhetők az alap pollenszenzorokon a forecast, tomorrow_* és d2_* attribútumokon keresztül. Frissítsd azokat az irányítópultokat, automatizálásokat, sablonokat és egyéni kártyákat, amelyek még a régi entitásokra hivatkoznak."

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -157,6 +157,10 @@
       "title": "Posizione memorizzata non valida in Pollen Levels",
       "description": "Pollen Levels ha trovato dati di posizione memorizzati non validi per {entry_title}: {location_title}. Elimina e ricrea la posizione interessata o ripristina un backup di Home Assistant precedente alla creazione della posizione non valida."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "I sensori di previsione per giorno sono stati rimossi",
       "description": "Pollen Levels non crea più entità di previsione separate che terminano con _d1 o _d2. I dati di previsione restano disponibili sui sensori polline di base tramite gli attributi forecast, tomorrow_* e d2_*. Aggiorna dashboard, automazioni, modelli e schede personalizzate che fanno ancora riferimento alle vecchie entità."

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels ha trovato dati di posizione memorizzati non validi per {entry_title}: {location_title}. Elimina e ricrea la posizione interessata o ripristina un backup di Home Assistant precedente alla creazione della posizione non valida."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Impossibile caricare la posizione di Pollen Levels",
+      "description": "Pollen Levels non ha potuto caricare {location_title} per {entry_title} durante la configurazione ({error_type}). Le altre posizioni funzionanti possono continuare a operare. Motivo: {reason}. Risolvi il problema indicato e ricarica la voce dell'integrazione per riprovare questa posizione. Le entità esistenti e la cronologia non vengono rimosse a causa di questo errore locale di configurazione."
     },
     "per_day_forecast_sensors_removed": {
       "title": "I sensori di previsione per giorno sono stati rimossi",

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -157,6 +157,10 @@
       "title": "Ugyldig lagret Pollen Levels-plassering",
       "description": "Pollen Levels fant ugyldige lagrede plasseringsdata for {entry_title}: {location_title}. Slett og opprett den berørte plasseringen på nytt, eller gjenopprett en Home Assistant-sikkerhetskopi fra før den ugyldige plasseringen ble opprettet."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Prognosesensorer per dag ble fjernet",
       "description": "Pollen Levels oppretter ikke lenger separate prognoseentiteter som slutter på _d1 eller _d2. Prognosedata er fortsatt tilgjengelige på de grunnleggende pollensensorene via attributtene forecast, tomorrow_* og d2_*. Oppdater dashbord, automatiseringer, maler og egendefinerte kort som fortsatt viser til de gamle entitetene."

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels fant ugyldige lagrede plasseringsdata for {entry_title}: {location_title}. Slett og opprett den berørte plasseringen på nytt, eller gjenopprett en Home Assistant-sikkerhetskopi fra før den ugyldige plasseringen ble opprettet."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels-plasseringen kunne ikke lastes",
+      "description": "Pollen Levels kunne ikke laste {location_title} for {entry_title} under oppsettet ({error_type}). Andre friske plasseringer kan fortsette å fungere. Årsak: {reason}. Rett det rapporterte problemet og last integrasjonsoppføringen på nytt for å prøve denne plasseringen igjen. Eksisterende entiteter og historikk fjernes ikke på grunn av denne lokale oppsettsfeilen."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Prognosesensorer per dag ble fjernet",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels heeft ongeldige opgeslagen locatiegegevens gevonden voor {entry_title}: {location_title}. Verwijder en maak de betreffende locatie opnieuw aan, of herstel een Home Assistant-backup van vóór het aanmaken van de ongeldige locatie."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels-locatie kon niet worden geladen",
+      "description": "Pollen Levels kon {location_title} voor {entry_title} niet laden tijdens het instellen ({error_type}). Andere werkende locaties kunnen blijven functioneren. Reden: {reason}. Los het gemelde probleem op en herlaad de integratievermelding om deze locatie opnieuw te proberen. Bestaande entiteiten en geschiedenis worden niet verwijderd door deze lokale instelfout."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Voorspellingssensoren per dag zijn verwijderd",

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -157,6 +157,10 @@
       "title": "Ongeldige opgeslagen Pollen Levels-locatie",
       "description": "Pollen Levels heeft ongeldige opgeslagen locatiegegevens gevonden voor {entry_title}: {location_title}. Verwijder en maak de betreffende locatie opnieuw aan, of herstel een Home Assistant-backup van vóór het aanmaken van de ongeldige locatie."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Voorspellingssensoren per dag zijn verwijderd",
       "description": "Pollen Levels maakt geen afzonderlijke voorspellingsentiteiten meer aan die eindigen op _d1 of _d2. Voorspellingsgegevens blijven beschikbaar op de basispollensensoren via de attributen forecast, tomorrow_* en d2_*. Werk dashboards, automatiseringen, sjablonen en aangepaste kaarten bij die nog naar de oude entiteiten verwijzen."

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -157,6 +157,10 @@
       "title": "Nieprawidłowa zapisana lokalizacja Pollen Levels",
       "description": "Pollen Levels znalazł nieprawidłowe zapisane dane lokalizacji dla {entry_title}: {location_title}. Usuń i utwórz ponownie dotkniętą lokalizację lub przywróć kopię zapasową Home Assistant sprzed utworzenia nieprawidłowej lokalizacji."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Usunięto dzienne sensory prognozy",
       "description": "Pollen Levels nie tworzy już oddzielnych encji prognozy kończących się na _d1 lub _d2. Dane prognozy nadal są dostępne w podstawowych sensorach pyłków przez atrybuty forecast, tomorrow_* i d2_*. Zaktualizuj pulpity, automatyzacje, szablony i niestandardowe karty, które nadal odwołują się do starych encji."

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels znalazł nieprawidłowe zapisane dane lokalizacji dla {entry_title}: {location_title}. Usuń i utwórz ponownie dotkniętą lokalizację lub przywróć kopię zapasową Home Assistant sprzed utworzenia nieprawidłowej lokalizacji."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Nie udało się wczytać lokalizacji Pollen Levels",
+      "description": "Pollen Levels nie mógł wczytać {location_title} dla {entry_title} podczas konfiguracji ({error_type}). Inne działające lokalizacje mogą nadal pracować. Powód: {reason}. Napraw zgłoszony problem i przeładuj wpis integracji, aby ponowić próbę dla tej lokalizacji. Istniejące encje i historia nie są usuwane z powodu tej lokalnej awarii konfiguracji."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Usunięto dzienne sensory prognozy",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Exclua e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Não foi possível carregar a localização do Pollen Levels",
+      "description": "O Pollen Levels não conseguiu carregar {location_title} para {entry_title} durante a configuração ({error_type}). Outras localizações saudáveis podem continuar funcionando. Motivo: {reason}. Corrija o problema informado e recarregue a entrada da integração para tentar esta localização novamente. As entidades existentes e o histórico não são removidos por causa desta falha local de configuração."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Os sensores de previsão por dia foram removidos",

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -157,6 +157,10 @@
       "title": "Localização armazenada inválida no Pollen Levels",
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Exclua e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Os sensores de previsão por dia foram removidos",
       "description": "Pollen Levels não cria mais entidades de previsão separadas terminadas em _d1 ou _d2. Os dados de previsão continuam disponíveis nos sensores base de pólen por meio dos atributos forecast, tomorrow_* e d2_*. Atualize painéis, automações, modelos e cartões personalizados que ainda referenciam as entidades antigas."

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -157,6 +157,10 @@
       "title": "Localização armazenada inválida no Pollen Levels",
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Elimine e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Os sensores de previsão por dia foram removidos",
       "description": "Pollen Levels já não cria entidades de previsão separadas terminadas em _d1 ou _d2. Os dados de previsão continuam disponíveis nos sensores base de pólen através dos atributos forecast, tomorrow_* e d2_*. Atualize painéis, automatizações, modelos e cartões personalizados que ainda referenciem as entidades antigas."

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels encontrou dados de localização armazenados inválidos para {entry_title}: {location_title}. Elimine e recrie a localização afetada ou restaure um backup do Home Assistant anterior à criação da localização inválida."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Não foi possível carregar a localização do Pollen Levels",
+      "description": "O Pollen Levels não conseguiu carregar {location_title} para {entry_title} durante a configuração ({error_type}). Outras localizações saudáveis podem continuar a funcionar. Motivo: {reason}. Corrija o problema indicado e recarregue a entrada da integração para tentar novamente esta localização. As entidades existentes e o histórico não são removidos devido a esta falha local de configuração."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Os sensores de previsão por dia foram removidos",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels a găsit date de locație stocate invalide pentru {entry_title}: {location_title}. Ștergeți și recreați locația afectată sau restaurați o copie de rezervă Home Assistant dinaintea creării locației invalide."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Locația Pollen Levels nu a putut fi încărcată",
+      "description": "Pollen Levels nu a putut încărca {location_title} pentru {entry_title} în timpul configurării ({error_type}). Alte locații funcționale pot continua să meargă. Motiv: {reason}. Remediază problema raportată și reîncarcă intrarea integrării pentru a reîncerca această locație. Entitățile existente și istoricul nu sunt eliminate din cauza acestei erori locale de configurare."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Senzorii de prognoză pe zi au fost eliminați",

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -157,6 +157,10 @@
       "title": "Locație stocată invalidă în Pollen Levels",
       "description": "Pollen Levels a găsit date de locație stocate invalide pentru {entry_title}: {location_title}. Ștergeți și recreați locația afectată sau restaurați o copie de rezervă Home Assistant dinaintea creării locației invalide."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Senzorii de prognoză pe zi au fost eliminați",
       "description": "Pollen Levels nu mai creează entități de prognoză separate care se termină în _d1 sau _d2. Datele de prognoză rămân disponibile pe senzorii de polen de bază prin atributele forecast, tomorrow_* și d2_*. Actualizează tablourile de bord, automatizările, șabloanele și cardurile personalizate care încă fac referire la entitățile vechi."

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels обнаружил недействительные сохранённые данные местоположения для {entry_title}: {location_title}. Удалите и создайте затронутое местоположение заново или восстановите резервную копию Home Assistant, созданную до появления недействительного местоположения."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Не удалось загрузить местоположение Pollen Levels",
+      "description": "Pollen Levels не удалось загрузить {location_title} для {entry_title} во время настройки ({error_type}). Другие исправные местоположения могут продолжать работать. Причина: {reason}. Исправьте указанную проблему и перезагрузите запись интеграции, чтобы повторить попытку для этого местоположения. Существующие сущности и история не удаляются из-за этого локального сбоя настройки."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Дневные датчики прогноза были удалены",

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -157,6 +157,10 @@
       "title": "Недействительное сохранённое местоположение Pollen Levels",
       "description": "Pollen Levels обнаружил недействительные сохранённые данные местоположения для {entry_title}: {location_title}. Удалите и создайте затронутое местоположение заново или восстановите резервную копию Home Assistant, созданную до появления недействительного местоположения."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Дневные датчики прогноза были удалены",
       "description": "Pollen Levels больше не создает отдельные сущности прогноза, оканчивающиеся на _d1 или _d2. Данные прогноза по-прежнему доступны в базовых датчиках пыльцы через атрибуты forecast, tomorrow_* и d2_*. Обновите панели, автоматизации, шаблоны и пользовательские карточки, которые все еще ссылаются на старые сущности."

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels hittade ogiltiga lagrade platsdata för {entry_title}: {location_title}. Ta bort och återskapa den berörda platsen eller återställ en Home Assistant-säkerhetskopia från före den ogiltiga platsen skapades."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Pollen Levels-platsen kunde inte läsas in",
+      "description": "Pollen Levels kunde inte läsa in {location_title} för {entry_title} under konfigureringen ({error_type}). Andra fungerande platser kan fortsätta att fungera. Orsak: {reason}. Åtgärda det rapporterade problemet och läs in integrationsposten på nytt för att försöka med den här platsen igen. Befintliga entiteter och historik tas inte bort på grund av detta lokala konfigurationsfel."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Prognossensorer per dag har tagits bort",

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -157,6 +157,10 @@
       "title": "Ogiltig lagrad Pollen Levels-plats",
       "description": "Pollen Levels hittade ogiltiga lagrade platsdata för {entry_title}: {location_title}. Ta bort och återskapa den berörda platsen eller återställ en Home Assistant-säkerhetskopia från före den ogiltiga platsen skapades."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Prognossensorer per dag har tagits bort",
       "description": "Pollen Levels skapar inte längre separata prognosenheter som slutar på _d1 eller _d2. Prognosdata är fortfarande tillgängliga på de grundläggande pollensensorerna via attributen forecast, tomorrow_* och d2_*. Uppdatera instrumentpaneler, automatiseringar, mallar och anpassade kort som fortfarande refererar till de gamla enheterna."

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -157,6 +157,10 @@
       "title": "Недійсне збережене розташування Pollen Levels",
       "description": "Pollen Levels виявив недійсні збережені дані розташування для {entry_title}: {location_title}. Видаліть і створіть заново відповідне розташування або відновіть резервну копію Home Assistant, створену до появи недійсного розташування."
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "Денні сенсори прогнозу було видалено",
       "description": "Pollen Levels більше не створює окремі сутності прогнозу, що закінчуються на _d1 або _d2. Дані прогнозу й надалі доступні в базових сенсорах пилку через атрибути forecast, tomorrow_* і d2_*. Оновіть панелі, автоматизації, шаблони та користувацькі картки, які все ще посилаються на старі сутності."

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels виявив недійсні збережені дані розташування для {entry_title}: {location_title}. Видаліть і створіть заново відповідне розташування або відновіть резервну копію Home Assistant, створену до появи недійсного розташування."
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "Не вдалося завантажити місце Pollen Levels",
+      "description": "Pollen Levels не вдалося завантажити {location_title} для {entry_title} під час налаштування ({error_type}). Інші справні місця можуть продовжувати працювати. Причина: {reason}. Виправте повідомлену проблему та перезавантажте запис інтеграції, щоб повторити спробу для цього місця. Наявні сутності та історія не видаляються через цей локальний збій налаштування."
     },
     "per_day_forecast_sensors_removed": {
       "title": "Денні сенсори прогнозу було видалено",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels 发现 {entry_title}：{location_title} 的存储位置数据无效。请删除并重新创建受影响的设置，或恢复在创建无效位置之前的 Home Assistant 备份。"
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "无法加载 Pollen Levels 位置",
+      "description": "Pollen Levels 在设置期间无法为 {entry_title} 加载 {location_title}（{error_type}）。其他正常的位置仍可继续工作。原因：{reason}。请修复报告的问题并重新加载该集成条目，以重试此位置。现有实体和历史记录不会因为这个本地设置失败而被删除。"
     },
     "per_day_forecast_sensors_removed": {
       "title": "已移除按天预报传感器",

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -157,6 +157,10 @@
       "title": "Pollen Levels 中无效的存储位置",
       "description": "Pollen Levels 发现 {entry_title}：{location_title} 的存储位置数据无效。请删除并重新创建受影响的设置，或恢复在创建无效位置之前的 Home Assistant 备份。"
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "已移除按天预报传感器",
       "description": "Pollen Levels 不再创建以 _d1 或 _d2 结尾的独立预报实体。预报数据仍可通过基础花粉传感器上的 forecast、tomorrow_* 和 d2_* 属性获得。请更新仍引用旧实体的仪表板、自动化、模板和自定义卡片。"

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -157,6 +157,10 @@
       "title": "Pollen Levels 中無效的儲存位置",
       "description": "Pollen Levels 發現 {entry_title}：{location_title} 的儲存位置資料無效。請刪除並重新建立受影響的位置，或還原建立無效位置之前的 Home Assistant 備份。"
     },
+    "location_setup_failed": {
+      "title": "Pollen Levels location could not be loaded",
+      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+    },
     "per_day_forecast_sensors_removed": {
       "title": "已移除按日預報感測器",
       "description": "Pollen Levels 不再建立以 _d1 或 _d2 結尾的獨立預報實體。預報資料仍可透過基礎花粉感測器上的 forecast、tomorrow_* 和 d2_* 屬性取得。請更新仍參照舊實體的儀表板、自動化、範本和自訂卡片。"

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -158,8 +158,8 @@
       "description": "Pollen Levels 發現 {entry_title}：{location_title} 的儲存位置資料無效。請刪除並重新建立受影響的位置，或還原建立無效位置之前的 Home Assistant 備份。"
     },
     "location_setup_failed": {
-      "title": "Pollen Levels location could not be loaded",
-      "description": "Pollen Levels could not load {location_title} for {entry_title} during setup ({error_type}). Other healthy locations may continue to work. Reason: {reason}. Fix the reported issue and reload the integration entry to retry this location. Existing entities and history are not removed because of this local setup failure."
+      "title": "無法載入 Pollen Levels 位置",
+      "description": "Pollen Levels 在設定期間無法為 {entry_title} 載入 {location_title}（{error_type}）。其他正常的位置仍可繼續運作。原因：{reason}。請修正回報的問題並重新載入該整合項目，以重試此位置。現有實體與歷史紀錄不會因為這個本機設定失敗而被移除。"
     },
     "per_day_forecast_sensors_removed": {
       "title": "已移除按日預報感測器",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0b4"
+version = "3.0.0b5"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -311,6 +311,9 @@ class StubIssueRegistry:
         self.deleted.append((hass, domain, issue_id))
         self.issues.pop(issue_id, None)
 
+    def async_get(self, _hass):
+        return self
+
 
 class StubIssueSeverity:
     ERROR = "error"
@@ -324,6 +327,7 @@ def stub_issue_registry_module(
     module = ModuleType("homeassistant.helpers.issue_registry")
     registry = StubIssueRegistry()
     module.registry = registry
+    module.async_get = registry.async_get
     module.async_create_issue = registry.async_create_issue
     module.async_delete_issue = registry.async_delete_issue
     module.IssueSeverity = StubIssueSeverity

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -311,9 +311,6 @@ class StubIssueRegistry:
         self.deleted.append((hass, domain, issue_id))
         self.issues.pop(issue_id, None)
 
-    def async_get(self, _hass):
-        return self
-
 
 class StubIssueSeverity:
     ERROR = "error"
@@ -327,7 +324,6 @@ def stub_issue_registry_module(
     module = ModuleType("homeassistant.helpers.issue_registry")
     registry = StubIssueRegistry()
     module.registry = registry
-    module.async_get = registry.async_get
     module.async_create_issue = registry.async_create_issue
     module.async_delete_issue = registry.async_delete_issue
     module.IssueSeverity = StubIssueSeverity

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -322,3 +322,54 @@ async def test_setup_entry_skips_stale_runtime_locations(
     )
 
     assert added == []
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_ignores_failed_locations(
+    button_platform: SimpleNamespace,
+) -> None:
+    """Button setup should create buttons only for loaded runtime locations."""
+
+    coordinator = _FakeCoordinator()
+    entry = types.SimpleNamespace(
+        data={},
+        subentries={
+            "loaded-location": types.SimpleNamespace(
+                subentry_id="loaded-location",
+                subentry_type="location",
+            ),
+            "failed-location": types.SimpleNamespace(
+                subentry_id="failed-location",
+                subentry_type="location",
+            ),
+        },
+        runtime_data=types.SimpleNamespace(
+            locations={
+                "loaded-location": types.SimpleNamespace(
+                    subentry_id="loaded-location",
+                    coordinator=coordinator,
+                )
+            },
+            failed_locations={
+                "failed-location": types.SimpleNamespace(
+                    subentry_id="failed-location",
+                    title="Failed",
+                    error_type="UpdateFailed",
+                    reason="No data",
+                )
+            },
+        ),
+    )
+    added = []
+    subentry_ids = []
+
+    def _add_entities(entities, **kwargs):
+        added.extend(entities)
+        subentry_ids.append(kwargs.get("config_subentry_id"))
+
+    await button_platform.module.async_setup_entry(
+        button_platform.hass_class(), entry, _add_entities
+    )
+
+    assert len(added) == 1
+    assert subentry_ids == ["loaded-location"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -715,6 +715,42 @@ async def test_diagnostics_reports_failed_locations_separately_from_stale(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_marks_invalid_stored_location_as_not_reload_retryable(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Invalid stored location diagnostics should not claim reload retry is enough."""
+
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
+    }
+    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    entry.subentries = {
+        "invalid": SimpleNamespace(subentry_id="invalid", subentry_type="location")
+    }
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={},
+        failed_locations={
+            "invalid": diagnostics_modules.PollenLocationSetupFailure(
+                subentry_id="invalid",
+                title="Invalid",
+                error_type="InvalidStoredLocation",
+                reason="Pollen Levels location has invalid stored coordinates",
+            )
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    failed_payload = diagnostics["failed_locations"]["invalid"]
+    assert failed_payload["error_type"] == "InvalidStoredLocation"
+    assert failed_payload["will_retry_on_reload"] is False
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_request_days_are_fixed(
     diagnostics_modules: DiagnosticsModules,
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -24,6 +24,7 @@ class DiagnosticsModules(NamedTuple):
     diag: ModuleType
     PollenLevelsRuntimeData: type[object]
     PollenLocationRuntime: type[object]
+    PollenLocationSetupFailure: type[object]
     CONF_API_KEY: str
     CONF_LANGUAGE_CODE: str
     CONF_LATITUDE: str
@@ -103,12 +104,14 @@ def diagnostics_modules(monkeypatch: pytest.MonkeyPatch) -> DiagnosticsModules:
     from custom_components.pollenlevels.runtime import (
         PollenLevelsRuntimeData as ImportedRuntimeData,
         PollenLocationRuntime as ImportedLocationRuntime,
+        PollenLocationSetupFailure as ImportedLocationSetupFailure,
     )
 
     modules = DiagnosticsModules(
         diag=imported_diag,
         PollenLevelsRuntimeData=ImportedRuntimeData,
         PollenLocationRuntime=ImportedLocationRuntime,
+        PollenLocationSetupFailure=ImportedLocationSetupFailure,
         CONF_API_KEY=imported_conf_api_key,
         CONF_LANGUAGE_CODE=imported_conf_language_code,
         CONF_LATITUDE=imported_conf_latitude,
@@ -237,6 +240,7 @@ async def test_diagnostics_includes_all_locations_without_top_level_duplicates(
     assert set(diagnostics["locations"]) == {"subentry-1", "subentry-2"}
     assert set(diagnostics) == {
         "entry",
+        "failed_locations",
         "locations",
         "runtime_summary",
         "registry_summary",
@@ -246,6 +250,8 @@ async def test_diagnostics_includes_all_locations_without_top_level_duplicates(
     assert diagnostics["runtime_summary"] == {
         "stale_location_count": 0,
         "stale_location_ids": [],
+        "failed_location_count": 0,
+        "failed_location_ids": [],
     }
     assert "registry_summary" in diagnostics
     assert first_payload["request_params_example"]["key"] == "***"
@@ -543,6 +549,8 @@ async def test_diagnostics_summarizes_runtime_locations_when_parent_has_no_locat
     assert diagnostics["runtime_summary"] == {
         "stale_location_count": 1,
         "stale_location_ids": ["deleted-location"],
+        "failed_location_count": 0,
+        "failed_location_ids": [],
     }
     serialized = json.dumps(diagnostics, sort_keys=True)
     assert "secret-token" not in serialized
@@ -604,11 +612,104 @@ async def test_diagnostics_summarizes_stale_runtime_locations(
     assert diagnostics["runtime_summary"] == {
         "stale_location_count": 1,
         "stale_location_ids": ["trabajo"],
+        "failed_location_count": 0,
+        "failed_location_ids": [],
     }
     serialized = json.dumps(diagnostics, sort_keys=True)
     assert "secret-token" not in serialized
     assert "12.345678" not in serialized
     assert "-98.765432" not in serialized
+    assert "23.456789" not in serialized
+    assert "-87.654321" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_reports_failed_locations_separately_from_stale(
+    diagnostics_modules: DiagnosticsModules,
+) -> None:
+    """Diagnostics should keep failed setup locations separate from stale runtime."""
+
+    data = {
+        diagnostics_modules.CONF_API_KEY: "secret-token",
+        diagnostics_modules.CONF_LANGUAGE_CODE: "en",
+    }
+    entry = _ConfigEntry(data=data, options={}, entry_id="entry", title="Home")
+    entry.subentries = {
+        "loaded": SimpleNamespace(subentry_id="loaded", subentry_type="location"),
+        "failed": SimpleNamespace(
+            subentry_id="failed",
+            subentry_type="location",
+            data={
+                diagnostics_modules.CONF_LATITUDE: 12.345678,
+                diagnostics_modules.CONF_LONGITUDE: -98.765432,
+            },
+        ),
+    }
+
+    loaded_coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="loaded",
+        language="en",
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=40.4168,
+        lon=-3.7038,
+        entry_title="Loaded",
+        data={},
+    )
+    stale_coordinator = SimpleNamespace(
+        entry_id="entry",
+        subentry_id="deleted",
+        language="en",
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        lat=23.456789,
+        lon=-87.654321,
+        entry_title="Deleted",
+        data={},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "loaded": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="loaded",
+                coordinator=loaded_coordinator,
+            ),
+            "deleted": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="deleted",
+                coordinator=stale_coordinator,
+            ),
+        },
+        failed_locations={
+            "failed": diagnostics_modules.PollenLocationSetupFailure(
+                subentry_id="failed",
+                title="Failed secret-token 12.345678",
+                error_type="UpdateFailed",
+                reason=(
+                    "API response missing data for key=secret-token "
+                    "location.latitude=12.345678"
+                ),
+            )
+        },
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    assert set(diagnostics["locations"]) == {"loaded"}
+    assert set(diagnostics["failed_locations"]) == {"failed"}
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 1,
+        "stale_location_ids": ["deleted"],
+        "failed_location_count": 1,
+        "failed_location_ids": ["failed"],
+    }
+    failed_payload = diagnostics["failed_locations"]["failed"]
+    assert failed_payload["error_type"] == "UpdateFailed"
+    assert failed_payload["will_retry_on_reload"] is True
+    assert failed_payload["is_auth_error"] is False
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert "secret-token" not in serialized
+    assert "12.345678" not in serialized
     assert "23.456789" not in serialized
     assert "-87.654321" not in serialized
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4641,33 +4641,21 @@ def test_setup_entry_clears_location_repairs_for_deleted_subentries(
     stale_setup_issue_id = integration.issue_helpers.location_setup_failed_issue_id(
         entry.entry_id, "deleted-location"
     )
-    registry.async_create_issue(
-        None,
-        integration.DOMAIN,
-        stale_invalid_issue_id,
-        is_fixable=False,
-        is_persistent=False,
-        severity="error",
-        translation_key="invalid_stored_location",
-        translation_placeholders={
-            "entry_title": "Stale Home",
-            "location_title": "Deleted",
-        },
+    integration.issue_helpers.create_invalid_stored_location_issue(
+        hass,
+        entry_id=entry.entry_id,
+        entry_title="Stale Home",
+        location_title="Deleted",
+        subentry_id="deleted-location",
     )
-    registry.async_create_issue(
-        None,
-        integration.DOMAIN,
-        stale_setup_issue_id,
-        is_fixable=False,
-        is_persistent=False,
-        severity="warning",
-        translation_key="location_setup_failed",
-        translation_placeholders={
-            "entry_title": "Stale Home",
-            "location_title": "Deleted",
-            "error_type": "UpdateFailed",
-            "reason": "old failure",
-        },
+    integration.issue_helpers.create_location_setup_failed_issue(
+        hass,
+        entry_id=entry.entry_id,
+        entry_title="Stale Home",
+        location_title="Deleted",
+        subentry_id="deleted-location",
+        error_type="UpdateFailed",
+        reason="old failure",
     )
 
     class _StubCoordinator:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -125,6 +125,7 @@ class _StubDataUpdateCoordinator:
         self.last_updated = None
 
     async def async_config_entry_first_refresh(self):
+        self.data = {"date": {}, "region": {}}
         self.last_updated = "now"
         return None
 
@@ -655,13 +656,14 @@ def test_setup_entry_boundary_coordinates_are_allowed(
         assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
 
-def test_setup_entry_raises_not_ready_when_one_subentry_fails(
+def test_setup_entry_loads_healthy_subentries_when_one_subentry_fails(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A local refresh failure should retry the whole parent entry."""
+    """A local refresh failure should not block other healthy locations."""
     integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
     bad_subentry = integration.ConfigSubentry(
         data={
@@ -706,12 +708,25 @@ def test_setup_entry_raises_not_ready_when_one_subentry_fails(
     monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
 
     with caplog.at_level("WARNING", logger=integration.__name__):
-        with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
-            asyncio.run(integration.async_setup_entry(hass, entry))
+        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
-    assert exc_info.value.__cause__ is None
-    assert entry.runtime_data is None
-    assert hass.config_entries.forward_calls == []
+    assert entry.runtime_data is not None
+    assert set(entry.runtime_data.locations) == {"good-location"}
+    assert set(entry.runtime_data.failed_locations) == {"bad-location"}
+    failure = entry.runtime_data.failed_locations["bad-location"]
+    assert failure.error_type == "RuntimeError"
+    assert "secret-key" not in failure.reason
+    assert "3.123456" not in failure.reason
+    assert "-4.654321" not in failure.reason
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, "bad-location"
+    )
+    assert issue_id in registry.issues
+    issue = registry.issues[issue_id]
+    assert issue["translation_key"] == "location_setup_failed"
+    assert issue["translation_placeholders"]["location_title"] == "Bad"
+    assert issue["translation_placeholders"]["error_type"] == "RuntimeError"
     log_text = caplog.text
     assert "Initial data refresh failed for entry entry-1 subentry bad-location" in (
         log_text
@@ -721,12 +736,13 @@ def test_setup_entry_raises_not_ready_when_one_subentry_fails(
     assert "-4.654321" not in log_text
 
 
-def test_setup_entry_raises_not_ready_when_subentry_coordinates_are_invalid(
+def test_setup_entry_skips_invalid_subentry_coordinates_when_others_load(
     integration_modules: _InitModules,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Invalid subentry coordinates should retry without partial runtime data."""
+    """Invalid subentry coordinates should not block valid locations."""
     integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
     bad_subentry = integration.ConfigSubentry(
         data={
@@ -752,12 +768,18 @@ def test_setup_entry_raises_not_ready_when_subentry_coordinates_are_invalid(
     hass = _FakeHass()
 
     with caplog.at_level("WARNING", logger=integration.__name__):
-        with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
-            asyncio.run(integration.async_setup_entry(hass, entry))
+        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
-    assert exc_info.value.__cause__ is None
-    assert entry.runtime_data is None
-    assert hass.config_entries.forward_calls == []
+    assert entry.runtime_data is not None
+    assert set(entry.runtime_data.locations) == {"good-location"}
+    assert set(entry.runtime_data.failed_locations) == {"bad-location"}
+    failure = entry.runtime_data.failed_locations["bad-location"]
+    assert failure.error_type == "InvalidStoredLocation"
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    expected_issue_id = integration.invalid_stored_location_issue_id(
+        entry.entry_id, subentry_id="bad-location"
+    )
+    assert expected_issue_id in registry.issues
     log_text = caplog.text
     assert (
         "Invalid coordinates for Pollen Levels entry entry-1 subentry bad-location"
@@ -768,12 +790,66 @@ def test_setup_entry_raises_not_ready_when_subentry_coordinates_are_invalid(
     assert "2.654321" not in log_text
 
 
-def test_setup_entry_raises_not_ready_when_later_subentry_is_not_ready(
+def test_setup_entry_skips_location_without_usable_initial_data(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A later not-ready location should discard earlier successful setup work."""
+    """A location with no usable initial data should not block healthy locations."""
     integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    empty = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="empty-location",
+        title="Empty",
+    )
+    good = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 3.0, integration.CONF_LONGITUDE: 4.0},
+        subentry_id="good-location",
+        title="Good",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "key"},
+        subentries={empty.subentry_id: empty, good.subentry_id: good},
+    )
+    hass = _FakeHass()
+
+    class _StubCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = (
+                {"region": {"source": "meta"}}
+                if self.subentry_id == "empty-location"
+                else {"date": {"source": "meta"}}
+            )
+
+        async def async_config_entry_first_refresh(self):
+            return None
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
+
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+
+    assert entry.runtime_data is not None
+    assert set(entry.runtime_data.locations) == {"good-location"}
+    assert set(entry.runtime_data.failed_locations) == {"empty-location"}
+    failure = entry.runtime_data.failed_locations["empty-location"]
+    assert failure.error_type == "UpdateFailed"
+    assert failure.reason == "API response missing usable pollen data"
+    issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, "empty-location"
+    )
+    assert issue_id in registry.issues
+
+
+def test_setup_entry_keeps_first_subentry_when_later_subentry_is_not_ready(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A later not-ready location should be isolated when another location works."""
+    integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
     first = integration.ConfigSubentry(
         data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
@@ -794,6 +870,7 @@ def test_setup_entry_raises_not_ready_when_later_subentry_is_not_ready(
     class _PartiallyReadyCoordinator:
         def __init__(self, *args, **kwargs):
             self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
 
         async def async_config_entry_first_refresh(self):
             refreshed.append(self.subentry_id)
@@ -804,13 +881,17 @@ def test_setup_entry_raises_not_ready_when_later_subentry_is_not_ready(
         integration, "PollenDataUpdateCoordinator", _PartiallyReadyCoordinator
     )
 
-    with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
-        asyncio.run(integration.async_setup_entry(hass, entry))
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
-    assert exc_info.value.__cause__ is None
     assert refreshed == ["first-location", "second-location"]
-    assert entry.runtime_data is None
-    assert hass.config_entries.forward_calls == []
+    assert entry.runtime_data is not None
+    assert set(entry.runtime_data.locations) == {"first-location"}
+    assert set(entry.runtime_data.failed_locations) == {"second-location"}
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, "second-location"
+    )
+    assert issue_id in registry.issues
 
 
 def test_setup_entry_raises_not_ready_when_all_subentries_fail(
@@ -1631,6 +1712,49 @@ def test_force_update_parent_without_locations_is_noop(
 
     assert "Skipping force_update for entry entry-empty" in caplog.text
     assert "No coordinators available for force_update" in caplog.text
+
+
+def test_force_update_skips_failed_locations_without_coordinators(
+    integration_modules: _InitModules,
+) -> None:
+    """force_update should refresh only loaded runtime locations."""
+    integration = integration_modules.integration
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    coordinator = _Coordinator()
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-parent",
+        data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "loaded", "failed"),
+    )
+    entry.runtime_data = types.SimpleNamespace(
+        locations={
+            "loaded": types.SimpleNamespace(
+                subentry_id="loaded", coordinator=coordinator
+            )
+        },
+        failed_locations={
+            "failed": types.SimpleNamespace(
+                subentry_id="failed",
+                title="Failed",
+                error_type="UpdateFailed",
+                reason="No data",
+            )
+        },
+    )
+    hass = _FakeHass(entries=[entry])
+
+    assert asyncio.run(integration.async_setup(hass, {})) is True
+    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
+
+    assert coordinator.calls == 1
 
 
 def test_migrate_entry_removes_legacy_mode_and_creates_issue(
@@ -4136,7 +4260,7 @@ def test_setup_entry_creates_repair_issue_for_invalid_location_coordinates(
     assert hass.config_entries.forward_calls == []
 
     expected_issue_id = integration.invalid_stored_location_issue_id(
-        entry.entry_id, subentry_id=None
+        entry.entry_id, subentry_id="bad-location"
     )
     assert expected_issue_id in registry.issues
     issue = registry.issues[expected_issue_id]
@@ -4154,11 +4278,11 @@ def test_setup_entry_creates_repair_issue_for_invalid_location_coordinates(
     assert "91.123456" not in caplog.text
 
 
-def test_setup_entry_creates_repair_for_later_invalid_subentry_before_refresh(
+def test_setup_entry_loads_valid_location_when_later_subentry_is_invalid(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A later invalid subentry should create the Repair before any coordinator is created."""
+    """A later invalid subentry should create a Repair without blocking setup."""
     import sys
 
     integration = integration_modules.integration
@@ -4185,13 +4309,18 @@ def test_setup_entry_creates_repair_for_later_invalid_subentry_before_refresh(
         },
     )
     hass = _FakeHass()
+    created_coordinators: list[str] = []
 
-    def _fail_coordinator(*_args, **_kwargs):
-        pytest.fail(
-            "Coordinator should not be instantiated before all coordinates are validated"
-        )
+    class _StubCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
+            created_coordinators.append(self.subentry_id)
 
-    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _fail_coordinator)
+        async def async_config_entry_first_refresh(self):
+            return None
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
 
     class _StubClient:
         def __init__(self, _session, _api_key):
@@ -4200,18 +4329,18 @@ def test_setup_entry_creates_repair_for_later_invalid_subentry_before_refresh(
 
     monkeypatch.setattr(integration, "GooglePollenApiClient", _StubClient)
 
-    with pytest.raises(integration.ConfigEntryNotReady) as exc_info:
-        asyncio.run(integration.async_setup_entry(hass, entry))
-
-    assert exc_info.value.__cause__ is None
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
     expected_issue_id = integration.invalid_stored_location_issue_id(
-        entry.entry_id, subentry_id=None
+        entry.entry_id, subentry_id="bad-location"
     )
     assert expected_issue_id in registry.issues
     assert (hass, integration.DOMAIN, expected_issue_id) not in registry.deleted
-    assert entry.runtime_data is None
-    assert hass.config_entries.forward_calls == []
+    assert created_coordinators == ["first-location"]
+    assert entry.runtime_data is not None
+    assert set(entry.runtime_data.locations) == {"first-location"}
+    assert set(entry.runtime_data.failed_locations) == {"bad-location"}
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
 
 
 def test_setup_entry_deletes_invalid_location_repair_issue_after_coordinates_are_valid(
@@ -4237,6 +4366,23 @@ def test_setup_entry_deletes_invalid_location_repair_issue_after_coordinates_are
         subentries={good_subentry.subentry_id: good_subentry},
     )
     hass = _FakeHass()
+    expected_issue_id = integration.invalid_stored_location_issue_id(
+        entry.entry_id, subentry_id=good_subentry.subentry_id
+    )
+    registry.async_create_issue(
+        None,
+        integration.DOMAIN,
+        expected_issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity="error",
+        translation_key="invalid_stored_location",
+        translation_placeholders={
+            "entry_title": "Valid Home",
+            "location_title": "Good",
+        },
+    )
+    assert expected_issue_id in registry.issues
 
     class _StubCoordinator:
         def __init__(self, *args, **kwargs):
@@ -4265,10 +4411,8 @@ def test_setup_entry_deletes_invalid_location_repair_issue_after_coordinates_are
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
-    expected_issue_id = integration.invalid_stored_location_issue_id(
-        entry.entry_id, subentry_id=None
-    )
     assert (hass, integration.DOMAIN, expected_issue_id) in registry.deleted
+    assert expected_issue_id not in registry.issues
 
 
 def test_setup_entry_removes_entry_level_repair_issue_when_no_invalid_subentries(
@@ -4338,6 +4482,67 @@ def test_setup_entry_removes_entry_level_repair_issue_when_no_invalid_subentries
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert (hass, integration.DOMAIN, existing_issue_id) in registry.deleted
     assert existing_issue_id not in registry.issues
+
+
+def test_setup_entry_clears_location_setup_failed_repair_on_success(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successfully loaded location should clear its previous setup-failed Repair."""
+    import sys
+
+    integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    subentry = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="recovered-location",
+        title="Recovered",
+    )
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-recovered",
+        title="Recovered Home",
+        data={integration.CONF_API_KEY: "key"},
+        subentries={subentry.subentry_id: subentry},
+    )
+    issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, subentry.subentry_id
+    )
+    registry.async_create_issue(
+        None,
+        integration.DOMAIN,
+        issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity="warning",
+        translation_key="location_setup_failed",
+        translation_placeholders={
+            "entry_title": "Recovered Home",
+            "location_title": "Recovered",
+            "error_type": "UpdateFailed",
+            "reason": "old failure",
+        },
+    )
+    assert issue_id in registry.issues
+
+    class _StubCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            return None
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
+
+    assert asyncio.run(integration.async_setup_entry(_FakeHass(), entry)) is True
+
+    assert any(
+        domain == integration.DOMAIN and deleted_issue_id == issue_id
+        for _hass, domain, deleted_issue_id in registry.deleted
+    )
+    assert issue_id not in registry.issues
 
 
 def test_setup_entry_does_not_create_repair_issue_for_temporal_refresh_failure(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -345,6 +345,9 @@ class _FakeConfigEntries:
     async def async_reload(self, entry_id: str):  # pragma: no cover - used in tests
         self.reload_calls.append(entry_id)
 
+    def async_schedule_reload(self, entry_id: str):
+        self.reload_calls.append(entry_id)
+
     def async_get_entry(self, entry_id: str):
         return next(
             (
@@ -783,11 +786,8 @@ def test_setup_entry_loads_healthy_subentries_when_one_subentry_fails(
     issue_id = integration.issue_helpers.location_setup_failed_issue_id(
         entry.entry_id, "bad-location"
     )
-    assert issue_id in registry.issues
-    issue = registry.issues[issue_id]
-    assert issue["translation_key"] == "location_setup_failed"
-    assert issue["translation_placeholders"]["location_title"] == "Bad"
-    assert issue["translation_placeholders"]["error_type"] == "RuntimeError"
+    assert issue_id not in registry.issues
+    assert hass.config_entries.reload_calls == [entry.entry_id]
     log_text = caplog.text
     assert "Initial data refresh failed for entry entry-1 subentry bad-location" in (
         log_text
@@ -901,7 +901,8 @@ def test_setup_entry_skips_location_without_usable_initial_data(
     issue_id = integration.issue_helpers.location_setup_failed_issue_id(
         entry.entry_id, "empty-location"
     )
-    assert issue_id in registry.issues
+    assert issue_id not in registry.issues
+    assert hass.config_entries.reload_calls == [entry.entry_id]
 
 
 def test_setup_entry_keeps_first_subentry_when_later_subentry_is_not_ready(
@@ -952,7 +953,63 @@ def test_setup_entry_keeps_first_subentry_when_later_subentry_is_not_ready(
     issue_id = integration.issue_helpers.location_setup_failed_issue_id(
         entry.entry_id, "second-location"
     )
+    assert issue_id not in registry.issues
+    assert hass.config_entries.reload_calls == [entry.entry_id]
+
+
+def test_setup_entry_creates_repair_after_retryable_failure_repeats(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated retryable partial setup failures should create a Repair warning."""
+    integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    first = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="first-location",
+    )
+    second = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 3.0, integration.CONF_LONGITUDE: 4.0},
+        subentry_id="second-location",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "key"},
+        subentries={first.subentry_id: first, second.subentry_id: second},
+    )
+    hass = _FakeHass()
+    hass.data[integration.DOMAIN] = {
+        integration._SETUP_RETRY_FAILURES_DATA_KEY: {
+            entry.entry_id: {"second-location"}
+        }
+    }
+
+    class _PartiallyReadyCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            if self.subentry_id == "second-location":
+                raise integration.ConfigEntryNotReady("retry later")
+
+    monkeypatch.setattr(
+        integration, "PollenDataUpdateCoordinator", _PartiallyReadyCoordinator
+    )
+
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+
+    issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, "second-location"
+    )
     assert issue_id in registry.issues
+    issue = registry.issues[issue_id]
+    assert issue["translation_key"] == "location_setup_failed"
+    assert issue["translation_placeholders"]["error_type"].endswith(
+        "ConfigEntryNotReady"
+    )
+    assert hass.config_entries.reload_calls == []
 
 
 def test_setup_entry_raises_not_ready_when_all_subentries_fail(
@@ -993,6 +1050,7 @@ def test_setup_entry_raises_not_ready_when_all_subentries_fail(
     assert exc_info.value.__cause__ is None
     assert entry.runtime_data is None
     assert hass.config_entries.forward_calls == []
+    assert hass.config_entries.reload_calls == []
     assert not any(
         issue_id.startswith("location_setup_failed_")
         for issue_id in sys.modules[
@@ -4551,6 +4609,89 @@ def test_setup_entry_removes_entry_level_repair_issue_when_no_invalid_subentries
     assert existing_issue_id not in registry.issues
 
 
+def test_setup_entry_clears_location_repairs_for_deleted_subentries(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setup should delete location Repair issues for removed subentries."""
+    integration = integration_modules.integration
+    registry = sys.modules["homeassistant.helpers.issue_registry"].registry
+
+    active_subentry = integration.ConfigSubentry(
+        data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
+        subentry_id="active-location",
+        title="Active",
+    )
+    entry = _FakeEntry(
+        integration,
+        entry_id="entry-stale",
+        title="Stale Home",
+        data={integration.CONF_API_KEY: "key"},
+        subentries={active_subentry.subentry_id: active_subentry},
+    )
+    hass = _FakeHass()
+    hass.data[integration.DOMAIN] = {
+        integration._SETUP_RETRY_FAILURES_DATA_KEY: {
+            entry.entry_id: {"active-location", "deleted-location"}
+        }
+    }
+    stale_invalid_issue_id = integration.invalid_stored_location_issue_id(
+        entry.entry_id, subentry_id="deleted-location"
+    )
+    stale_setup_issue_id = integration.issue_helpers.location_setup_failed_issue_id(
+        entry.entry_id, "deleted-location"
+    )
+    registry.async_create_issue(
+        None,
+        integration.DOMAIN,
+        stale_invalid_issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity="error",
+        translation_key="invalid_stored_location",
+        translation_placeholders={
+            "entry_title": "Stale Home",
+            "location_title": "Deleted",
+        },
+    )
+    registry.async_create_issue(
+        None,
+        integration.DOMAIN,
+        stale_setup_issue_id,
+        is_fixable=False,
+        is_persistent=False,
+        severity="warning",
+        translation_key="location_setup_failed",
+        translation_placeholders={
+            "entry_title": "Stale Home",
+            "location_title": "Deleted",
+            "error_type": "UpdateFailed",
+            "reason": "old failure",
+        },
+    )
+
+    class _StubCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            return None
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
+
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+
+    assert stale_invalid_issue_id not in registry.issues
+    assert stale_setup_issue_id not in registry.issues
+    assert (
+        hass.data[integration.DOMAIN][integration._SETUP_RETRY_FAILURES_DATA_KEY] == {}
+    )
+    deleted_issue_ids = {issue_id for _hass, _domain, issue_id in registry.deleted}
+    assert stale_invalid_issue_id in deleted_issue_ids
+    assert stale_setup_issue_id in deleted_issue_ids
+
+
 def test_setup_entry_clears_location_setup_failed_repair_on_success(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
@@ -4592,6 +4733,12 @@ def test_setup_entry_clears_location_setup_failed_repair_on_success(
         },
     )
     assert issue_id in registry.issues
+    hass = _FakeHass()
+    hass.data[integration.DOMAIN] = {
+        integration._SETUP_RETRY_FAILURES_DATA_KEY: {
+            entry.entry_id: {subentry.subentry_id}
+        }
+    }
 
     class _StubCoordinator:
         def __init__(self, *args, **kwargs):
@@ -4603,13 +4750,16 @@ def test_setup_entry_clears_location_setup_failed_repair_on_success(
 
     monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _StubCoordinator)
 
-    assert asyncio.run(integration.async_setup_entry(_FakeHass(), entry)) is True
+    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
     assert any(
         domain == integration.DOMAIN and deleted_issue_id == issue_id
         for _hass, domain, deleted_issue_id in registry.deleted
     )
     assert issue_id not in registry.issues
+    assert (
+        hass.data[integration.DOMAIN][integration._SETUP_RETRY_FAILURES_DATA_KEY] == {}
+    )
 
 
 def test_setup_entry_does_not_create_repair_issue_for_temporal_refresh_failure(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -71,6 +71,67 @@ class _StubServiceCall:  # pragma: no cover - structure only
     pass
 
 
+def test_safe_setup_failure_text_uses_fallback_for_none(
+    integration_modules: _InitModules,
+) -> None:
+    """None setup failure text should use the caller fallback."""
+    integration = integration_modules.integration
+
+    assert (
+        integration._safe_setup_failure_text(
+            None,
+            api_key="secret-key",
+            latitude=1.234567,
+            longitude=2.345678,
+            fallback="Location setup failed",
+        )
+        == "Location setup failed"
+    )
+
+
+def test_safe_setup_failure_text_stringifies_custom_objects(
+    integration_modules: _InitModules,
+) -> None:
+    """Custom object setup failure text should not break redaction/truncation."""
+    integration = integration_modules.integration
+
+    class _CustomFailure:
+        def __str__(self) -> str:
+            return "custom failure"
+
+    assert (
+        integration._safe_setup_failure_text(
+            _CustomFailure(),
+            api_key=None,
+            fallback="Location setup failed",
+        )
+        == "custom failure"
+    )
+
+
+def test_safe_setup_failure_text_redacts_secrets_and_coordinates(
+    integration_modules: _InitModules,
+) -> None:
+    """Setup failure text should not expose API keys or exact coordinates."""
+    integration = integration_modules.integration
+    reason = RuntimeError(
+        "boom secret-key at location.latitude=1.234567 " "location.longitude=2.345678"
+    )
+
+    redacted = integration._safe_setup_failure_text(
+        reason,
+        api_key="secret-key",
+        latitude=1.234567,
+        longitude=2.345678,
+        fallback="Location setup failed",
+    )
+
+    assert "secret-key" not in redacted
+    assert "1.234567" not in redacted
+    assert "2.345678" not in redacted
+    assert "***" in redacted
+
+
 class _StubSensorEntity:  # pragma: no cover - structure only
     def __init__(self, *args, **kwargs):
         self._attr_unique_id = None
@@ -932,6 +993,12 @@ def test_setup_entry_raises_not_ready_when_all_subentries_fail(
     assert exc_info.value.__cause__ is None
     assert entry.runtime_data is None
     assert hass.config_entries.forward_calls == []
+    assert not any(
+        issue_id.startswith("location_setup_failed_")
+        for issue_id in sys.modules[
+            "homeassistant.helpers.issue_registry"
+        ].registry.issues
+    )
 
 
 def test_setup_entry_auth_failure_still_fails_parent(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3086,6 +3086,75 @@ async def test_async_setup_entry_skips_stale_runtime_locations(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_ignores_failed_locations(
+    sensor_modules: SensorModules,
+) -> None:
+    """Sensor setup should create entities only for loaded runtime locations."""
+
+    hass = DummyHass(asyncio.get_running_loop())
+    config_entry = FakeConfigEntry(
+        data={sensor_modules.sensor.CONF_API_KEY: "key"},
+        entry_id="entry",
+    )
+    config_entry.subentries = {
+        "loaded-location": types.SimpleNamespace(
+            subentry_id="loaded-location",
+            subentry_type=sensor_modules.const.SUBENTRY_TYPE_LOCATION,
+        ),
+        "failed-location": types.SimpleNamespace(
+            subentry_id="failed-location",
+            subentry_type=sensor_modules.const.SUBENTRY_TYPE_LOCATION,
+        ),
+    }
+    coordinator = types.SimpleNamespace(
+        data={
+            "date": {"source": "meta", "value": "2026-05-08"},
+            "type_grass": {
+                "source": "type",
+                "displayName": "Grass",
+                "value": 3,
+            },
+        },
+        entry_id="entry",
+        subentry_id="loaded-location",
+        entity_identity_id="entry_loaded-location",
+        device_identity_id="entry_loaded-location",
+        entry_title="Loaded",
+        lat=1.0,
+        lon=2.0,
+        last_updated=None,
+    )
+    config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "loaded-location": types.SimpleNamespace(
+                subentry_id="loaded-location",
+                coordinator=coordinator,
+            )
+        },
+        failed_locations={
+            "failed-location": types.SimpleNamespace(
+                subentry_id="failed-location",
+                title="Failed",
+                error_type="UpdateFailed",
+                reason="No data",
+            )
+        },
+    )
+    add_calls: list[tuple[list[Any], dict[str, Any]]] = []
+
+    def _capture_entities(entities, **kwargs):
+        add_calls.append((list(entities), kwargs))
+
+    await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
+
+    assert add_calls
+    assert {call[1].get("config_subentry_id") for call in add_calls} == {
+        "loaded-location"
+    }
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_update(
     sensor_modules: SensorModules,
 ) -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -391,6 +391,8 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
         "config_subentries.location.error.quota_exceeded",
         "config_subentries.location.error.unknown",
         "config_subentries.location.abort.reconfigure_successful",
+        "issues.location_setup_failed.title",
+        "issues.location_setup_failed.description",
         "issues.per_day_forecast_sensors_removed.title",
         "issues.per_day_forecast_sensors_removed.description",
     }


### PR DESCRIPTION
## Summary

- Implement conservative partial setup for v3 location subentries so local non-auth failures no longer block healthy locations under the same parent entry.
- Add runtime `failed_locations` metadata plus Repair issue creation/cleanup for isolated setup failures.
- Extend diagnostics with separate failed-location summary/details while keeping stale runtime locations separate.
- Keep sensors, update buttons, and `force_update` limited to loaded runtime locations.
- Add regression coverage for partial setup, invalid coordinates, no usable initial data, Repair cleanup, diagnostics, platforms, and service behavior.

## Notes

- v2-to-v3 migration code was intentionally not changed.
- Failed locations do not create placeholder sensors/buttons and are retried by reloading the parent entry after the issue is fixed.
- Locale keysets were synchronized with a new `issues.location_setup_failed` entry.

## Validation

- `python -m ruff check --fix --select I`
- `python -m black --check .`
- `python -m ruff check`
- `python -m pytest tests/` (466 passed)

Not available locally:

- `python -m hassfest --help` failed: `No module named hassfest`
- `python -m hacs.validate --help` failed: `No module named hacs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-location resilience: One location's setup failure no longer blocks healthy siblings from loading.
  * Per-location setup failure diagnostics with privacy-safe error details.
  * Home Assistant Repair warnings for isolated setup failures with guidance.

* **Bug Fixes**
  * Failing locations no longer block sibling locations from continuing.
  * Repair warnings clear automatically after successful reloads or subentry removal.
  * Improved handling of missing initial pollen data.

* **Documentation**
  * Updated CHANGELOG for v3.0.0b5 release.
  * Added localization for setup failure messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->