### PR TITLE
test: add Home Assistant harness coverage

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=9"
+          python -m pip install --upgrade "black>=26" "ruff>=0.15" "pytest>=9"
+          python -m pip install -r requirements_test.txt
 
       - name: Compile Python sources
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=25" "ruff>=0.14" "pytest>=9"
+          python -m pip install --upgrade "black>=26" "ruff>=0.15" "pytest>=9"
+          python -m pip install -r requirements_test.txt
 
       - name: Compile Python sources
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.0.0b5] - 2026-06-13
+## [3.0.0b5] - 2026-06-14
 
 ### Added
 
@@ -10,6 +10,8 @@
 - Added a Home Assistant Repair warning for repeated isolated location setup
   failures, with privacy-safe details and guidance to reload the parent entry
   after fixing the affected location.
+- Added Home Assistant harness coverage for setup, subentry flows, services,
+  diagnostics, platform entity registration, and the fixed 5-day API request.
 
 ### Changed
 
@@ -19,6 +21,8 @@
   through separate summary fields.
 - Retryable partial setup failures now schedule a conservative automatic parent
   reload before surfacing the per-location Repair warning.
+- Replaced duplicated lightweight stub tests with Home Assistant harness tests
+  where the real runtime path now provides equivalent coverage.
 
 ### Fixed
 
@@ -38,6 +42,8 @@
 - Removed legacy single-location duplicate fields from diagnostics. In v3,
   per-location diagnostics are now exposed only under `locations`, avoiding
   misleading top-level data copied from the first location.
+- Passed the config entry into the data update coordinator when supported by
+  Home Assistant, preserving compatibility with newer coordinator contracts.
 
 ## [3.0.0b4] - 2026-06-11
 

--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -518,6 +518,7 @@ async def async_setup_entry(
             subentry_id=subentry_id,
             entry_title=title,
             legacy_entry_id=legacy_entry_id,
+            config_entry=entry,
             client=client,
         )
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -22,6 +22,7 @@ from .forecast import attach_forecast_attributes
 from .util import redact_api_key, redact_sensitive_values, safe_parse_int
 
 if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
 
@@ -152,17 +153,35 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         entry_title: str = DEFAULT_ENTRY_TITLE,
         subentry_id: str | None = None,
         legacy_entry_id: str | None = None,
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         """Initialize coordinator with configuration and interval."""
         explicit_subentry = subentry_id is not None
         subentry_id = subentry_id or entry_id
         update_interval = timedelta(hours=hours)
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=f"{DOMAIN}_{entry_id}_{subentry_id}",
-            update_interval=update_interval,
-        )
+        coordinator_kwargs: dict[str, Any] = {
+            "name": f"{DOMAIN}_{entry_id}_{subentry_id}",
+            "update_interval": update_interval,
+        }
+        if config_entry is not None:
+            coordinator_kwargs["config_entry"] = config_entry
+        try:
+            super().__init__(
+                hass,
+                _LOGGER,
+                **coordinator_kwargs,
+            )
+        except TypeError as err:
+            if "config_entry" not in coordinator_kwargs or "config_entry" not in str(
+                err
+            ):
+                raise
+            coordinator_kwargs.pop("config_entry")
+            super().__init__(
+                hass,
+                _LOGGER,
+                **coordinator_kwargs,
+            )
         self.api_key = api_key
         self.lat = lat
         self.lon = lon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"
 
 # --- Optional hardening (uncomment if needed) ---
 # [tool.ruff]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+pytest-homeassistant-custom-component>=0.13.339
+pytest-asyncio
+aioresponses

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,61 @@
+"""Local pytest compatibility shims.
+
+Home Assistant 2026.6 imports ``fcntl`` while loading its pytest plugin. The
+module is POSIX-only, so provide the tiny surface needed for collection on
+Windows test runs. Linux CI keeps using the real stdlib module.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+if sys.platform == "win32":
+    import socket as _socket
+
+    _original_socket = _socket.socket
+
+    def _loopback_socketpair(
+        family: int = _socket.AF_INET,
+        type: int = _socket.SOCK_STREAM,  # noqa: A002
+        proto: int = 0,
+    ) -> tuple[_socket.socket, _socket.socket]:
+        """Create a local socket pair without pytest-socket's guarded socket."""
+        host = "::1" if family == _socket.AF_INET6 else "127.0.0.1"
+        listener = _original_socket(family, type, proto)
+        try:
+            listener.bind((host, 0))
+            listener.listen(1)
+            client = _original_socket(family, type, proto)
+            try:
+                client.connect(listener.getsockname())
+                guarded_socket = _socket.socket
+                try:
+                    _socket.socket = _original_socket
+                    server, _address = listener.accept()
+                finally:
+                    _socket.socket = guarded_socket
+                return server, client
+            except Exception:
+                client.close()
+                raise
+        finally:
+            listener.close()
+
+    _socket.socketpair = _loopback_socketpair
+
+
+if sys.platform == "win32" and "fcntl" not in sys.modules:
+    fcntl = ModuleType("fcntl")
+    fcntl.LOCK_EX = 1
+    fcntl.LOCK_NB = 2
+    fcntl.LOCK_UN = 8
+    fcntl.flock = lambda _fd, _operation: None
+    sys.modules["fcntl"] = fcntl
+
+if sys.platform == "win32" and "resource" not in sys.modules:
+    resource = ModuleType("resource")
+    resource.RLIMIT_NOFILE = 7
+    resource.getrlimit = lambda _resource: (2048, 2048)
+    resource.setrlimit = lambda _resource, _limits: None
+    sys.modules["resource"] = resource

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,25 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
+from pathlib import Path
+from typing import Any
 
 import pytest
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE_CODE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    SUBENTRY_TYPE_LOCATION,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+
+TESTS_DIR = Path(__file__).resolve().parent
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -85,3 +102,67 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
                     asyncio.set_event_loop(None)
 
     return True
