### PR TITLE
Harden language validation and registry helpers for beta 5

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m compileall -q custom_components tests
+          python -m compileall -q sitecustomize.py custom_components tests
 
       - name: Ruff validation
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m compileall -q custom_components tests
+          python -m compileall -q sitecustomize.py custom_components tests
 
       - name: Ruff validation
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,9 @@ jobs:
           python -m pip install .
 
       - name: Compile Python sources
+        shell: bash
         run: |
+          set -euo pipefail
           python -m compileall -q sitecustomize.py custom_components tests
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Compile Python sources
         run: |
-          python -m compileall -q custom_components tests
+          python -m compileall -q sitecustomize.py custom_components tests
 
       - name: Run tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   misleading top-level data copied from the first location.
 - Passed the config entry into the data update coordinator when supported by
   Home Assistant, preserving compatibility with newer coordinator contracts.
+- Ignored invalid stored API language codes instead of sending malformed
+  `languageCode` values to Google.
 
 ## [3.0.0b4] - 2026-06-11
 

--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -55,6 +55,7 @@ from .util import (
     api_key_unique_id,
     entry_api_key,
     format_location_unique_id,
+    normalize_language_code,
     redact_api_key,
     redact_sensitive_values,
     safe_parse_int,
@@ -66,15 +67,6 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# BCP-47-ish regex (common patterns, not full grammar).
-LANGUAGE_CODE_REGEX = re.compile(
-    r"^[A-Za-z]{2,3}"
-    r"(?:-[A-Za-z]{4})?"  # optional script
-    r"(?:-(?:[A-Za-z]{2}|\d{3}))?"  # optional region
-    r"(?:-(?:[A-Za-z0-9]{5,8}|\d[A-Za-z0-9]{3}))?$",  # optional single variant
-    re.IGNORECASE,
-)
-
 
 def is_valid_language_code(value: str) -> str:
     """Validate language code format; return normalized (trimmed) value."""
@@ -83,10 +75,11 @@ def is_valid_language_code(value: str) -> str:
     norm = value.strip()
     if not norm:
         raise vol.Invalid("empty")
-    if not LANGUAGE_CODE_REGEX.match(norm):
+    normalized = normalize_language_code(norm)
+    if normalized is None:
         _LOGGER.warning("Invalid language code format (BCP-47-like)")
         raise vol.Invalid("invalid_language")
-    return norm
+    return normalized
 
 
 def _language_error_to_form_key(error: vol.Invalid) -> str:
@@ -420,10 +413,7 @@ def _entry_language_code(entry: config_entries.ConfigEntry) -> str | None:
     raw_language = (entry.options or {}).get(
         CONF_LANGUAGE_CODE, (entry.data or {}).get(CONF_LANGUAGE_CODE)
     )
-    if not isinstance(raw_language, str):
-        return None
-    language = raw_language.strip()
-    return language or None
+    return normalize_language_code(raw_language)
 
 
 def _first_location_data(entry: config_entries.ConfigEntry) -> dict[str, Any]:

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -19,7 +19,12 @@ from .const import (
     FORECAST_DAYS,
 )
 from .forecast import attach_forecast_attributes
-from .util import redact_api_key, redact_sensitive_values, safe_parse_int
+from .util import (
+    normalize_language_code,
+    redact_api_key,
+    redact_sensitive_values,
+    safe_parse_int,
+)
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -186,12 +191,14 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.lat = lat
         self.lon = lon
 
-        # Normalize language once at runtime:
-        # - Trim whitespace
-        # - Use None if empty after normalization (skip sending languageCode)
-        if isinstance(language, str):
-            language = language.strip()
-        self.language = language if language else None
+        normalized_language = normalize_language_code(language)
+        if (
+            normalized_language is None
+            and isinstance(language, str)
+            and language.strip()
+        ):
+            _LOGGER.warning("Ignoring invalid stored API language code")
+        self.language = normalized_language
 
         self.entry_id = entry_id
         self.subentry_id = subentry_id

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -35,6 +35,7 @@ from .util import (
     active_location_subentry_ids,
     device_subentry_ids,
     has_legacy_location_data,
+    normalize_language_code,
     redact_api_key,
     redact_sensitive_values,
 )
@@ -273,7 +274,8 @@ async def async_get_config_entry_diagnostics(
     options: dict[str, Any] = dict(entry.options or {})
     data: dict[str, Any] = dict(entry.data or {})
     runtime = cast(PollenLevelsRuntimeData | None, getattr(entry, "runtime_data", None))
-    lang = options.get(CONF_LANGUAGE_CODE, data.get(CONF_LANGUAGE_CODE))
+    raw_lang = options.get(CONF_LANGUAGE_CODE, data.get(CONF_LANGUAGE_CODE))
+    lang = normalize_language_code(raw_lang)
     locations: dict[str, Any] = {}
     stale_location_ids: list[str] = []
     failed_locations: dict[str, Any] = {}

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -13,7 +13,6 @@ No network I/O is performed.
 from __future__ import annotations
 
 import math
-from collections.abc import Mapping
 from typing import Any, cast
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -34,6 +33,7 @@ from .runtime import PollenLevelsRuntimeData, PollenLocationSetupFailure
 from .summary import daily_summary as _daily_summary
 from .util import (
     active_location_subentry_ids,
+    device_subentry_ids,
     has_legacy_location_data,
     redact_api_key,
     redact_sensitive_values,
@@ -200,37 +200,6 @@ def _coordinate_from_coordinator_or_data(
     return data.get(key)
 
 
-def _normalized_subentry_ids(value: Any) -> set[str | None]:
-    """Return normalized subentry ids for registry diagnostics."""
-    if value is None:
-        return {None}
-    if isinstance(value, str):
-        return {value} if value else {None}
-    try:
-        ids = {item if isinstance(item, str) and item else None for item in value}
-    except TypeError:
-        return {None}
-    return ids or {None}
-
-
-def _device_subentry_ids_for_entry(device: Any, entry_id: str) -> set[str | None]:
-    """Return device subentry ids for one config entry."""
-    for attr in ("config_entries_subentries", "config_entry_subentries"):
-        mapping = getattr(device, attr, None)
-        if isinstance(mapping, Mapping):
-            return _normalized_subentry_ids(mapping.get(entry_id))
-
-    for attr in ("config_subentry_ids", "config_subentries"):
-        value = getattr(device, attr, None)
-        if value is not None:
-            return _normalized_subentry_ids(value)
-
-    direct_subentry_id = getattr(device, "config_subentry_id", None)
-    if direct_subentry_id is not None:
-        return _normalized_subentry_ids(direct_subentry_id)
-    return {None}
-
-
 def _empty_registry_summary() -> dict[str, Any]:
     """Return an empty registry summary payload."""
     return {
@@ -281,7 +250,7 @@ def _registry_summary(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]
 
     for device in devices:
         summary["devices"]["total"] += 1
-        subentry_ids = _device_subentry_ids_for_entry(device, entry.entry_id)
+        subentry_ids = device_subentry_ids(device, entry.entry_id) or {None}
         if None in subentry_ids:
             summary["devices"]["without_subentry"] += 1
             summary["devices"]["with_legacy_none_association"] += 1

--- a/custom_components/pollenlevels/migration.py
+++ b/custom_components/pollenlevels/migration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
-from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
@@ -32,6 +31,7 @@ from .issue_helpers import (
 from .util import (
     LEGACY_FORECAST_OPTION_KEYS,
     api_key_unique_id,
+    device_subentry_ids,
     entry_api_key,
     has_legacy_per_day_option,
     strip_legacy_forecast_options,
@@ -490,42 +490,11 @@ def _parent_legacy_location_target(
     )
 
 
-def _normalize_subentry_ids(value: Any) -> set[str | None]:
-    """Return a normalized subentry-id set while preserving legacy None links."""
-    if value is None:
-        return {None}
-    if isinstance(value, str):
-        return {value} if value else {None}
-    try:
-        ids: set[str | None] = set()
-        for item in value:
-            if item is None:
-                ids.add(None)
-            elif isinstance(item, str) and item:
-                ids.add(item)
-        return ids or {None}
-    except TypeError:
-        return {None}
-
-
 def _device_source_subentry_ids(
     device: Any, source_entry_id: str
 ) -> set[str | None] | None:
     """Return known source subentry IDs for a device, or None if unavailable."""
-    for attr in ("config_entries_subentries", "config_entry_subentries"):
-        mapping = getattr(device, attr, None)
-        if isinstance(mapping, Mapping):
-            return _normalize_subentry_ids(mapping.get(source_entry_id))
-
-    for attr in ("config_subentry_ids", "config_subentries"):
-        value = getattr(device, attr, None)
-        if value is not None:
-            return _normalize_subentry_ids(value)
-
-    direct_subentry_id = getattr(device, "config_subentry_id", None)
-    if direct_subentry_id is not None:
-        return _normalize_subentry_ids(direct_subentry_id)
-    return None
+    return device_subentry_ids(device, source_entry_id)
 
 
 def _migrate_entity_registry_for_merged_entry(

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -32,6 +32,13 @@ LEGACY_FORECAST_OPTION_KEYS = frozenset(
     }
 )
 LEGACY_ACTIVE_PER_DAY_SENSOR_MODES = frozenset({"D+1", "D+1+2"})
+_LANGUAGE_CODE_RE = re.compile(
+    r"^[A-Za-z]{2,3}"
+    r"(?:-[A-Za-z]{4})?"
+    r"(?:-(?:[A-Za-z]{2}|\d{3}))?"
+    r"(?:-(?:[A-Za-z0-9]{5,8}|\d[A-Za-z0-9]{3}))?$",
+    re.IGNORECASE,
+)
 
 
 def strip_legacy_forecast_options(
@@ -116,6 +123,52 @@ def stale_runtime_location_filter(entry: Any) -> tuple[set[str], bool]:
         entry
     )
     return active_subentry_ids, filter_stale_locations
+
+
+def normalize_subentry_ids(value: Any) -> set[str | None]:
+    """Return normalized subentry IDs while preserving legacy None links."""
+    if value is None:
+        return {None}
+    if isinstance(value, str):
+        return {value} if value else {None}
+    try:
+        ids: set[str | None] = set()
+        for item in value:
+            if item is None:
+                ids.add(None)
+            elif isinstance(item, str) and item:
+                ids.add(item)
+        return ids or {None}
+    except TypeError:
+        return {None}
+
+
+def device_subentry_ids(device: Any, entry_id: str) -> set[str | None] | None:
+    """Return normalized device subentry IDs for one config entry."""
+    for attr in ("config_entries_subentries", "config_entry_subentries"):
+        mapping = getattr(device, attr, None)
+        if isinstance(mapping, Mapping):
+            return normalize_subentry_ids(mapping.get(entry_id))
+
+    for attr in ("config_subentry_ids", "config_subentries"):
+        value = getattr(device, attr, None)
+        if value is not None:
+            return normalize_subentry_ids(value)
+
+    direct_subentry_id = getattr(device, "config_subentry_id", None)
+    if direct_subentry_id is not None:
+        return normalize_subentry_ids(direct_subentry_id)
+    return None
+
+
+def normalize_language_code(value: object) -> str | None:
+    """Return a normalized BCP-47-like language code, or None when invalid."""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or not _LANGUAGE_CODE_RE.match(normalized):
+        return None
+    return normalized
 
 
 async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
@@ -341,11 +394,14 @@ __all__ = [
     "api_key_unique_id",
     "coordinator_device_id",
     "coordinator_identity_id",
+    "device_subentry_ids",
     "entry_api_key",
     "extract_error_message",
     "format_location_unique_id",
     "has_legacy_per_day_option",
     "LEGACY_FORECAST_OPTION_KEYS",
+    "normalize_language_code",
+    "normalize_subentry_ids",
     "parse_finite_float",
     "redact_api_key",
     "redact_sensitive_values",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -786,6 +786,52 @@ async def test_diagnostics_request_days_are_fixed(
     )
 
 
+@pytest.mark.parametrize(
+    ("stored_language", "expected_language"),
+    [
+        (" es ", "es"),
+        ("es-ES", "es-ES"),
+        ("bad code", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_diagnostics_normalizes_request_example_language_code(
+    diagnostics_modules: DiagnosticsModules,
+    stored_language: str,
+    expected_language: str | None,
+) -> None:
+    """Diagnostics request params should match runtime language normalization."""
+
+    data = {
+        diagnostics_modules.CONF_API_KEY: "test-api-key",
+        diagnostics_modules.CONF_LATITUDE: 12.3,
+        diagnostics_modules.CONF_LONGITUDE: 45.6,
+    }
+    options = {diagnostics_modules.CONF_LANGUAGE_CODE: stored_language}
+
+    entry = _ConfigEntry(data=data, options=options, entry_id="entry", title="Home")
+
+    coordinator = SimpleNamespace(
+        entry_id="entry",
+        language=expected_language,
+        last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        data={"type_grass": {"source": "type"}},
+    )
+    entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
+        coordinator=coordinator, client=object()
+    )
+
+    diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
+        None, entry
+    )
+
+    request_params = diagnostics["locations"]["entry"]["request_params_example"]
+    if expected_language is None:
+        assert "languageCode" not in request_params
+    else:
+        assert request_params["languageCode"] == expected_language
+
+
 @pytest.mark.asyncio
 async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
     diagnostics_modules: DiagnosticsModules,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1047,6 +1047,43 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing(
     assert second_data == coordinator.data
 
 
+def test_coordinator_handles_real_partial_google_pollen_fixture(
+    sensor_modules: SensorModules, google_pollen_5_day_payload: dict[str, Any]
+) -> None:
+    """Real 5-day payloads with partial entries should remain parseable."""
+
+    fake_session = FakeSession(google_pollen_5_day_payload)
+    client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
+
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert "plants_hazel" in data
+    assert data["plants_hazel"]["displayName"] == "Avellano"
+    assert data["plants_hazel"]["value"] is None
+    assert data["plants_hazel"]["tomorrow_has_index"] is False
+    assert data["plants_hazel"]["d2_has_index"] is False
+    assert all(
+        forecast_item["has_index"] is False
+        for forecast_item in data["plants_hazel"]["forecast"]
+    )
+
+    assert "type_weed" in data
+    assert data["type_weed"]["displayName"] == "Maleza"
+    assert data["type_weed"]["value"] is None
+    assert any(
+        forecast_item["has_index"] is False
+        for forecast_item in data["type_weed"]["forecast"]
+    )
+
+    assert not any(key.endswith(("_d1", "_d2")) for key in data)
+
+
 def test_coordinator_uses_fixed_forecast_days(sensor_modules: SensorModules) -> None:
     """Coordinator always uses the fixed Google Pollen maximum forecast horizon."""
 
@@ -1069,6 +1106,46 @@ def test_coordinator_uses_fixed_forecast_days(sensor_modules: SensorModules) -> 
         loop.close()
 
     assert coordinator.forecast_days == sensor_modules.const.FORECAST_DAYS
+
+
+def test_coordinator_normalizes_and_ignores_invalid_runtime_language(
+    sensor_modules: SensorModules, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Runtime language from storage should be validated before API requests."""
+
+    loop = asyncio.new_event_loop()
+    hass = DummyHass(loop)
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
+
+    try:
+        valid = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+            hass=hass,
+            api_key="test",
+            lat=1.0,
+            lon=2.0,
+            hours=12,
+            language=" es ",
+            entry_id="entry",
+            client=client,
+        )
+        with caplog.at_level("WARNING", logger=sensor_modules.coordinator_mod.__name__):
+            invalid = sensor_modules.coordinator_mod.PollenDataUpdateCoordinator(
+                hass=hass,
+                api_key="test",
+                lat=1.0,
+                lon=2.0,
+                hours=12,
+                language="bad code",
+                entry_id="entry",
+                client=client,
+            )
+    finally:
+        loop.close()
+
+    assert valid.language == "es"
+    assert invalid.language is None
+    assert "Ignoring invalid stored API language code" in caplog.text
+    assert "bad code" not in caplog.text
 
 
 def test_coordinator_first_refresh_missing_dailyinfo_raises(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,7 +3,7 @@
 import importlib
 import sys
 from collections.abc import Iterator
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -399,3 +399,86 @@ def test_validate_location_pair_rejects_invalid_pair(util_module, latitude, long
     """validate_location_pair rejects pairs with any invalid coordinate."""
 
     assert util_module.validate_location_pair(latitude, longitude) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, {None}),
+        ("", {None}),
+        ("abc", {"abc"}),
+        (["abc", None, ""], {"abc", None}),
+        ({"abc", None}, {"abc", None}),
+        (("abc", "def"), {"abc", "def"}),
+    ],
+)
+def test_normalize_subentry_ids(util_module, value, expected):
+    """Subentry ID containers should normalize to stable string/None sets."""
+
+    assert util_module.normalize_subentry_ids(value) == expected
+
+
+def test_normalize_subentry_ids_handles_non_iterable_values(util_module):
+    """Non-iterable subentry containers should fall back to legacy None."""
+
+    assert util_module.normalize_subentry_ids(123) == {None}
+
+
+def test_device_subentry_ids_returns_none_without_supported_attributes(util_module):
+    """Devices without subentry attributes should report unavailable metadata."""
+
+    assert util_module.device_subentry_ids(SimpleNamespace(), "entry") is None
+
+
+@pytest.mark.parametrize(
+    ("attr", "value", "expected"),
+    [
+        ("config_entries_subentries", {"entry": {"abc", None}}, {"abc", None}),
+        ("config_entry_subentries", {"entry": {"abc", None}}, {"abc", None}),
+        ("config_subentry_ids", {"abc", None}, {"abc", None}),
+        ("config_subentries", {"abc", None}, {"abc", None}),
+        ("config_subentry_id", "abc", {"abc"}),
+    ],
+)
+def test_device_subentry_ids_reads_supported_home_assistant_attributes(
+    util_module, attr, value, expected
+):
+    """Supported Home Assistant device attributes should use one normalization path."""
+
+    device = SimpleNamespace(**{attr: value})
+
+    assert util_module.device_subentry_ids(device, "entry") == expected
+
+
+def test_device_subentry_ids_mapping_for_other_entry_returns_legacy_none(util_module):
+    """Entry-scoped mappings should preserve legacy None when entry is missing."""
+
+    device = SimpleNamespace(config_entries_subentries={"other": {"abc"}})
+
+    assert util_module.device_subentry_ids(device, "entry") == {None}
+
+
+def test_device_subentry_ids_mapping_for_matching_entry(util_module):
+    """Entry-scoped mappings should return IDs for the requested entry."""
+
+    device = SimpleNamespace(config_entries_subentries={"entry": {"abc"}})
+
+    assert util_module.device_subentry_ids(device, "entry") == {"abc"}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("es", "es"),
+        (" es ", "es"),
+        ("es-ES", "es-ES"),
+        ("zh-Hans", "zh-Hans"),
+        ("", None),
+        (None, None),
+        ("bad code", None),
+    ],
+)
+def test_normalize_language_code(util_module, value, expected):
+    """Language codes should share one validation path for flow and runtime use."""
+
+    assert util_module.normalize_language_code(value) == expected


### PR DESCRIPTION
## Summary

- Shared Home Assistant subentry/device registry normalization between diagnostics and migration through common helpers in `util.py`.
- Centralized API language-code validation so config/options flow and runtime use the same BCP-47-like rules.
- Ignored invalid stored runtime language codes instead of sending malformed `languageCode` values to Google.
- Added regression coverage for the sanitized real 5-day Google Pollen fixture with partial plant/type entries.
- Included `sitecustomize.py` in CI `compileall` validation.

## Why

DeepSeek's audit identified real duplication around registry subentry handling and a runtime gap where manually edited storage could bypass language-code validation. This PR keeps the behavior focused for beta 5: it removes duplicated registry normalization without changing migration semantics, and it hardens runtime language handling with tests.

## Not changed

- `_BaseSummarySensor` fallback: left unchanged because current call sites only pass `type` or `plant`, so this is not an active bug. It can be changed later as a low-risk defensive follow-up if we want to protect future subclasses.
- `sensor.py.__all__`, redundant same-name aliases, and `_redact_api_key`: left unchanged because they are compatibility/cosmetic cleanup rather than beta-blocking behavior.
- Registry import helper extraction and coordinate helper consolidation: left unchanged to avoid extra migration churn beyond the duplicated subentry/device logic covered here.

## Validation

- `python -m ruff check --fix --select I .`
- `python -m black .`
- `python -m ruff check .`
- `python -m black --check .`
- `python -m compileall -q sitecustomize.py custom_components tests`
- `$env:PYTHONPATH='.'; python -m pytest -q` -> 508 passed, 29 warnings from `aioresponses` deprecation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid Google API language codes are now consistently ignored, preventing malformed `languageCode` values from being sent; trimming/validation is applied to stored and runtime settings.
  * Diagnostics request examples now reflect the normalized language value (or omit it when invalid).

* **Tests**
  * Added coverage for parsing partial Google pollen fixtures and for language-code normalization/ignoring behavior.
  * Expanded utility and diagnostics test cases for language/subentry-id handling.

* **Chores**
  * Updated CI/CD compile steps to also syntax-check `sitecustomize.py` as part of testing and release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->