### PR TITLE
chore(tests): pin Home Assistant test dependency

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=9
 pytest-asyncio>=1.3.0
-pytest-homeassistant-custom-component>=0.13.339
+pytest-homeassistant-custom-component==0.13.340
 aioresponses>=0.7.8


### PR DESCRIPTION
## Summary

- Pin `pytest-homeassistant-custom-component` to `0.13.340`.
- Restore the Home Assistant 2026.6.4 / aiohttp 3.13.5 test environment.
- Avoid the current incompatibility between aiohttp 3.14 and aioresponses 0.7.9.

## Scope

This is a temporary test-dependency pin. Migrating the HTTP mocks to aiointercept will be handled in a separate PR.

## Validation

- Python compilation
- Ruff
- Black
- Full pytest suite