### PR TITLE
docs: clarify plant code stability across languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-### Documentation
+### Changed
 
 - Clarified that Google `plantInfo.code` values are stable across tested API
   languages and are used for plant sensor identity, while localized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Documentation
+
+- Clarified that Google `plantInfo.code` values are stable across tested API
+  languages and are used for plant sensor identity, while localized
+  `displayName` values only affect visible names and attributes.
+
 ## [3.0.0b5] - 2026-06-14
 
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -66,8 +66,20 @@ Docs: https://developers.google.com/maps/documentation/pollen/overview
 
 ## 6. Can I request pollen data in my language?
 
-Yes. Set a **language code** in the integration options (e.g., `en`, `es`, `fr`, `de`, `uk`).  
-This controls localized fields returned by the API.
+Yes. Set a **language code** in the integration options (e.g., `en`, `es`,
+`fr`, `de`, `uk`). This controls localized fields returned by the API, such as
+display names, categories, descriptions, and health recommendations.
+
+Pollen Levels uses Google `plantInfo.code` values, not localized
+`displayName` values, to build plant sensor identity. In tests across `es`,
+`en`, `fr`, `de`, `it`, and `pt`, Google returned the same plant codes while
+localizing the visible names. For example, `GRAMINALES` remained the plant code
+for grass pollen plants, while the display name changed by language.
+
+This means changing the API language should update localized attributes without
+recreating plant sensors, as long as Google keeps returning the same
+`plantInfo.code` values. If Google changes plant codes in the future, treat it
+as an upstream API behavior change and include diagnostics when reporting it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -350,9 +350,16 @@ color: '[[[
 
 ## ⚠️ Known caveats
 
-* **Localized plant codes**: Google may localize `plantInfo.code` in some locales (e.g., `GRAMINALES` in ES) while others remain English (`OLIVE`, `MUGWORT`).
-  Changing `languageCode` may recreate plant sensors with a different suffix.
-  **Recommendation**: keep API language stable or rename entities in UI after changing it.
+* **Plant codes and localized names**: Pollen Levels uses Google
+  `plantInfo.code` values to keep plant sensor identities stable. In tests
+  across `es`, `en`, `fr`, `de`, `it`, and `pt`, Google returned the same plant
+  codes while localizing `displayName`, descriptions, categories, and
+  recommendations. For example, `GRAMINALES` is the Google plant code for grass
+  pollen plants, while the visible name may appear as `Gramíneas`, `Grasses`,
+  `Graminées`, `Gräser`, or another localized value depending on the selected
+  API language. Pollen Levels does not use localized `displayName` values to
+  build entity identity. If Google changes plant codes in the future, treat that
+  as an upstream API behavior change and include diagnostics when reporting it.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only PR correcting the documentation about `plantInfo.code` stability when changing the API language.

## Changes

- **README.md**: Replaced the misleading "Localized plant codes" caveat under `## ⚠️ Known caveats` with accurate text describing that `plantInfo.code` values are stable across tested languages (`es`, `en`, `fr`, `de`, `it`, `pt`) while `displayName` localizes.
- **FAQ.md**: Expanded section 6 to explain the difference between stable plant codes and localized display names, noting that changing language updates attributes without recreating sensors.
- **CHANGELOG.md**: Added `## [Unreleased]` section with a Documentation entry.

## Checklist

- [x] Docs-only
- [x] No runtime changes
- [x] No migration changes
- [x] No `unique_id` changes
- [x] No entity registry changes
- [x] No `GRAMINALES -> GRASS` mapping
- [x] README caveat corrected
- [x] FAQ language section expanded
- [x] CHANGELOG `[Unreleased]` documentation entry added
- [x] No version bump
- [x] No release metadata changes

Closes: (no issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Clarified how plant identification works across languages: stable plant codes are used for sensor identity, while localized display names, descriptions, categories, and recommendations update based on your language selection.
- Updated the FAQ to explain language behavior and what happens when switching language settings.
- Revised the README “Known caveats” section to note that any future change to plant codes should be treated as an upstream API change and reported with diagnostics.
- Added an `[Unreleased]` changelog note reflecting the same behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->