### PR TITLE
[codex] Cover options reload and button press in HA harness

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -187,18 +187,6 @@ def test_button_available_when_last_update_failed(
 
 
 @pytest.mark.asyncio
-async def test_button_press_awaits_async_request_refresh(
-    button_platform: SimpleNamespace,
-) -> None:
-    coordinator = _FakeCoordinator()
-    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
-
-    await entity.async_press()
-
-    coordinator.async_request_refresh.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_button_press_raises_homeassistant_error_on_refresh_failure(
     button_platform: SimpleNamespace,
 ) -> None:

--- a/tests/test_ha_config_flow.py
+++ b/tests/test_ha_config_flow.py
@@ -148,10 +148,19 @@ async def test_ha_options_flow_saves_supported_options_only(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     ha_config_entry,
+    monkeypatch,
 ) -> None:
-    """Options flow should persist supported options and drop legacy keys."""
+    """Options flow should persist supported options and schedule a reload."""
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
+    scheduled_reloads: list[str] = []
+
+    def _capture_schedule_reload(entry_id: str) -> None:
+        scheduled_reloads.append(entry_id)
+
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", _capture_schedule_reload
+    )
     hass.config_entries.async_update_entry(
         ha_config_entry,
         options={
@@ -179,6 +188,7 @@ async def test_ha_options_flow_saves_supported_options_only(
         CONF_LANGUAGE_CODE: "en",
         CONF_UPDATE_INTERVAL: 12,
     }
+    assert scheduled_reloads == [ha_config_entry.entry_id]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock
 
 from aioresponses import aioresponses
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
@@ -85,6 +87,48 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
             entity.domain == "button" and entity.config_subentry_id == subentry_id
             for entity in entries
         )
+
+
+async def test_ha_button_press_refreshes_location_coordinator(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """button.press should refresh the coordinator for its location subentry."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    with aioresponses() as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, ha_config_entry)
+
+        registry = er.async_get(hass)
+        button_entry = next(
+            entity
+            for entity in er.async_entries_for_config_entry(
+                registry, ha_config_entry.entry_id
+            )
+            if entity.domain == "button"
+            and entity.config_subentry_id == "location-madrid"
+        )
+        refresh = AsyncMock()
+        monkeypatch.setattr(
+            ha_config_entry.runtime_data.locations["location-madrid"].coordinator,
+            "async_request_refresh",
+            refresh,
+        )
+
+        await hass.services.async_call(
+            "button",
+            "press",
+            {ATTR_ENTITY_ID: button_entry.entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    refresh.assert_awaited_once()
 
 
 async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(


### PR DESCRIPTION
## Summary
- Extend the Home Assistant config-flow harness to verify `OptionsFlowWithReload` schedules a reload when options are saved.
- Add a Home Assistant harness test for the real `button.press` service refreshing the coordinator attached to a location subentry.
- Remove the now-duplicated direct unit happy path for `button.async_press`, while keeping the unit tests for error handling and wrapping.

## Impact
- Test-only change. No runtime, version, or changelog changes.

## Validation
- `python -m pytest -q tests/test_ha_config_flow.py tests/test_config_flow.py tests/test_ha_platforms.py tests/test_button.py`
- `python -m compileall -q custom_components tests`
- `python -m ruff check --fix --select I .`
- `python -m ruff check .`
- `python -m black .`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized button functionality test coverage with Home Assistant integration testing
  * Updated configuration flow tests to verify reload scheduling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->