+
+
+@pytest.fixture
+def fake_api_key() -> str:
+    """Return a fake Google Pollen API key for harness tests."""
+    return "test-api-key"
+
+
+@pytest.fixture
+def sample_location() -> dict[str, Any]:
+    """Return a sample location using public integration constants."""
+    return {
+        "title": "Madrid",
+        CONF_LATITUDE: 40.4168,
+        CONF_LONGITUDE: -3.7038,
+        "subentry_id": "location-madrid",
+    }
+
+
+@pytest.fixture
+def sample_location_subentry_data(sample_location: dict[str, Any]) -> dict[str, Any]:
+    """Return ConfigSubentryData-compatible location data."""
+    latitude = sample_location[CONF_LATITUDE]
+    longitude = sample_location[CONF_LONGITUDE]
+    return {
+        "subentry_id": sample_location["subentry_id"],
+        "subentry_type": SUBENTRY_TYPE_LOCATION,
+        "title": sample_location["title"],
+        "unique_id": f"{latitude:.4f}_{longitude:.4f}",
+        "data": {
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+        },
+    }
+
+
+@pytest.fixture
+def ha_config_entry(
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+):
+    """Return a parent MockConfigEntry with one location subentry."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        unique_id=api_key_unique_id(fake_api_key),
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        subentries_data=[sample_location_subentry_data],
+        version=6,
+    )
+
+
+@pytest.fixture
+def google_pollen_5_day_payload() -> dict[str, Any]:
+    """Return the sanitized real 5-day Google Pollen fixture."""
+    fixture_path = TESTS_DIR / "fixtures" / "google_pollen_forecast_5_days.json"
+    return json.loads(fixture_path.read_text(encoding="ascii"))

--- a/tests/fixtures/google_pollen_forecast_5_days.json
+++ b/tests/fixtures/google_pollen_forecast_5_days.json
@@ -1,0 +1,850 @@
+{
+  "dailyInfo": [
+    {
+      "date": {
+        "day": 13,
+        "month": 6,
+        "year": 2026
+      },
+      "plantInfo": [
+        {
+          "code": "HAZEL",
+          "displayName": "Avellano"
+        },
+        {
+          "code": "ASH",
+          "displayName": "Fresno"
+        },
+        {
+          "code": "COTTONWOOD",
+          "displayName": "Chopo"
+        },
+        {
+          "code": "OAK",
+          "displayName": "Roble"
+        },
+        {
+          "code": "PINE",
+          "displayName": "Pino",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de p\u00edcea, falso abeto y abeto.",
+            "family": "Pin\u00e1ceas (familia del pino)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/pine_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/pine_closeup.jpg",
+            "season": "Primavera",
+            "specialColors": "Corteza de color marr\u00f3n rojizo o gris.",
+            "specialShapes": "Las hojas tienen forma de aguja y son de color verde.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "BIRCH",
+          "displayName": "Abedul",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de aliso, avellano, carpe, haya, sauce y roble. Adem\u00e1s, puede haber un mayor riesgo de alergias alimentarias a las avellanas, las almendras, los cacahuetes, las peras, las manzanas, las cerezas y las zanahorias.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/birch_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/birch_closeup.jpg",
+            "season": "Finales de invierno, primavera",
+            "specialColors": "La corteza suele ser de color gris blanquecino, plateado o, en ocasiones, rojizo.",
+            "specialShapes": "Las hojas de abedul suelen ser triangulares y dentadas. La corteza de la mayor\u00eda de los abedules presenta rayas horizontales oscuras que parecen cortes. La corteza de abedul tambi\u00e9n es conocida por su textura similar al papel, que puede pelarse f\u00e1cilmente.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "OLIVE",
+          "displayName": "Olivo",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de fresno y alhe\u00f1a.",
+            "family": "Ole\u00e1ceas (familia del olivo)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/olive_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/olive_closeup.jpg",
+            "season": "Final de la primavera, principio del verano",
+            "specialColors": "Las hojas son de color verde oscuro en el haz y plateadas en el env\u00e9s.",
+            "specialShapes": "Las hojas est\u00e1n dispuestas de forma inversa y lineal, con m\u00e1rgenes lisos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "GRAMINALES",
+          "displayName": "Gram\u00edneas",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de pl\u00e1tano (Plantago). Adem\u00e1s, puede haber un mayor riesgo de alergia alimentaria a los melones, a las naranjas, a los tomates, a los cacahuetes, a la soja, a la patata y a otras legumbres.",
+            "family": "Po\u00e1ceas",
+            "picture": "https://storage.googleapis.com/pollen-pictures/graminales_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/graminales_closeup.jpg",
+            "season": "Finales de la primavera, verano",
+            "specialColors": "Ninguno",
+            "specialShapes": "Las hojas son alternativas, largas y estrechas, y el borde es liso.",
+            "type": "GRASS"
+          }
+        },
+        {
+          "code": "RAGWEED",
+          "displayName": "Ambros\u00eda"
+        },
+        {
+          "code": "ALDER",
+          "displayName": "Aliso",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de abedul, avellano, carpe, haya, sauce y roble.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/alder_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/alder_closeup.jpg",
+            "season": "Finales de invierno, principios de primavera",
+            "specialColors": "En oto\u00f1o, las hojas tienden a volverse de color marr\u00f3n.",
+            "specialShapes": "Los \u00e1rboles producen amentos, que son grupos de flores sin p\u00e9talos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "MUGWORT",
+          "displayName": "Artemisia"
+        }
+      ],
+      "pollenTypeInfo": [
+        {
+          "code": "GRASS",
+          "displayName": "Gram\u00edneas",
+          "healthRecommendations": [
+            "Es importante ducharse y lavarse el pelo despu\u00e9s de pasar mucho tiempo al aire libre.",
+            "Cuando est\u00e9s en el exterior, ponte gafas de sol y gorra para mantener el polen alejado de la cara y los ojos.",
+            "Lava la ropa que hayas llevado en el exterior para eliminar los restos de polen.",
+            "Si es posible, usa gafas en vez de lentillas.",
+            "\u00bfHas tendido la ropa fuera? Ahora es un buen momento para tenderla dentro de casa o usar una secadora, si es posible."
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          }
+        },
+        {
+          "code": "TREE",
+          "displayName": "\u00c1rbol",
+          "healthRecommendations": [
+            "Los niveles de polen actuales son muy bajos. \u00a1Es un d\u00eda fant\u00e1stico para disfrutar al aire libre!"
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          }
+        },
+        {
+          "code": "WEED",
+          "displayName": "Maleza"
+        }
+      ]
+    },
+    {
+      "date": {
+        "day": 14,
+        "month": 6,
+        "year": 2026
+      },
+      "plantInfo": [
+        {
+          "code": "HAZEL",
+          "displayName": "Avellano"
+        },
+        {
+          "code": "ASH",
+          "displayName": "Fresno"
+        },
+        {
+          "code": "COTTONWOOD",
+          "displayName": "Chopo"
+        },
+        {
+          "code": "OAK",
+          "displayName": "Roble"
+        },
+        {
+          "code": "PINE",
+          "displayName": "Pino"
+        },
+        {
+          "code": "BIRCH",
+          "displayName": "Abedul",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de aliso, avellano, carpe, haya, sauce y roble. Adem\u00e1s, puede haber un mayor riesgo de alergias alimentarias a las avellanas, las almendras, los cacahuetes, las peras, las manzanas, las cerezas y las zanahorias.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/birch_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/birch_closeup.jpg",
+            "season": "Finales de invierno, primavera",
+            "specialColors": "La corteza suele ser de color gris blanquecino, plateado o, en ocasiones, rojizo.",
+            "specialShapes": "Las hojas de abedul suelen ser triangulares y dentadas. La corteza de la mayor\u00eda de los abedules presenta rayas horizontales oscuras que parecen cortes. La corteza de abedul tambi\u00e9n es conocida por su textura similar al papel, que puede pelarse f\u00e1cilmente.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "OLIVE",
+          "displayName": "Olivo",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de fresno y alhe\u00f1a.",
+            "family": "Ole\u00e1ceas (familia del olivo)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/olive_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/olive_closeup.jpg",
+            "season": "Final de la primavera, principio del verano",
+            "specialColors": "Las hojas son de color verde oscuro en el haz y plateadas en el env\u00e9s.",
+            "specialShapes": "Las hojas est\u00e1n dispuestas de forma inversa y lineal, con m\u00e1rgenes lisos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "GRAMINALES",
+          "displayName": "Gram\u00edneas",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de pl\u00e1tano (Plantago). Adem\u00e1s, puede haber un mayor riesgo de alergia alimentaria a los melones, a las naranjas, a los tomates, a los cacahuetes, a la soja, a la patata y a otras legumbres.",
+            "family": "Po\u00e1ceas",
+            "picture": "https://storage.googleapis.com/pollen-pictures/graminales_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/graminales_closeup.jpg",
+            "season": "Finales de la primavera, verano",
+            "specialColors": "Ninguno",
+            "specialShapes": "Las hojas son alternativas, largas y estrechas, y el borde es liso.",
+            "type": "GRASS"
+          }
+        },
+        {
+          "code": "RAGWEED",
+          "displayName": "Ambros\u00eda"
+        },
+        {
+          "code": "ALDER",
+          "displayName": "Aliso",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de abedul, avellano, carpe, haya, sauce y roble.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/alder_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/alder_closeup.jpg",
+            "season": "Finales de invierno, principios de primavera",
+            "specialColors": "En oto\u00f1o, las hojas tienden a volverse de color marr\u00f3n.",
+            "specialShapes": "Los \u00e1rboles producen amentos, que son grupos de flores sin p\u00e9talos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "MUGWORT",
+          "displayName": "Artemisia"
+        }
+      ],
+      "pollenTypeInfo": [
+        {
+          "code": "GRASS",
+          "displayName": "Gram\u00edneas",
+          "healthRecommendations": [
+            "Es importante ducharse y lavarse el pelo despu\u00e9s de pasar mucho tiempo al aire libre.",
+            "Cuando est\u00e9s en el exterior, ponte gafas de sol y gorra para mantener el polen alejado de la cara y los ojos.",
+            "Lava la ropa que hayas llevado en el exterior para eliminar los restos de polen.",
+            "Si es posible, usa gafas en vez de lentillas.",
+            "\u00bfHas tendido la ropa fuera? Ahora es un buen momento para tenderla dentro de casa o usar una secadora, si es posible."
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          }
+        },
+        {
+          "code": "TREE",
+          "displayName": "\u00c1rbol",
+          "healthRecommendations": [
+            "Los niveles de polen actuales son muy bajos. \u00a1Es un d\u00eda fant\u00e1stico para disfrutar al aire libre!"
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          }
+        },
+        {
+          "code": "WEED",
+          "displayName": "Maleza"
+        }
+      ]
+    },
+    {
+      "date": {
+        "day": 15,
+        "month": 6,
+        "year": 2026
+      },
+      "plantInfo": [
+        {
+          "code": "HAZEL",
+          "displayName": "Avellano"
+        },
+        {
+          "code": "ASH",
+          "displayName": "Fresno"
+        },
+        {
+          "code": "COTTONWOOD",
+          "displayName": "Chopo"
+        },
+        {
+          "code": "OAK",
+          "displayName": "Roble"
+        },
+        {
+          "code": "PINE",
+          "displayName": "Pino"
+        },
+        {
+          "code": "BIRCH",
+          "displayName": "Abedul",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de aliso, avellano, carpe, haya, sauce y roble. Adem\u00e1s, puede haber un mayor riesgo de alergias alimentarias a las avellanas, las almendras, los cacahuetes, las peras, las manzanas, las cerezas y las zanahorias.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/birch_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/birch_closeup.jpg",
+            "season": "Finales de invierno, primavera",
+            "specialColors": "La corteza suele ser de color gris blanquecino, plateado o, en ocasiones, rojizo.",
+            "specialShapes": "Las hojas de abedul suelen ser triangulares y dentadas. La corteza de la mayor\u00eda de los abedules presenta rayas horizontales oscuras que parecen cortes. La corteza de abedul tambi\u00e9n es conocida por su textura similar al papel, que puede pelarse f\u00e1cilmente.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "OLIVE",
+          "displayName": "Olivo",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de fresno y alhe\u00f1a.",
+            "family": "Ole\u00e1ceas (familia del olivo)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/olive_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/olive_closeup.jpg",
+            "season": "Final de la primavera, principio del verano",
+            "specialColors": "Las hojas son de color verde oscuro en el haz y plateadas en el env\u00e9s.",
+            "specialShapes": "Las hojas est\u00e1n dispuestas de forma inversa y lineal, con m\u00e1rgenes lisos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "GRAMINALES",
+          "displayName": "Gram\u00edneas",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de pl\u00e1tano (Plantago). Adem\u00e1s, puede haber un mayor riesgo de alergia alimentaria a los melones, a las naranjas, a los tomates, a los cacahuetes, a la soja, a la patata y a otras legumbres.",
+            "family": "Po\u00e1ceas",
+            "picture": "https://storage.googleapis.com/pollen-pictures/graminales_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/graminales_closeup.jpg",
+            "season": "Finales de la primavera, verano",
+            "specialColors": "Ninguno",
+            "specialShapes": "Las hojas son alternativas, largas y estrechas, y el borde es liso.",
+            "type": "GRASS"
+          }
+        },
+        {
+          "code": "RAGWEED",
+          "displayName": "Ambros\u00eda"
+        },
+        {
+          "code": "ALDER",
+          "displayName": "Aliso",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de abedul, avellano, carpe, haya, sauce y roble.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/alder_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/alder_closeup.jpg",
+            "season": "Finales de invierno, principios de primavera",
+            "specialColors": "En oto\u00f1o, las hojas tienden a volverse de color marr\u00f3n.",
+            "specialShapes": "Los \u00e1rboles producen amentos, que son grupos de flores sin p\u00e9talos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "MUGWORT",
+          "displayName": "Artemisia"
+        }
+      ],
+      "pollenTypeInfo": [
+        {
+          "code": "GRASS",
+          "displayName": "Gram\u00edneas",
+          "healthRecommendations": [
+            "Es importante ducharse y lavarse el pelo despu\u00e9s de pasar mucho tiempo al aire libre.",
+            "Cuando est\u00e9s en el exterior, ponte gafas de sol y gorra para mantener el polen alejado de la cara y los ojos.",
+            "Lava la ropa que hayas llevado en el exterior para eliminar los restos de polen.",
+            "Si es posible, usa gafas en vez de lentillas.",
+            "\u00bfHas tendido la ropa fuera? Ahora es un buen momento para tenderla dentro de casa o usar una secadora, si es posible."
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          }
+        },
+        {
+          "code": "TREE",
+          "displayName": "\u00c1rbol",
+          "healthRecommendations": [
+            "Los niveles de polen actuales son muy bajos. \u00a1Es un d\u00eda fant\u00e1stico para disfrutar al aire libre!"
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          }
+        },
+        {
+          "code": "WEED",
+          "displayName": "Maleza"
+        }
+      ]
+    },
+    {
+      "date": {
+        "day": 16,
+        "month": 6,
+        "year": 2026
+      },
+      "plantInfo": [
+        {
+          "code": "HAZEL",
+          "displayName": "Avellano"
+        },
+        {
+          "code": "ASH",
+          "displayName": "Fresno"
+        },
+        {
+          "code": "COTTONWOOD",
+          "displayName": "Chopo"
+        },
+        {
+          "code": "OAK",
+          "displayName": "Roble"
+        },
+        {
+          "code": "PINE",
+          "displayName": "Pino"
+        },
+        {
+          "code": "BIRCH",
+          "displayName": "Abedul",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de aliso, avellano, carpe, haya, sauce y roble. Adem\u00e1s, puede haber un mayor riesgo de alergias alimentarias a las avellanas, las almendras, los cacahuetes, las peras, las manzanas, las cerezas y las zanahorias.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/birch_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/birch_closeup.jpg",
+            "season": "Finales de invierno, primavera",
+            "specialColors": "La corteza suele ser de color gris blanquecino, plateado o, en ocasiones, rojizo.",
+            "specialShapes": "Las hojas de abedul suelen ser triangulares y dentadas. La corteza de la mayor\u00eda de los abedules presenta rayas horizontales oscuras que parecen cortes. La corteza de abedul tambi\u00e9n es conocida por su textura similar al papel, que puede pelarse f\u00e1cilmente.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "OLIVE",
+          "displayName": "Olivo",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de fresno y alhe\u00f1a.",
+            "family": "Ole\u00e1ceas (familia del olivo)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/olive_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/olive_closeup.jpg",
+            "season": "Final de la primavera, principio del verano",
+            "specialColors": "Las hojas son de color verde oscuro en el haz y plateadas en el env\u00e9s.",
+            "specialShapes": "Las hojas est\u00e1n dispuestas de forma inversa y lineal, con m\u00e1rgenes lisos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "GRAMINALES",
+          "displayName": "Gram\u00edneas",
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de pl\u00e1tano (Plantago). Adem\u00e1s, puede haber un mayor riesgo de alergia alimentaria a los melones, a las naranjas, a los tomates, a los cacahuetes, a la soja, a la patata y a otras legumbres.",
+            "family": "Po\u00e1ceas",
+            "picture": "https://storage.googleapis.com/pollen-pictures/graminales_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/graminales_closeup.jpg",
+            "season": "Finales de la primavera, verano",
+            "specialColors": "Ninguno",
+            "specialShapes": "Las hojas son alternativas, largas y estrechas, y el borde es liso.",
+            "type": "GRASS"
+          }
+        },
+        {
+          "code": "RAGWEED",
+          "displayName": "Ambros\u00eda"
+        },
+        {
+          "code": "ALDER",
+          "displayName": "Aliso",
+          "inSeason": false,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          },
+          "plantDescription": {
+            "crossReaction": "Polen de abedul, avellano, carpe, haya, sauce y roble.",
+            "family": "Betul\u00e1ceas (familia del abedul)",
+            "picture": "https://storage.googleapis.com/pollen-pictures/alder_full.jpg",
+            "pictureCloseup": "https://storage.googleapis.com/pollen-pictures/alder_closeup.jpg",
+            "season": "Finales de invierno, principios de primavera",
+            "specialColors": "En oto\u00f1o, las hojas tienden a volverse de color marr\u00f3n.",
+            "specialShapes": "Los \u00e1rboles producen amentos, que son grupos de flores sin p\u00e9talos.",
+            "type": "TREE"
+          }
+        },
+        {
+          "code": "MUGWORT",
+          "displayName": "Artemisia"
+        }
+      ],
+      "pollenTypeInfo": [
+        {
+          "code": "GRASS",
+          "displayName": "Gram\u00edneas",
+          "healthRecommendations": [
+            "Es importante ducharse y lavarse el pelo despu\u00e9s de pasar mucho tiempo al aire libre.",
+            "Cuando est\u00e9s en el exterior, ponte gafas de sol y gorra para mantener el polen alejado de la cara y los ojos.",
+            "Lava la ropa que hayas llevado en el exterior para eliminar los restos de polen.",
+            "Si es posible, usa gafas en vez de lentillas.",
+            "\u00bfHas tendido la ropa fuera? Ahora es un buen momento para tenderla dentro de casa o usar una secadora, si es posible."
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Moderado",
+            "code": "UPI",
+            "color": {
+              "green": 1,
+              "red": 1
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia al polen experimenten s\u00edntomas",
+            "value": 3
+          }
+        },
+        {
+          "code": "TREE",
+          "displayName": "\u00c1rbol",
+          "healthRecommendations": [
+            "Los niveles de polen actuales son muy bajos. \u00a1Es un d\u00eda fant\u00e1stico para disfrutar al aire libre!"
+          ],
+          "inSeason": true,
+          "indexInfo": {
+            "category": "Muy bajo",
+            "code": "UPI",
+            "color": {
+              "blue": 0.22745098,
+              "green": 0.61960787
+            },
+            "displayName": "Universal Pollen Index",
+            "indexDescription": "Es probable que las personas con alergia muy alta al polen experimenten s\u00edntomas",
+            "value": 1
+          }
+        },
+        {
+          "code": "WEED",
+          "displayName": "Maleza"
+        }
+      ]
+    },
+    {
+      "date": {
+        "day": 17,
+        "month": 6,
+        "year": 2026
+      },
+      "plantInfo": [
+        {
+          "code": "HAZEL",
+          "displayName": "Avellano"
+        },
+        {
+          "code": "ASH",
+          "displayName": "Fresno"
+        },
+        {
+          "code": "COTTONWOOD",
+          "displayName": "Chopo"
+        },
+        {
+          "code": "OAK",
+          "displayName": "Roble"
+        },
+        {
+          "code": "PINE",
+          "displayName": "Pino"
+        },
+        {
+          "code": "BIRCH",
+          "displayName": "Abedul"
+        },
+        {
+          "code": "OLIVE",
+          "displayName": "Olivo"
+        },
+        {
+          "code": "GRAMINALES",
+          "displayName": "Gram\u00edneas"
+        },
+        {
+          "code": "RAGWEED",
+          "displayName": "Ambros\u00eda"
+        },
+        {
+          "code": "ALDER",
+          "displayName": "Aliso"
+        },
+        {
+          "code": "MUGWORT",
+          "displayName": "Artemisia"
+        }
+      ],
+      "pollenTypeInfo": [
+        {
+          "code": "GRASS",
+          "displayName": "Gram\u00edneas"
+        },
+        {
+          "code": "TREE",
+          "displayName": "\u00c1rbol"
+        },
+        {
+          "code": "WEED",
+          "displayName": "Maleza"
+        }
+      ]
+    }
+  ],
+  "regionCode": "ES"
+}

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -1,0 +1,70 @@
+"""Shared helpers for Home Assistant harness tests."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import parse_qsl
+
+from aioresponses import CallbackResult, aioresponses
+from homeassistant.core import HomeAssistant
+
+from custom_components.pollenlevels.const import FORECAST_DAYS
+
+POLLEN_API_URL_RE = re.compile(
+    r"^https://pollen\.googleapis\.com/v1/forecast:lookup.*$"
+)
+
+
+def mock_pollen_api(
+    mocked: aioresponses,
+    payload: dict[str, Any],
+    captured_params: list[dict[str, Any]] | None = None,
+) -> None:
+    """Mock Google Pollen API responses and capture request parameters."""
+
+    def _callback(url, **kwargs):
+        params = dict(kwargs.get("params") or parse_qsl(url.query_string))
+        if captured_params is not None:
+            captured_params.append(params)
+        return CallbackResult(status=200, payload=payload)
+
+    mocked.get(POLLEN_API_URL_RE, callback=_callback, repeat=True)
+
+
+async def async_setup_config_entry(hass: HomeAssistant, config_entry: Any) -> None:
+    """Set up a config entry and wait for Home Assistant tasks to settle."""
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def assert_fixed_forecast_days(captured_params: list[dict[str, Any]]) -> None:
+    """Assert every captured Google Pollen request used the fixed days value."""
+    assert captured_params
+    assert all(params["days"] == FORECAST_DAYS for params in captured_params)
+
+
+def location_subentry_data(
+    *,
+    subentry_id: str,
+    title: str,
+    latitude: float,
+    longitude: float,
+) -> dict[str, Any]:
+    """Return ConfigSubentryData-compatible location data."""
+    from custom_components.pollenlevels.const import (
+        CONF_LATITUDE,
+        CONF_LONGITUDE,
+        SUBENTRY_TYPE_LOCATION,
+    )
+
+    return {
+        "subentry_id": subentry_id,
+        "subentry_type": SUBENTRY_TYPE_LOCATION,
+        "title": title,
+        "unique_id": f"{latitude:.4f}_{longitude:.4f}",
+        "data": {
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+        },
+    }

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -41,7 +41,7 @@ async def async_setup_config_entry(hass: HomeAssistant, config_entry: Any) -> No
 def assert_fixed_forecast_days(captured_params: list[dict[str, Any]]) -> None:
     """Assert every captured Google Pollen request used the fixed days value."""
     assert captured_params
