### PR TITLE
test: add clean v3 migration harness coverage

### DIFF
--- a/tests/test_ha_migration.py
+++ b/tests/test_ha_migration.py
@@ -27,15 +27,23 @@ from custom_components.pollenlevels.issue_helpers import (
 )
 from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
-from tests.ha_helpers import async_migrate_config_entry, legacy_config_entry
+from tests.ha_helpers import (
+    async_migrate_config_entry,
+    legacy_config_entry,
+    location_subentry_data,
+)
 
 
 def _subentries_by_legacy_entry(entry) -> dict[str, Any]:
     """Return migrated location subentries keyed by legacy entry id."""
     return {
-        subentry.data[CONF_LEGACY_ENTRY_ID]: subentry
+        legacy_entry_id: subentry
         for subentry in entry.subentries.values()
         if subentry.subentry_type == SUBENTRY_TYPE_LOCATION
+        if isinstance(
+            legacy_entry_id := subentry.data.get(CONF_LEGACY_ENTRY_ID),
+            str,
+        )
     }
 
 
@@ -154,6 +162,67 @@ async def test_ha_migration_same_api_key_entries_group_under_one_parent(
     )
 
 
+async def test_ha_migration_legacy_entry_merges_into_existing_clean_v3_parent(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """A residual legacy entry should merge into an existing clean parent."""
+    clear_integration_modules()
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.pollenlevels import TARGET_ENTRY_VERSION
+
+    clean_parent = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="clean-parent",
+        title="Pollen Levels",
+        data={CONF_API_KEY: "shared-key"},
+        options={CONF_LANGUAGE_CODE: "en"},
+        version=TARGET_ENTRY_VERSION,
+        unique_id=api_key_unique_id("shared-key"),
+        subentries_data=[
+            location_subentry_data(
+                subentry_id="existing-location",
+                title="Existing",
+                latitude=10.0,
+                longitude=20.0,
+            )
+        ],
+    )
+    legacy = legacy_config_entry(
+        entry_id="legacy-office",
+        title="Office",
+        api_key="shared-key",
+        latitude=3.0,
+        longitude=4.0,
+        options={CONF_UPDATE_INTERVAL: 8},
+        unique_id="3.0000_4.0000",
+    )
+    legacy.add_to_hass(hass)
+    clean_parent.add_to_hass(hass)
+
+    assert await async_migrate_config_entry(hass, legacy)
+
+    assert clean_parent.version == TARGET_ENTRY_VERSION
+    assert clean_parent.data == {CONF_API_KEY: "shared-key"}
+    assert clean_parent.unique_id == api_key_unique_id("shared-key")
+    assert clean_parent.options == {
+        CONF_LANGUAGE_CODE: "en",
+        CONF_UPDATE_INTERVAL: 8,
+    }
+    assert "existing-location" in clean_parent.subentries
+    assert clean_parent.subentries["existing-location"].unique_id == "10.0000_20.0000"
+    subentries = _subentries_by_legacy_entry(clean_parent)
+    _assert_location_subentry(
+        subentries["legacy-office"],
+        title="Office",
+        latitude=3.0,
+        longitude=4.0,
+        legacy_entry_id="legacy-office",
+    )
+    assert hass.config_entries.async_get_entry("legacy-office") is None
+
+
 async def test_ha_migration_different_api_keys_stay_separate(
     hass: HomeAssistant,
     enable_custom_integrations: None,
@@ -189,6 +258,35 @@ async def test_ha_migration_different_api_keys_stay_separate(
     assert second.unique_id == api_key_unique_id("key-two")
     assert set(_subentries_by_legacy_entry(first)) == {"legacy-home"}
     assert set(_subentries_by_legacy_entry(second)) == {"legacy-office"}
+
+
+async def test_ha_migration_preserves_version_newer_than_target(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Migration should clean legacy storage without downgrading newer entries."""
+    clear_integration_modules()
+    from custom_components.pollenlevels import TARGET_ENTRY_VERSION
+
+    entry = legacy_config_entry(
+        entry_id="newer-entry",
+        title="Newer Entry",
+        api_key="newer-key",
+        latitude=1.0,
+        longitude=2.0,
+        data={"http_referer": "https://legacy.example.com"},
+        options={"http_referer": "https://legacy.example.com"},
+        version=TARGET_ENTRY_VERSION + 1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_config_entry(hass, entry)
+
+    assert "http_referer" not in entry.data
+    assert "http_referer" not in entry.options
+    assert entry.version == TARGET_ENTRY_VERSION + 1
+    assert entry.data == {CONF_API_KEY: "newer-key"}
+    assert set(_subentries_by_legacy_entry(entry)) == {"newer-entry"}
 
 
 async def test_ha_migration_attaches_entity_and_device_registries_to_subentry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2060,70 +2060,6 @@ def test_migrate_group_with_partial_legacy_coordinates_is_left_unchanged(
     assert "45.123456" not in caplog.text
 
 
-def test_migrate_legacy_entry_into_existing_clean_v3_parent(
-    integration_modules: _InitModules,
-) -> None:
-    """A residual legacy entry should merge into an existing clean API-key parent."""
-    integration = integration_modules.integration
-
-    existing_subentry = integration.ConfigSubentry(
-        data={integration.CONF_LATITUDE: 10.0, integration.CONF_LONGITUDE: 20.0},
-        subentry_id="existing-location",
-        title="Existing",
-        unique_id="10.0000_20.0000",
-    )
-    clean_parent = _FakeEntry(
-        integration,
-        entry_id="clean-parent",
-        title="Pollen Levels",
-        data={integration.CONF_API_KEY: "shared-key"},
-        options={integration.CONF_LANGUAGE_CODE: "en"},
-        version=integration.TARGET_ENTRY_VERSION,
-        subentries={existing_subentry.subentry_id: existing_subentry},
-        unique_id=integration.api_key_unique_id("shared-key"),
-    )
-    legacy = _FakeEntry(
-        integration,
-        entry_id="legacy-office",
-        title="Office",
-        data={
-            integration.CONF_API_KEY: "shared-key",
-            integration.CONF_LATITUDE: 3.0,
-            integration.CONF_LONGITUDE: 4.0,
-        },
-        options={integration.CONF_UPDATE_INTERVAL: 8},
-        version=3,
-        subentries={},
-        unique_id="3.0000_4.0000",
-    )
-    hass = _FakeHass(entries=[legacy, clean_parent])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, legacy)) is True
-
-    assert clean_parent.data == {integration.CONF_API_KEY: "shared-key"}
-    assert clean_parent.unique_id == integration.api_key_unique_id("shared-key")
-    assert clean_parent.options == {
-        integration.CONF_LANGUAGE_CODE: "en",
-        integration.CONF_UPDATE_INTERVAL: 8,
-    }
-    assert existing_subentry.subentry_id in clean_parent.subentries
-    subentries_by_legacy_id = {
-        subentry.data.get(integration.CONF_LEGACY_ENTRY_ID): subentry
-        for subentry in clean_parent.subentries.values()
-    }
-    assert subentries_by_legacy_id["legacy-office"].title == "Office"
-    assert subentries_by_legacy_id["legacy-office"].unique_id == "3.0000_4.0000"
-    assert legacy.data == {
-        integration.CONF_API_KEY: "shared-key",
-        "merged_into_entry_id": "clean-parent",
-    }
-    assert legacy.version == integration.TARGET_ENTRY_VERSION
-    assert len(hass.created_tasks) == 1
-    assert hass.created_tasks[0].get_name() == (
-        "remove merged pollenlevels entry legacy-office"
-    )
-
-
 def test_migrate_entry_without_location_does_not_create_corrupt_subentry(
     integration_modules: _InitModules,
 ) -> None:
@@ -3717,31 +3653,6 @@ def test_migrate_entry_cleans_legacy_keys_when_version_current(
     assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.data
     assert integration.CONF_CREATE_FORECAST_SENSORS not in entry.options
     assert entry.version == integration.TARGET_ENTRY_VERSION
-
-
-def test_migrate_entry_does_not_downgrade_version(
-    integration_modules: _InitModules,
-) -> None:
-    """Migration should preserve versions newer than the target."""
-    integration = integration_modules.integration
-
-    entry = _FakeEntry(
-        integration,
-        data={
-            integration.CONF_API_KEY: "key",
-            integration.CONF_LATITUDE: 1.0,
-            integration.CONF_LONGITUDE: 2.0,
-            "http_referer": "https://legacy.example.com",
-        },
-        options={"http_referer": "https://legacy.example.com"},
-        version=integration.TARGET_ENTRY_VERSION + 1,
-    )
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_migrate_entry(hass, entry)) is True
-    assert "http_referer" not in entry.data
-    assert "http_referer" not in entry.options
-    assert entry.version == integration.TARGET_ENTRY_VERSION + 1
 
 
 def test_migrate_entry_removes_mode_from_data_and_options(


### PR DESCRIPTION
## Summary
- add HA harness coverage for clean v3 parent migration scenarios
- cover residual legacy entries merging into an existing clean parent without losing existing subentries
- cover newer-than-target config entry versions so migration cleans legacy storage without downgrading
- remove exact duplicate lightweight migration stubs now covered by the real HA harness

## Validation
- `$env:PYTHONPATH='.'; python -m pytest -q tests/test_ha_migration.py`
- `$env:PYTHONPATH='.'; python -m pytest -q tests/test_ha_migration.py tests/test_migration.py`
- `$env:PYTHONPATH='.'; python -m pytest -q tests/test_init.py -k migrate`
- `python -m compileall -q custom_components tests`
- `python -m ruff check --fix --select I .`
- `python -m ruff check .`
- `python -m black .`
- `$env:PYTHONPATH='.'; python -m pytest -q`

## Notes
- No runtime behavior changes.
- No changelog/version changes.
- Remaining warnings are the known external `aioresponses` Python 3.14 deprecation warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized and expanded migration test coverage with new validation scenarios for legacy entry consolidation and version preservation during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->