### PR TITLE
[codex] Strengthen empty parent runtime coverage

### DIFF
--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -200,6 +200,7 @@ async def test_ha_force_update_parent_without_locations_is_noop(
 
     await async_setup_config_entry(hass, entry)
     assert entry.runtime_data.locations == {}
+    assert entry.runtime_data.coordinator is None
 
     await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Summary
- Strengthen Home Assistant harness coverage for a parent config entry with no location subentries.
- Assert the v3 empty-parent runtime keeps the legacy `coordinator` property as `None`.

## Impact
- Test-only change.
- No runtime, migration, docs, version, or changelog changes.

## Validation
- `python -m pytest -q tests/test_ha_services.py tests/test_init.py`
- `python -m compileall -q custom_components tests`
- `python -m ruff check --fix --select I .`
- `python -m ruff check .`
- `python -m black .`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the `force_update` service to verify proper coordinator handling when parent entries have no location subentries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->