### PR TITLE
docs: update unreleased diagnostics cleanup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   languages and are used for plant sensor identity, while localized
   `displayName` values only affect visible names and attributes.
 - Removed the unused `is_auth_error` field from failed location diagnostics.
-  Authentication failures are handled at the parent/API-key level, so this
-  per-location diagnostics field was always false and could be misleading.
+  Authentication failures are handled at the parent/API-key level, so failed
+  location diagnostics no longer expose this per-location authentication flag.
 - Clarified the v3 beta documentation for partial location setup during startup
   and documented that diagnostics may include Home Assistant internal `entry_id`
   and `subentry_id` values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 - Clarified that Google `plantInfo.code` values are stable across tested API
   languages and are used for plant sensor identity, while localized
   `displayName` values only affect visible names and attributes.
+- Removed the unused `is_auth_error` field from failed location diagnostics.
+  Authentication failures are handled at the parent/API-key level, so this
+  per-location diagnostics field was always false and could be misleading.
+- Clarified the v3 beta documentation for partial location setup during startup
+  and documented that diagnostics may include Home Assistant internal `entry_id`
+  and `subentry_id` values.
 
 ## [3.0.0b5] - 2026-06-14
 


### PR DESCRIPTION
## Summary

Updates the `Unreleased` changelog section with the latest pre-RC diagnostics cleanup:

- Removed the unused `is_auth_error` field from failed location diagnostics.
- Clarified the documentation update around partial location setup and internal diagnostics identifiers.

## Not changed

- No code changes.
- No migration changes.
- No version bump.
- No release notes yet.

## Validation

- [x] Reviewed `CHANGELOG.md` diff
- [x] Confirmed only `CHANGELOG.md` changed