### PR TITLE
[codex] test: align test dependency minimums

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+pytest>=9
+pytest-asyncio>=1.3.0
 pytest-homeassistant-custom-component>=0.13.339
-pytest-asyncio
-aioresponses
+aioresponses>=0.7.8


### PR DESCRIPTION
## Summary
- Add explicit minimum versions for `pytest`, `pytest-asyncio`, and `aioresponses` in `requirements_test.txt`.
- Keep `pytest-homeassistant-custom-component>=0.13.339` as the Home Assistant harness floor.
- Leave Black and Ruff out of `requirements_test.txt` because CI installs tooling separately with the documented `black>=26` and `ruff>=0.15` minimums.

## Notes
- Post #189 cleanup; no runtime behavior changes.
- This makes local/test dependency setup match the Python 3.14 and pytest>=9 tooling story more directly.

## Test Plan
- `python -m pip index versions pytest`
- `python -m pip index versions pytest-asyncio`
- `python -m pip index versions aioresponses`
- `python -m pip index versions pytest-homeassistant-custom-component`
- `python -m pip install --dry-run -r requirements_test.txt`
- `python -m pip check`
- `$env:PYTHONPATH='.'; python -m pytest -q tests/test_metadata.py`
- `$env:PYTHONPATH='.'; python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum versions for test dependencies: pytest (>=9), pytest-asyncio (>=1.3.0), and aioresponses (>=0.7.8).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->