### PR TITLE
chore: clean failed location diagnostics before rc

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -173,14 +173,22 @@ If `runtime_summary.stale_location_count` is greater than `0` immediately after
 deleting a location subentry, reload the Pollen Levels parent entry from Home
 Assistant. This clears the stale runtime coordinator from memory.
 
+Diagnostics redact the API key and only include approximate coordinates rounded
+to 1 decimal for support purposes. They may also include Home Assistant internal
+`entry_id` and `subentry_id` values so support can match runtime, registry, and
+subentry state. These IDs are not credentials, but review diagnostics before
+sharing them publicly.
+
 During parent API-key reauthentication or reconfiguration, the integration tries
 configured locations until one validates successfully. Authentication and quota
 errors are treated as API-key-level failures.
 
-During startup, if any configured location cannot complete its initial refresh,
-the parent entry is marked not ready and Home Assistant will retry setup. Fix
-the underlying location or API issue, then reload or retry the Pollen Levels
-entry.
+During startup, if at least one configured location loads successfully, the
+parent entry remains available and failed locations are reported separately in
+diagnostics. Retryable location setup failures are retried on parent reload and
+can create a Repair warning after they repeat. If no configured location can
+load successfully, the parent entry is marked not ready so Home Assistant can
+retry setup.
 
 Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
 2.x after this migration is not supported.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 - Diagnostics include redacted daily, registry, and runtime summaries to help
   troubleshoot the integration without exposing API keys or exact coordinates.
   Approximate coordinates are rounded to 1 decimal for support purposes.
+  Diagnostics may also include Home Assistant internal config entry and location
+  subentry identifiers (`entry_id`, `subentry_id`). These are not credentials, but
+  you should still review diagnostics before posting them publicly.
 - Avoid sharing full debug logs publicly; review them for sensitive information before posting.
 - Never share real Google API keys publicly, and do not paste full Google Pollen
   API URLs containing `key=...` into public issues. If a key was exposed,
@@ -163,11 +166,12 @@ When reauthenticating or reconfiguring the parent API key, the integration tries
 the configured locations until one returns usable pollen data. Authentication
 and quota errors are treated as key-level failures.
 
-During startup, the v3 beta avoids partial parent setup. If any configured
-location fails its initial non-auth refresh, Home Assistant will retry setup
-until the underlying issue is fixed or the affected location is removed or
-reconfigured. This keeps all location entities, devices, and diagnostics in a
-consistent state during the beta migration.
+During startup, the v3 beta keeps the parent entry available when at least one
+configured location loads successfully. Locations that fail their initial
+non-auth refresh are isolated in diagnostics and retried on parent reload; after
+a repeated retryable failure, the integration creates a Repair warning for the
+affected location. If no configured location can load successfully, the parent
+entry is marked not ready so Home Assistant can retry setup.
 
 Create a Home Assistant backup before installing the v3 pre-release.
 Downgrading to Pollen Levels 2.x after the subentry migration is not supported.

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -185,7 +185,6 @@ def _failed_location_diagnostics(
             api_key,
             coordinate_pairs,
         ),
-        "is_auth_error": bool(getattr(failure, "is_auth_error", False)),
         "will_retry_on_reload": error_type != "InvalidStoredLocation",
     }
 

--- a/custom_components/pollenlevels/runtime.py
+++ b/custom_components/pollenlevels/runtime.py
@@ -27,7 +27,6 @@ class PollenLocationSetupFailure:
     title: str
     reason: str
     error_type: str
-    is_auth_error: bool = False
 
 
 @dataclass(slots=True, init=False)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -706,7 +706,7 @@ async def test_diagnostics_reports_failed_locations_separately_from_stale(
     failed_payload = diagnostics["failed_locations"]["failed"]
     assert failed_payload["error_type"] == "UpdateFailed"
     assert failed_payload["will_retry_on_reload"] is True
-    assert failed_payload["is_auth_error"] is False
+    assert "is_auth_error" not in failed_payload
     serialized = json.dumps(diagnostics, sort_keys=True)
     assert "secret-token" not in serialized
     assert "12.345678" not in serialized


### PR DESCRIPTION
## Summary

This PR performs a small pre-RC cleanup for v3 failed location diagnostics.

Changes:
- Remove the unused `is_auth_error` field from `PollenLocationSetupFailure`.
- Stop exposing `is_auth_error` in failed location diagnostics.
- Update diagnostics tests accordingly.
- Clarify README/FAQ wording for partial location setup during startup.
- Document that diagnostics may include Home Assistant internal `entry_id` and `subentry_id` values.

## Rationale

Authentication failures are handled at the parent/API-key level and are propagated as `ConfigEntryAuthFailed`. They are not represented as per-location setup failures, so `is_auth_error` was always false in failed location diagnostics and could be misleading.

Removing it before RC avoids carrying a dead diagnostics field into the stable v3 contract.

## Not changed

- No migration changes.
- No entity ID / unique ID changes.
- No device identifier changes.
- No service changes.
- No `force_update` changes.
- No `manifest.json`, `pyproject.toml`, or `hacs.json` version changes.
- No HACS metadata changes.

## Validation

- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest -q` (511 passed)
- [x] `rg "is_auth_error" .` — only match is the negative assertion in the test