-    assert all(params["days"] == FORECAST_DAYS for params in captured_params)
+    assert all(int(params["days"]) == FORECAST_DAYS for params in captured_params)
 
 
 def location_subentry_data(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -145,7 +145,7 @@ async def _fetch_with_response(
     await client.async_fetch_pollen_data(
         latitude=latitude,
         longitude=longitude,
-        days=1,
+        days=5,
         language_code=None,
     )
 
@@ -222,7 +222,7 @@ async def test_client_redacts_sensitive_values_from_url_like_http_error(
     url = (
         "https://pollen.googleapis.com/v1/forecast:lookup?"
         f"key={api_key}&location.latitude={latitude}&"
-        f"location.longitude={longitude}&days=1"
+        f"location.longitude={longitude}&days=5"
     )
     response = FakeResponse(
         status=400,
@@ -261,7 +261,7 @@ async def test_client_redacts_sensitive_values_from_client_error(
         "request failed: "
         "https://pollen.googleapis.com/v1/forecast:lookup?"
         f"key={api_key}&location.latitude={latitude}&"
-        f"location.longitude={longitude}&days=1"
+        f"location.longitude={longitude}&days=5"
     )
     client = client_module.GooglePollenApiClient(RaisingSession(error), api_key)
 
@@ -269,7 +269,7 @@ async def test_client_redacts_sensitive_values_from_client_error(
         await client.async_fetch_pollen_data(
             latitude=latitude,
             longitude=longitude,
-            days=1,
+            days=5,
             language_code=None,
         )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1434,41 +1434,6 @@ def test_validate_input_ignores_removed_forecast_options_and_uses_fixed_days(
     assert config_flow_stubs.CONF_CREATE_FORECAST_SENSORS not in normalized
 
 
-def test_options_flow_drops_removed_forecast_options(
-    config_flow_stubs: ConfigFlowStubs,
-) -> None:
-    """Options flow preserves supported options and drops legacy forecast keys."""
-
-    flow = _build_options_flow(
-        config_flow_stubs,
-        {
-            config_flow_stubs.CONF_LANGUAGE_CODE: "en",
-        },
-    )
-    flow.config_entry.options = {
-        config_flow_stubs.CONF_UPDATE_INTERVAL: 12,
-        config_flow_stubs.CONF_FORECAST_DAYS: 1,
-        config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1",
-    }
-
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                config_flow_stubs.CONF_UPDATE_INTERVAL: 6,
-                config_flow_stubs.CONF_LANGUAGE_CODE: "es",
-                config_flow_stubs.CONF_FORECAST_DAYS: "bad",
-                config_flow_stubs.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
-            }
-        )
-    )
-
-    assert result["type"] == "create_entry"
-    assert result["data"] == {
-        config_flow_stubs.CONF_UPDATE_INTERVAL: 6,
-        config_flow_stubs.CONF_LANGUAGE_CODE: "es",
-    }
-
-
 def test_validate_input_auth_error_sets_error_message_placeholder(
     config_flow_stubs: ConfigFlowStubs,
     monkeypatch: pytest.MonkeyPatch,
@@ -2568,55 +2533,6 @@ def test_reconfigure_does_not_reintroduce_option_fields_in_data(
     assert created["called"] is False
 
 
-def test_async_step_user_uses_custom_entry_name(
-    config_flow_stubs: ConfigFlowStubs,
-) -> None:
-    """Config flow should honor a custom entry title provided by the user."""
-
-    flow = config_flow_stubs.PollenLevelsConfigFlow()
-    flow.hass = SimpleNamespace(
-        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en")
-    )
-
-    normalized = {
-        config_flow_stubs.CONF_API_KEY: "test-key",
-        config_flow_stubs.CONF_LATITUDE: 1.0,
-        config_flow_stubs.CONF_LONGITUDE: 2.0,
-        config_flow_stubs.CONF_LANGUAGE_CODE: "en",
-    }
-
-    async def fake_validate(
-        user_input, *, check_unique_id, description_placeholders=None
-    ):
-        assert check_unique_id is False
-        assert user_input[config_flow_stubs.CONF_NAME].strip() == "Custom Name"
-        return {}, normalized
-
-    flow._async_validate_input = fake_validate  # type: ignore[assignment]
-
-    user_input = {
-        config_flow_stubs.CONF_API_KEY: "test-key",
-        config_flow_stubs.CONF_NAME: " Custom Name ",
-        config_flow_stubs.CONF_LOCATION: {
-            config_flow_stubs.CONF_LATITUDE: 1.0,
-            config_flow_stubs.CONF_LONGITUDE: 2.0,
-        },
-        config_flow_stubs.CONF_UPDATE_INTERVAL: 6,
-        config_flow_stubs.CONF_LANGUAGE_CODE: "en",
-    }
-
-    result = asyncio.run(flow.async_step_user(user_input))
-
-    assert result["title"] == "Custom Name"
-    assert result["data"] == {config_flow_stubs.CONF_API_KEY: "test-key"}
-    assert result["options"][config_flow_stubs.CONF_LANGUAGE_CODE] == "en"
-    assert result["subentries"][0]["title"] == "Custom Name"
-    assert result["subentries"][0]["data"] == {
-        config_flow_stubs.CONF_LATITUDE: 1.0,
-        config_flow_stubs.CONF_LONGITUDE: 2.0,
-    }
-
-
 def test_async_step_user_defaults_entry_name(
     config_flow_stubs: ConfigFlowStubs,
 ) -> None:
@@ -2662,66 +2578,6 @@ def test_async_step_user_defaults_entry_name(
         config_flow_stubs.CONF_LATITUDE: 1.0,
         config_flow_stubs.CONF_LONGITUDE: 2.0,
     }
-
-
-def test_async_step_user_checks_api_key_unique_id_for_existing_parent(
-    config_flow_stubs: ConfigFlowStubs,
-) -> None:
-    """New setup should detect an existing migrated parent by API-key identity."""
-
-    class _AlreadyConfigured(Exception):
-        pass
-
-    class _TrackingFlow(config_flow_stubs.PollenLevelsConfigFlow):
-        def __init__(self) -> None:
-            super().__init__()
-            self.unique_ids: list[str] = []
-
-        async def async_set_unique_id(self, uid: str, raise_on_progress: bool = False):
-            self.unique_ids.append(uid)
-            return None
-
-        def _abort_if_unique_id_configured(self):
-            raise _AlreadyConfigured
-
-    flow = _TrackingFlow()
-    flow.hass = SimpleNamespace(
-        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
-        config_entries=SimpleNamespace(
-            async_entry_for_domain_unique_id=lambda *_args: object()
-        ),
-    )
-
-    normalized = {
-        config_flow_stubs.CONF_API_KEY: "shared-key",
-        config_flow_stubs.CONF_LATITUDE: 1.0,
-        config_flow_stubs.CONF_LONGITUDE: 2.0,
-        config_flow_stubs.CONF_LANGUAGE_CODE: "en",
-    }
-
-    async def fake_validate(
-        user_input, *, check_unique_id, description_placeholders=None
-    ):
-        assert check_unique_id is False
-        return {}, normalized
-
-    flow._async_validate_input = fake_validate  # type: ignore[assignment]
-
-    user_input = {
-        config_flow_stubs.CONF_API_KEY: "shared-key",
-        config_flow_stubs.CONF_NAME: "Home",
-        config_flow_stubs.CONF_LOCATION: {
-            config_flow_stubs.CONF_LATITUDE: 1.0,
-            config_flow_stubs.CONF_LONGITUDE: 2.0,
-        },
-    }
-
-    result = asyncio.run(flow.async_step_user(user_input))
-
-    assert result == {"type": "abort", "reason": "api_key_already_configured"}
-    assert flow.unique_ids == [
-        config_flow_stubs.config_flow._api_key_unique_id("shared-key")
-    ]
 
 
 def test_async_step_user_checks_api_key_unique_id_with_async_entries_fallback(
@@ -2837,59 +2693,6 @@ def test_location_subentry_user_step_shows_form(
     result = asyncio.run(flow.async_step_user())
 
     assert result == {"type": "form", "step_id": "user", "errors": {}}
-
-
-def test_location_subentry_user_step_creates_entry_without_premature_reload(
-    config_flow_stubs: ConfigFlowStubs,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Adding a valid location should reload the parent after create is returned."""
-
-    calls = _patch_client_fetch(config_flow_stubs, monkeypatch)
-    entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(
-        data={config_flow_stubs.CONF_API_KEY: "key"},
-        options={config_flow_stubs.CONF_LANGUAGE_CODE: " es-ES "},
-        entry_id="entry-id",
-    )
-    flow, recorder = _build_location_subentry_flow(config_flow_stubs, entry)
-
-    async def run_flow():
-        result = await flow.async_step_user(
-            {
-                config_flow_stubs.CONF_NAME: " Garden ",
-                config_flow_stubs.CONF_LOCATION: {
-                    config_flow_stubs.CONF_LATITUDE: 12.34567,
-                    config_flow_stubs.CONF_LONGITUDE: -98.76543,
-                },
-            }
-        )
-        assert recorder.reload_calls == []
-        assert len(recorder.created_tasks) == 1
-        assert recorder.created_tasks[0].get_name() == (
-            "reload Pollen Levels parent after location subentry create"
-        )
-        await recorder.created_tasks[0]
-        return result
-
-    result = asyncio.run(run_flow())
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == "Garden"
-    assert result["data"] == {
-        config_flow_stubs.CONF_LATITUDE: 12.34567,
-        config_flow_stubs.CONF_LONGITUDE: -98.76543,
-    }
-    assert result["unique_id"] == "12.3457_-98.7654"
-    assert len(recorder.created_tasks) == 1
-    assert recorder.reload_calls == ["entry-id"]
-    assert calls == [
-        {
-            "latitude": 12.34567,
-            "longitude": -98.76543,
-            "days": config_flow_stubs.FORECAST_DAYS,
-            "language_code": "es-ES",
-        }
-    ]
 
 
 def test_location_subentry_create_reload_helper_falls_back_to_async_reload(
@@ -3013,103 +2816,6 @@ def test_location_subentry_user_step_rejects_invalid_coordinates(
     }
     assert recorder.created_tasks == []
     assert recorder.reload_calls == []
-
-
-def test_location_subentry_user_step_rejects_duplicate_location(
-    config_flow_stubs: ConfigFlowStubs,
-) -> None:
-    """Duplicate coordinate unique IDs should be rejected within one parent."""
-
-    existing = config_flow_stubs.config_flow.config_entries.ConfigSubentry(
-        data={
-            config_flow_stubs.CONF_LATITUDE: 1.0,
-            config_flow_stubs.CONF_LONGITUDE: 2.0,
-        },
-        subentry_id="subentry-1",
-        title="Home",
-        unique_id="1.0000_2.0000",
-    )
-    entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(
-        data={config_flow_stubs.CONF_API_KEY: "key"},
-        entry_id="entry-id",
-        subentries={existing.subentry_id: existing},
-    )
-    flow, recorder = _build_location_subentry_flow(config_flow_stubs, entry)
-
-    result = asyncio.run(
-        flow.async_step_user(
-            {
-                config_flow_stubs.CONF_NAME: "Duplicate",
-                config_flow_stubs.CONF_LOCATION: {
-                    config_flow_stubs.CONF_LATITUDE: 1.0,
-                    config_flow_stubs.CONF_LONGITUDE: 2.0,
-                },
-            }
-        )
-    )
-
-    assert result == {
-        "type": "form",
-        "step_id": "user",
-        "errors": {"base": "already_configured"},
-    }
-    assert recorder.created_tasks == []
-    assert recorder.reload_calls == []
-
-
-def test_location_subentry_reconfigure_updates_entry_and_schedules_reload(
-    config_flow_stubs: ConfigFlowStubs,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Reconfiguring a location should update the subentry and reload parent."""
-
-    calls = _patch_client_fetch(config_flow_stubs, monkeypatch)
-    subentry = config_flow_stubs.config_flow.config_entries.ConfigSubentry(
-        data={
-            config_flow_stubs.CONF_LATITUDE: 1.0,
-            config_flow_stubs.CONF_LONGITUDE: 2.0,
-        },
-        subentry_id="subentry-1",
-        title="Home",
-        unique_id="1.0000_2.0000",
-    )
-    entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(
-        data={config_flow_stubs.CONF_API_KEY: "key"},
-        entry_id="entry-id",
-        subentries={subentry.subentry_id: subentry},
-    )
-    flow, recorder = _build_location_subentry_flow(config_flow_stubs, entry)
-    flow.context = {"subentry_id": subentry.subentry_id}
-
-    result = asyncio.run(
-        flow.async_step_reconfigure(
-            {
-                config_flow_stubs.CONF_NAME: " Garden ",
-                config_flow_stubs.CONF_LOCATION: {
-                    config_flow_stubs.CONF_LATITUDE: 3.0,
-                    config_flow_stubs.CONF_LONGITUDE: 4.0,
-                },
-            }
-        )
-    )
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "reconfigure_successful"
-    assert subentry.title == "Garden"
-    assert subentry.data == {
-        config_flow_stubs.CONF_LATITUDE: 3.0,
-        config_flow_stubs.CONF_LONGITUDE: 4.0,
-    }
-    assert subentry.unique_id == "3.0000_4.0000"
-    assert recorder.reload_calls == ["entry-id"]
-    assert calls == [
-        {
-            "latitude": 3.0,
-            "longitude": 4.0,
-            "days": config_flow_stubs.FORECAST_DAYS,
-            "language_code": None,
-        }
-    ]
 
 
 def test_location_subentry_reconfigure_preserves_legacy_entry_id(

--- a/tests/test_ha_config_flow.py
+++ b/tests/test_ha_config_flow.py
@@ -1,0 +1,316 @@
+"""Home Assistant harness tests for config and subentry flows."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+from aioresponses import aioresponses
+from homeassistant.config_entries import SOURCE_RECONFIGURE, SOURCE_USER
+from homeassistant.const import CONF_LOCATION, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_CREATE_FORECAST_SENSORS,
+    CONF_FORECAST_DAYS,
+    CONF_LANGUAGE_CODE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    SUBENTRY_TYPE_LOCATION,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import assert_fixed_forecast_days, mock_pollen_api
+
+
+def _location_input(
+    *,
+    name: str = "Madrid",
+    latitude: float = 40.4168,
+    longitude: float = -3.7038,
+) -> dict[str, Any]:
+    """Return user input for a location selector."""
+    return {
+        CONF_NAME: name,
+        CONF_LOCATION: {
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+        },
+    }
+
+
+async def test_ha_user_flow_creates_parent_entry_with_location_subentry(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """User flow should create a parent entry with the first location subentry."""
+    clear_integration_modules()
+    captured_params: list[dict[str, Any]] = []
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_KEY: f" {fake_api_key} ",
+                CONF_LANGUAGE_CODE: " es ",
+                CONF_UPDATE_INTERVAL: 8,
+                **_location_input(name=" Casa "),
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert_fixed_forecast_days(captured_params)
+
+    entry = result["result"]
+    assert entry.domain == DOMAIN
+    assert entry.title == "Casa"
+    assert entry.unique_id == api_key_unique_id(fake_api_key)
+    assert entry.data == {CONF_API_KEY: fake_api_key}
+    assert entry.options == {
+        CONF_LANGUAGE_CODE: "es",
+        CONF_UPDATE_INTERVAL: 8,
+    }
+
+    assert len(entry.subentries) == 1
+    subentry = next(iter(entry.subentries.values()))
+    assert subentry.subentry_type == SUBENTRY_TYPE_LOCATION
+    assert subentry.title == "Casa"
+    assert subentry.unique_id == "40.4168_-3.7038"
+    assert dict(subentry.data) == {
+        CONF_LATITUDE: 40.4168,
+        CONF_LONGITUDE: -3.7038,
+    }
+
+
+async def test_ha_user_flow_rejects_duplicate_parent_api_key(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """User flow should reject another parent with the same API-key identity."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="Existing",
+        data={CONF_API_KEY: fake_api_key},
+        unique_id=api_key_unique_id(fake_api_key),
+        version=6,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_API_KEY: fake_api_key,
+                CONF_LANGUAGE_CODE: "en",
+                CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+                **_location_input(),
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "api_key_already_configured"
+
+
+async def test_ha_options_flow_saves_supported_options_only(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+) -> None:
+    """Options flow should persist supported options and drop legacy keys."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        ha_config_entry,
+        options={
+            CONF_LANGUAGE_CODE: "es",
+            CONF_UPDATE_INTERVAL: 8,
+            CONF_FORECAST_DAYS: 1,
+            CONF_CREATE_FORECAST_SENSORS: "D+1",
+        },
+    )
+
+    result = await hass.config_entries.options.async_init(ha_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_LANGUAGE_CODE: " en ",
+            CONF_UPDATE_INTERVAL: 12,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert ha_config_entry.options == {
+        CONF_LANGUAGE_CODE: "en",
+        CONF_UPDATE_INTERVAL: 12,
+    }
+
+
+async def test_ha_location_subentry_flow_creates_subentry(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """Location subentry flow should persist a new location on the parent entry."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    captured_params: list[dict[str, Any]] = []
+    scheduled_reloads: list[str] = []
+    original_schedule_reload = hass.config_entries.async_schedule_reload
+
+    def _capture_schedule_reload(entry_id: str) -> None:
+        scheduled_reloads.append(entry_id)
+        original_schedule_reload(entry_id)
+
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", _capture_schedule_reload
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="parent-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={CONF_LANGUAGE_CODE: "es"},
+        unique_id=api_key_unique_id(fake_api_key),
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            _location_input(name="Garden", latitude=41.3874, longitude=2.1686),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert_fixed_forecast_days(captured_params)
+    assert captured_params[0]["languageCode"] == "es"
+    assert scheduled_reloads == [entry.entry_id]
+    assert len(entry.subentries) == 1
+
+    subentry = next(iter(entry.subentries.values()))
+    assert subentry.subentry_type == SUBENTRY_TYPE_LOCATION
+    assert subentry.title == "Garden"
+    assert subentry.unique_id == "41.3874_2.1686"
+    assert dict(subentry.data) == {
+        CONF_LATITUDE: 41.3874,
+        CONF_LONGITUDE: 2.1686,
+    }
+
+
+async def test_ha_location_subentry_flow_rejects_duplicate_location(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+) -> None:
+    """Location subentry flow should reject duplicate coordinate identities."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (ha_config_entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        _location_input(name="Duplicate"),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "already_configured"}
+    assert len(ha_config_entry.subentries) == 1
+
+
+async def test_ha_location_subentry_reconfigure_updates_entry_and_schedules_reload(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """Location subentry reconfigure should update stored data and schedule reload."""
+    clear_integration_modules()
+    captured_params: list[dict[str, Any]] = []
+    ha_config_entry.add_to_hass(hass)
+    subentry = ha_config_entry.subentries["location-madrid"]
+    scheduled_reloads: list[str] = []
+    original_schedule_reload = hass.config_entries.async_schedule_reload
+
+    def _capture_schedule_reload(entry_id: str) -> None:
+        scheduled_reloads.append(entry_id)
+        original_schedule_reload(entry_id)
+
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", _capture_schedule_reload
+    )
+
+    result = await hass.config_entries.subentries.async_init(
+        (ha_config_entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "subentry_id": subentry.subentry_id,
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            _location_input(name="Barcelona", latitude=41.3874, longitude=2.1686),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert_fixed_forecast_days(captured_params)
+
+    updated = ha_config_entry.subentries["location-madrid"]
+    assert updated.title == "Barcelona"
+    assert updated.unique_id == "41.3874_2.1686"
+    assert updated.data == MappingProxyType(
+        {
+            CONF_LATITUDE: 41.3874,
+            CONF_LONGITUDE: 2.1686,
+        }
+    )
+    assert scheduled_reloads == [ha_config_entry.entry_id]

--- a/tests/test_ha_diagnostics.py
+++ b/tests/test_ha_diagnostics.py
@@ -1,0 +1,232 @@
+"""Home Assistant harness tests for diagnostics."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qsl
+
+from aioresponses import CallbackResult, aioresponses
+from homeassistant.core import HomeAssistant
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE_CODE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import (
+    POLLEN_API_URL_RE,
+    async_setup_config_entry,
+    location_subentry_data,
+    mock_pollen_api,
+)
+
+
+async def test_ha_diagnostics_redacts_secrets_and_summarizes_runtime(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Diagnostics should use real HA registries while redacting sensitive data."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+
+        await async_setup_config_entry(hass, ha_config_entry)
+
+        diagnostics_module = importlib.import_module(
+            "custom_components.pollenlevels.diagnostics"
+        )
+        diagnostics = await diagnostics_module.async_get_config_entry_diagnostics(
+            hass, ha_config_entry
+        )
+
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert fake_api_key not in serialized
+    assert "40.4168" not in serialized
+    assert "-3.7038" not in serialized
+
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 0,
+        "stale_location_ids": [],
+        "failed_location_count": 0,
+        "failed_location_ids": [],
+    }
+    assert "registry_summary" in diagnostics
+
+    location = diagnostics["locations"]["location-madrid"]
+    assert location["request_params_example"]["key"] == "***"
+    assert location["request_params_example"]["days"] == 5
+    assert location["request_params_example"]["location.latitude"] == 40.4
+    assert location["request_params_example"]["location.longitude"] == -3.7
+    assert location["approximate_location"] == {
+        "label": "approximate_location (rounded)",
+        "latitude_rounded": 40.4,
+        "longitude_rounded": -3.7,
+    }
+
+
+async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Diagnostics should summarize stale and failed locations from real runtime."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    def _callback(url, **kwargs):
+        params = dict(kwargs.get("params") or parse_qsl(url.query_string))
+        if float(params["location.latitude"]) == 41.3874:
+            return CallbackResult(status=200, payload={"dailyInfo": []})
+        return CallbackResult(status=200, payload=google_pollen_5_day_payload)
+
+    with aioresponses() as mocked:
+        mocked.get(POLLEN_API_URL_RE, callback=_callback, repeat=True)
+        await async_setup_config_entry(hass, entry)
+
+        entry.runtime_data.locations["deleted-location"] = SimpleNamespace(
+            subentry_id="deleted-location",
+            coordinator=SimpleNamespace(
+                entry_id=entry.entry_id,
+                subentry_id="deleted-location",
+                language="es",
+                last_updated=None,
+                lat=12.345678,
+                lon=-98.765432,
+                entry_title="Deleted secret 12.345678",
+                data={},
+            ),
+        )
+
+        diagnostics_module = importlib.import_module(
+            "custom_components.pollenlevels.diagnostics"
+        )
+        diagnostics = await diagnostics_module.async_get_config_entry_diagnostics(
+            hass, entry
+        )
+
+    assert set(diagnostics["locations"]) == {"location-madrid"}
+    assert set(diagnostics["failed_locations"]) == {"location-barcelona"}
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 1,
+        "stale_location_ids": ["deleted-location"],
+        "failed_location_count": 1,
+        "failed_location_ids": ["location-barcelona"],
+    }
+    assert diagnostics["failed_locations"]["location-barcelona"]["error_type"]
+    assert (
+        diagnostics["failed_locations"]["location-barcelona"]["will_retry_on_reload"]
+        is True
+    )
+
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert fake_api_key not in serialized
+    assert "41.3874" not in serialized
+    assert "2.1686" not in serialized
+    assert "12.345678" not in serialized
+    assert "-98.765432" not in serialized
+
+
+async def test_ha_diagnostics_registry_summary_uses_real_registries(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Diagnostics should summarize real entity and device registry links."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+        diagnostics_module = importlib.import_module(
+            "custom_components.pollenlevels.diagnostics"
+        )
+        diagnostics = await diagnostics_module.async_get_config_entry_diagnostics(
+            hass, entry
+        )
+
+    registry_summary = diagnostics["registry_summary"]
+    assert registry_summary["entities"]["total"] > 0
+    assert registry_summary["entities"]["without_subentry"] == 0
+    assert set(registry_summary["entities"]["by_subentry_id"]) == {
+        "location-madrid",
+        "location-barcelona",
+    }
+    assert registry_summary["devices"]["total"] > 0
+    assert registry_summary["devices"]["without_subentry"] == 0
+    assert set(registry_summary["devices"]["by_subentry_id"]) == {
+        "location-madrid",
+        "location-barcelona",
+    }
+
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert fake_api_key not in serialized
+    assert "pollenlevels-entry_location-madrid" not in serialized
+    assert "pollenlevels-entry_location-barcelona" not in serialized
+    assert "40.4168" not in serialized
+    assert "-3.7038" not in serialized
+    assert "41.3874" not in serialized
+    assert "2.1686" not in serialized

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -7,6 +7,7 @@ from typing import Any
 from aioresponses import aioresponses
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
@@ -36,9 +37,13 @@ async def test_ha_setup_unload_reload_smoke(
         assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
         assert_fixed_forecast_days(captured_params)
 
-        entity_ids = {state.entity_id for state in hass.states.async_all()}
-        assert any(entity_id.startswith("sensor.") for entity_id in entity_ids)
-        assert any(entity_id.startswith("button.") for entity_id in entity_ids)
+        registry = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(
+            registry,
+            ha_config_entry.entry_id,
+        )
+        assert any(entity.domain == "sensor" for entity in entries)
+        assert any(entity.domain == "button" for entity in entries)
 
         assert await hass.config_entries.async_unload(ha_config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -1,0 +1,50 @@
+"""Home Assistant harness tests for config entry setup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aioresponses import aioresponses
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import (
+    assert_fixed_forecast_days,
+    async_setup_config_entry,
+    mock_pollen_api,
+)
+
+
+async def test_ha_setup_unload_reload_smoke(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Set up, unload and reload a parent entry with one location subentry."""
+    captured_params: list[dict[str, Any]] = []
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
+
+        await async_setup_config_entry(hass, ha_config_entry)
+
+        assert ha_config_entry.state is ConfigEntryState.LOADED
+        assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
+        assert_fixed_forecast_days(captured_params)
+
+        entity_ids = {state.entity_id for state in hass.states.async_all()}
+        assert any(entity_id.startswith("sensor.") for entity_id in entity_ids)
+        assert any(entity_id.startswith("button.") for entity_id in entity_ids)
+
+        assert await hass.config_entries.async_unload(ha_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert ha_config_entry.state is ConfigEntryState.NOT_LOADED
+        assert getattr(ha_config_entry, "runtime_data", None) is None
+
+        assert await hass.config_entries.async_setup(ha_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert ha_config_entry.state is ConfigEntryState.LOADED

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -1,0 +1,126 @@
+"""Home Assistant harness tests for platform entity setup."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aioresponses import aioresponses
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE_CODE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+from custom_components.pollenlevels.issue_helpers import (
+    PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import (
+    async_setup_config_entry,
+    location_subentry_data,
+    mock_pollen_api,
+)
+
+
+async def test_ha_platforms_create_entities_for_each_location_subentry(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Sensor and button platforms should attach entities to each subentry."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+    registry = er.async_get(hass)
+    entries = [
+        entity
+        for entity in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if entity.platform == DOMAIN
+    ]
+
+    expected_subentries = {"location-madrid", "location-barcelona"}
+    assert expected_subentries <= {
+        entity.config_subentry_id for entity in entries if entity.config_subentry_id
+    }
+    for subentry_id in expected_subentries:
+        assert any(
+            entity.domain == "sensor" and entity.config_subentry_id == subentry_id
+            for entity in entries
+        )
+        assert any(
+            entity.domain == "button" and entity.config_subentry_id == subentry_id
+            for entity in entries
+        )
+
+
+async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Sensor setup should remove legacy D+1/D+2 entities in the real registry."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    identity_id = f"{ha_config_entry.entry_id}_location-madrid"
+    legacy_unique_ids = [
+        f"{identity_id}_type_grass_d1",
+        f"{identity_id}_type_grass_d2",
+    ]
+
+    for unique_id in legacy_unique_ids:
+        registry.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=unique_id,
+            config_entry=ha_config_entry,
+            config_subentry_id="location-madrid",
+        )
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, ha_config_entry)
+
+    for unique_id in legacy_unique_ids:
+        assert registry.async_get_entity_id("sensor", DOMAIN, unique_id) is None
+
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID
+    )
+    assert issue is not None

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -1,0 +1,205 @@
+"""Home Assistant harness tests for Pollen Levels services."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from aioresponses import aioresponses
+from homeassistant.core import HomeAssistant
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE_CODE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import (
+    async_setup_config_entry,
+    location_subentry_data,
+    mock_pollen_api,
+)
+
+
+async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """force_update should refresh active subentries and skip stale runtimes."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+
+        await async_setup_config_entry(hass, ha_config_entry)
+
+        active = ha_config_entry.runtime_data.locations["location-madrid"]
+        active_refresh = AsyncMock()
+        monkeypatch.setattr(active.coordinator, "async_request_refresh", active_refresh)
+
+        stale_refresh = AsyncMock()
+        ha_config_entry.runtime_data.locations["deleted-location"] = SimpleNamespace(
+            subentry_id="deleted-location",
+            coordinator=SimpleNamespace(async_request_refresh=stale_refresh),
+        )
+
+        await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    active_refresh.assert_awaited_once()
+    stale_refresh.assert_not_awaited()
+
+
+async def test_ha_force_update_refreshes_multiple_location_subentries(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """force_update should refresh every active location subentry."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+        refreshes = {
+            subentry_id: AsyncMock()
+            for subentry_id in ("location-madrid", "location-barcelona")
+        }
+        for subentry_id, refresh in refreshes.items():
+            monkeypatch.setattr(
+                entry.runtime_data.locations[subentry_id].coordinator,
+                "async_request_refresh",
+                refresh,
+            )
+
+        await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    for refresh in refreshes.values():
+        refresh.assert_awaited_once()
+
+
+async def test_ha_force_update_continues_after_one_location_failure(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """force_update should continue refreshing locations after one failure."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+        failing_refresh = AsyncMock(side_effect=RuntimeError("boom"))
+        ok_refresh = AsyncMock()
+        monkeypatch.setattr(
+            entry.runtime_data.locations["location-madrid"].coordinator,
+            "async_request_refresh",
+            failing_refresh,
+        )
+        monkeypatch.setattr(
+            entry.runtime_data.locations["location-barcelona"].coordinator,
+            "async_request_refresh",
+            ok_refresh,
+        )
+
+        await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    failing_refresh.assert_awaited_once()
+    ok_refresh.assert_awaited_once()
+
+
+async def test_ha_force_update_parent_without_locations_is_noop(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    fake_api_key: str,
+) -> None:
+    """force_update should be a safe no-op when a parent has no locations."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-empty-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    await async_setup_config_entry(hass, entry)
+    assert entry.runtime_data.locations == {}
+
+    await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
+    await hass.async_block_till_done()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1511,46 +1511,6 @@ def test_force_update_logs_do_not_expose_secrets(
     assert "Manual refresh failed for entry entry-secrets (RuntimeError):" in text
 
 
-def test_force_update_refreshes_all_location_subentries(
-    integration_modules: _InitModules,
-) -> None:
-    """force_update should refresh every configured location coordinator."""
-    integration = integration_modules.integration
-
-    class _Coordinator:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        async def async_request_refresh(self):
-            self.calls += 1
-
-    coordinator_1 = _Coordinator()
-    coordinator_2 = _Coordinator()
-    entry = _FakeEntry(
-        integration,
-        entry_id="entry-parent",
-        data={integration.CONF_API_KEY: "key"},
-        subentries=_location_subentries(integration, "loc-1", "loc-2"),
-    )
-    entry.runtime_data = types.SimpleNamespace(
-        locations={
-            "loc-1": types.SimpleNamespace(
-                subentry_id="loc-1", coordinator=coordinator_1
-            ),
-            "loc-2": types.SimpleNamespace(
-                subentry_id="loc-2", coordinator=coordinator_2
-            ),
-        }
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
-
-    assert coordinator_1.calls == 1
-    assert coordinator_2.calls == 1
-
-
 def test_force_update_refreshes_location_subentries_sequentially(
     integration_modules: _InitModules,
 ) -> None:
@@ -1680,54 +1640,6 @@ def test_force_update_skips_runtime_locations_when_parent_has_no_locations(
     ) in caplog.text
 
 
-def test_force_update_skips_stale_location_subentries(
-    integration_modules: _InitModules, caplog
-) -> None:
-    """force_update should not refresh runtime locations removed from entry.subentries."""
-    integration = integration_modules.integration
-
-    class _Coordinator:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        async def async_request_refresh(self):
-            self.calls += 1
-
-    casa = _Coordinator()
-    trabajo = _Coordinator()
-    guineta = _Coordinator()
-    entry = _FakeEntry(
-        integration,
-        entry_id="entry-parent",
-        data={integration.CONF_API_KEY: "key"},
-        subentries=_location_subentries(integration, "casa", "guineta"),
-    )
-    entry.runtime_data = types.SimpleNamespace(
-        locations={
-            "casa": types.SimpleNamespace(subentry_id="casa", coordinator=casa),
-            "trabajo": types.SimpleNamespace(
-                subentry_id="trabajo", coordinator=trabajo
-            ),
-            "guineta": types.SimpleNamespace(
-                subentry_id="guineta", coordinator=guineta
-            ),
-        }
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-    with caplog.at_level("DEBUG"):
-        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
-
-    assert casa.calls == 1
-    assert guineta.calls == 1
-    assert trabajo.calls == 0
-    assert (
-        "Skipping stale Pollen Levels runtime location trabajo for entry entry-parent"
-        in caplog.text
-    )
-
-
 def test_force_update_continues_after_one_location_failure(
     integration_modules: _InitModules, caplog
 ) -> None:
@@ -1815,28 +1727,6 @@ def test_force_update_propagates_location_cancelled_error(
         "Manual refresh cancelled for entry entry-parent subentry loc-cancel"
         in caplog.text
     )
-
-
-def test_force_update_parent_without_locations_is_noop(
-    integration_modules: _InitModules, caplog
-) -> None:
-    """A loaded parent entry with no locations should be a safe no-op."""
-    integration = integration_modules.integration
-
-    entry = _FakeEntry(
-        integration,
-        entry_id="entry-empty",
-        data={integration.CONF_API_KEY: "key"},
-    )
-    entry.runtime_data = types.SimpleNamespace(locations={})
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-    with caplog.at_level("DEBUG"):
-        asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
-
-    assert "Skipping force_update for entry entry-empty" in caplog.text
-    assert "No coordinators available for force_update" in caplog.text
 
 
 def test_force_update_skips_failed_locations_without_coordinators(

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -264,64 +264,6 @@ def test_options_flow_invalid_language_code_not_logged_raw(
     }
 
 
-def test_options_flow_drops_removed_forecast_options(
-    options_flow_env: OptionsFlowEnv,
-) -> None:
-    """Legacy forecast option keys should be ignored and removed on save."""
-
-    flow = _flow(
-        options_flow_env,
-        options={
-            options_flow_env.CONF_LANGUAGE_CODE: "en",
-            options_flow_env.CONF_UPDATE_INTERVAL: 6,
-            options_flow_env.CONF_FORECAST_DAYS: 2,
-            options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1",
-        },
-    )
-
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: " es ",
-                options_flow_env.CONF_UPDATE_INTERVAL: 8,
-                options_flow_env.CONF_FORECAST_DAYS: 0,
-                options_flow_env.CONF_CREATE_FORECAST_SENSORS: "D+1+2",
-            }
-        )
-    )
-
-    assert result == {
-        "title": "",
-        "data": {
-            options_flow_env.CONF_LANGUAGE_CODE: "es",
-            options_flow_env.CONF_UPDATE_INTERVAL: 8,
-        },
-    }
-
-
-def test_options_flow_valid_submission_returns_entry_data(
-    options_flow_env: OptionsFlowEnv,
-) -> None:
-    """A valid options submission should return supported options only."""
-
-    flow = _flow(options_flow_env)
-
-    user_input = {
-        options_flow_env.CONF_LANGUAGE_CODE: " es ",
-        options_flow_env.CONF_UPDATE_INTERVAL: 8,
-    }
-
-    result = asyncio.run(flow.async_step_init(dict(user_input)))
-
-    assert result == {
-        "title": "",
-        "data": {
-            options_flow_env.CONF_LANGUAGE_CODE: "es",
-            options_flow_env.CONF_UPDATE_INTERVAL: 8,
-        },
-    }
-
-
 def test_options_flow_update_interval_below_min_sets_error(
     options_flow_env: OptionsFlowEnv,
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2371,7 +2371,7 @@ def test_client_raises_dedicated_quota_error_after_terminal_429(
         await client.async_fetch_pollen_data(
             latitude=1.0,
             longitude=2.0,
-            days=1,
+            days=5,
             language_code=None,
         )
 


### PR DESCRIPTION
## Summary
- Add pytest-homeassistant-custom-component test dependencies and asyncio pytest configuration.
- Add a sanitized real 5-day Google Pollen fixture plus HA harness helpers.
- Cover setup/unload/reload, config/options/subentry flows, platforms, services, diagnostics, and days=5 request behavior through the real Home Assistant harness.
- Remove stub-only duplicate tests now covered by harness tests.
- Add a small coordinator compatibility path for newer Home Assistant versions requiring explicit config_entry.

## Validation
- python -m compileall -q custom_components tests
- python -m ruff check --fix --select I .
- python -m ruff check .
- python -m black .
- $env:PYTHONPATH='.'; python -m pytest -q

Final local result: 477 passed, 24 warnings from aioresponses using deprecated asyncio.iscoroutinefunction on Python 3.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the 5-day forecast API request to ensure accurate and consistent pollen data retrieval.

* **Improvements**
  * Improved Home Assistant integration compatibility by enhancing how configuration entries are provided to the data update coordinator.
  * Strengthened setup/config flow behavior and runtime reliability across Home Assistant environments.

* **Tests / Chores**
  * Expanded Home Assistant harness test coverage and updated the test tooling/fixtures for more robust validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->