### PR TITLE
test: migrate HTTP mocks to aiointercept

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=9
 pytest-asyncio>=1.3.0
-pytest-homeassistant-custom-component>=0.13.339
-aioresponses>=0.7.8
+pytest-homeassistant-custom-component>=0.13.340
+aiointercept>=0.1.7,<0.2.0

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -6,7 +6,7 @@ import re
 from typing import Any
 from urllib.parse import parse_qsl
 
-from aioresponses import CallbackResult, aioresponses
+from aiointercept import CallbackResult, aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -23,7 +23,7 @@ POLLEN_API_URL_RE = re.compile(
 
 
 def mock_pollen_api(
-    mocked: aioresponses,
+    mocked: aiointercept,
     payload: dict[str, Any],
     captured_params: list[dict[str, Any]] | None = None,
 ) -> None:

--- a/tests/test_ha_config_flow.py
+++ b/tests/test_ha_config_flow.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 from typing import Any
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_LOCATION, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -94,7 +94,7 @@ async def test_ha_user_flow_creates_parent_entry_with_location_subentry(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -152,7 +152,7 @@ async def test_ha_user_flow_rejects_duplicate_parent_api_key(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -273,7 +273,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -346,7 +346,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     assert result["step_id"] == step_id
 
     new_api_key = f"{fake_api_key}-{source}"
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -365,7 +365,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     assert scheduled_reloads == [entry.entry_id]
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -417,7 +417,7 @@ async def test_ha_parent_api_key_flow_rejects_duplicate_parent_unique_id(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == step_id
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -471,7 +471,7 @@ async def test_ha_location_subentry_flow_creates_subentry(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
@@ -552,7 +552,7 @@ async def test_ha_location_subentry_reconfigure_updates_entry_and_schedules_relo
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],

--- a/tests/test_ha_diagnostics.py
+++ b/tests/test_ha_diagnostics.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 from urllib.parse import parse_qsl
 
-from aioresponses import CallbackResult, aioresponses
+from aiointercept import CallbackResult, aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -39,7 +39,7 @@ async def test_ha_diagnostics_redacts_secrets_and_summarizes_runtime(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
 
         await async_setup_config_entry(hass, ha_config_entry)
@@ -116,7 +116,7 @@ async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
             return CallbackResult(status=200, payload={"dailyInfo": []})
         return CallbackResult(status=200, payload=google_pollen_5_day_payload)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(POLLEN_API_URL_RE, callback=_callback, repeat=True)
         await async_setup_config_entry(hass, entry)
 
@@ -197,7 +197,7 @@ async def test_ha_diagnostics_registry_summary_uses_real_registries(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -28,7 +28,7 @@ async def test_ha_setup_unload_reload_smoke(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
 
         await async_setup_config_entry(hass, ha_config_entry)

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
@@ -63,7 +63,7 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -100,7 +100,7 @@ async def test_ha_button_press_refreshes_location_coordinator(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, ha_config_entry)
 
@@ -157,7 +157,7 @@ async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(
             config_subentry_id="location-madrid",
         )
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, ha_config_entry)
 

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -6,7 +6,7 @@ from types import MappingProxyType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -36,7 +36,7 @@ async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
 
         await async_setup_config_entry(hass, ha_config_entry)
@@ -93,7 +93,7 @@ async def test_ha_force_update_skips_removed_subentry_without_reload(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -168,7 +168,7 @@ async def test_ha_force_update_refreshes_multiple_location_subentries(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -225,7 +225,7 @@ async def test_ha_force_update_continues_after_one_location_failure(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 


### PR DESCRIPTION
## Summary

- Replace `aioresponses` with `aiointercept>=0.1.7,<0.2.0` in the Home Assistant harness tests.
- Migrate all 19 HTTP mock context managers to the async `aiointercept(mock_external_urls=True)` form.
- Raise the Home Assistant test harness floor to `pytest-homeassistant-custom-component>=0.13.340` while allowing current releases.
- Keep runtime code, migration logic, entities, translations, and release metadata unchanged.

## Why

`pytest-homeassistant-custom-component 0.13.341` installs Home Assistant 2026.7.0b1 and `aiohttp 3.14.1`. `aioresponses 0.7.9` constructs `ClientResponse` using aiohttp internals and does not provide the new required `stream_writer` argument, causing 21 cascading test failures before the integration client is exercised.

`aiointercept` routes requests through a real local aiohttp test server and supports aiohttp 3.14. `mock_external_urls=True` is required because the production client uses the fixed Google Pollen API URL.

## Scope

Changed only:

- `requirements_test.txt`
- `tests/ha_helpers.py`
- `tests/test_ha_config_flow.py`
- `tests/test_ha_diagnostics.py`
- `tests/test_ha_init.py`
- `tests/test_ha_platforms.py`
- `tests/test_ha_services.py`

No production or migration changes.

## Validation

Completed before opening:

- Verified the remote branch matches the prepared files exactly.
- Verified no `aioresponses` references remain in the changed files.
- Verified all 19 HTTP mock contexts use `async with aiointercept(mock_external_urls=True)`.
- `python -m compileall -q tests` on the changed test modules: passed.

CI should validate:

- `ruff check .`
- `black --check .`
- `python -m pytest -q` (524 tests expected)
- hassfest
- HACS validation
- package test
- CodeQL

## Safety

- No migration changes.
- No runtime changes.
- No entity ID, unique ID, device identifier, service, or translation changes.
- External requests remain intercepted; unmatched traffic is not allowed through.