### PR TITLE
test: migrate HTTP mocks to aiointercept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.0.0rc2] - 2026-06-24
+## [3.0.0rc2] - 2026-06-27
 
 ### Changed
 
@@ -13,6 +13,9 @@
 - Hardened CI validation by running package checks on pull requests, using
   `python -m pytest`, cleaning legacy branch triggers, and removing the
   auto-format workflow.
+- Migrated Home Assistant harness HTTP mocks from `aioresponses` to `aiointercept`
+  so tests remain compatible with `pytest-homeassistant-custom-component>=0.13.341`
+  and `aiohttp` 3.14+.
 
 ## [3.0.0rc1] - 2026-06-20
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=9
 pytest-asyncio>=1.3.0
-pytest-homeassistant-custom-component>=0.13.339
-aioresponses>=0.7.8
+pytest-homeassistant-custom-component>=0.13.341
+aiointercept>=0.1.7

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -6,7 +6,7 @@ import re
 from typing import Any
 from urllib.parse import parse_qsl
 
-from aioresponses import CallbackResult, aioresponses
+from aiointercept import CallbackResult, aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -23,14 +23,14 @@ POLLEN_API_URL_RE = re.compile(
 
 
 def mock_pollen_api(
-    mocked: aioresponses,
+    mocked: aiointercept,
     payload: dict[str, Any],
     captured_params: list[dict[str, Any]] | None = None,
 ) -> None:
     """Mock Google Pollen API responses and capture request parameters."""
 
-    def _callback(url, **kwargs):
-        params = dict(kwargs.get("params") or parse_qsl(url.query_string))
+    def _callback(url, **_kwargs):
+        params = dict(parse_qsl(url.query_string))
         if captured_params is not None:
             captured_params.append(params)
         return CallbackResult(status=200, payload=payload)

--- a/tests/test_ha_config_flow.py
+++ b/tests/test_ha_config_flow.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 from typing import Any
 
 import pytest
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_LOCATION, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -81,6 +81,7 @@ def _parent_entry_snapshot(entry) -> dict[str, Any]:
 async def test_ha_user_flow_creates_parent_entry_with_location_subentry(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
@@ -94,7 +95,7 @@ async def test_ha_user_flow_creates_parent_entry_with_location_subentry(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -133,6 +134,7 @@ async def test_ha_user_flow_creates_parent_entry_with_location_subentry(
 async def test_ha_user_flow_rejects_duplicate_parent_api_key(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
@@ -152,7 +154,7 @@ async def test_ha_user_flow_rejects_duplicate_parent_api_key(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -232,6 +234,7 @@ async def test_ha_options_flow_saves_supported_options_only(
 async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -273,7 +276,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -346,7 +349,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     assert result["step_id"] == step_id
 
     new_api_key = f"{fake_api_key}-{source}"
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -365,7 +368,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
     assert scheduled_reloads == [entry.entry_id]
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -382,6 +385,7 @@ async def test_ha_parent_api_key_flow_updates_entry_and_schedules_reload(
 async def test_ha_parent_api_key_flow_rejects_duplicate_parent_unique_id(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
     source: str,
@@ -417,7 +421,7 @@ async def test_ha_parent_api_key_flow_rejects_duplicate_parent_unique_id(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == step_id
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -434,6 +438,7 @@ async def test_ha_parent_api_key_flow_rejects_duplicate_parent_unique_id(
 async def test_ha_location_subentry_flow_creates_subentry(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
@@ -471,7 +476,7 @@ async def test_ha_location_subentry_flow_creates_subentry(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],
@@ -522,6 +527,7 @@ async def test_ha_location_subentry_flow_rejects_duplicate_location(
 async def test_ha_location_subentry_reconfigure_updates_entry_and_schedules_reload(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
@@ -552,7 +558,7 @@ async def test_ha_location_subentry_reconfigure_updates_entry_and_schedules_relo
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"],

--- a/tests/test_ha_diagnostics.py
+++ b/tests/test_ha_diagnostics.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 from urllib.parse import parse_qsl
 
-from aioresponses import CallbackResult, aioresponses
+from aiointercept import CallbackResult, aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -31,6 +31,7 @@ from tests.ha_helpers import (
 async def test_ha_diagnostics_redacts_secrets_and_summarizes_runtime(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
@@ -39,7 +40,7 @@ async def test_ha_diagnostics_redacts_secrets_and_summarizes_runtime(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
 
         await async_setup_config_entry(hass, ha_config_entry)
@@ -79,9 +80,11 @@ async def test_ha_diagnostics_redacts_secrets_and_summarizes_runtime(
 async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
 ) -> None:
     """Diagnostics should summarize stale and failed locations from real runtime."""
     from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -109,14 +112,17 @@ async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
         version=6,
     )
     entry.add_to_hass(hass)
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", lambda _entry_id: None
+    )
 
-    def _callback(url, **kwargs):
-        params = dict(kwargs.get("params") or parse_qsl(url.query_string))
+    def _callback(url, **_kwargs):
+        params = dict(parse_qsl(url.query_string))
         if float(params["location.latitude"]) == 41.3874:
             return CallbackResult(status=200, payload={"dailyInfo": []})
         return CallbackResult(status=200, payload=google_pollen_5_day_payload)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(POLLEN_API_URL_RE, callback=_callback, repeat=True)
         await async_setup_config_entry(hass, entry)
 
@@ -166,6 +172,7 @@ async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
 async def test_ha_diagnostics_registry_summary_uses_real_registries(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -197,7 +204,7 @@ async def test_ha_diagnostics_registry_summary_uses_real_registries(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -20,6 +20,7 @@ from tests.ha_helpers import (
 async def test_ha_setup_unload_reload_smoke(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
@@ -28,7 +29,7 @@ async def test_ha_setup_unload_reload_smoke(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
 
         await async_setup_config_entry(hass, ha_config_entry)

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
@@ -32,6 +32,7 @@ from tests.ha_helpers import (
 async def test_ha_platforms_create_entities_for_each_location_subentry(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -63,7 +64,7 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -92,6 +93,7 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
 async def test_ha_button_press_refreshes_location_coordinator(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
@@ -100,7 +102,7 @@ async def test_ha_button_press_refreshes_location_coordinator(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, ha_config_entry)
 
@@ -134,6 +136,7 @@ async def test_ha_button_press_refreshes_location_coordinator(
 async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
@@ -157,7 +160,7 @@ async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(
             config_subentry_id="location-madrid",
         )
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, ha_config_entry)
 

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -6,7 +6,7 @@ from types import MappingProxyType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
-from aioresponses import aioresponses
+from aiointercept import aiointercept
 from homeassistant.core import HomeAssistant
 
 from custom_components.pollenlevels.const import (
@@ -28,6 +28,7 @@ from tests.ha_helpers import (
 async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
@@ -36,7 +37,7 @@ async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
 
         await async_setup_config_entry(hass, ha_config_entry)
@@ -61,6 +62,7 @@ async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
 async def test_ha_force_update_skips_removed_subentry_without_reload(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -93,7 +95,7 @@ async def test_ha_force_update_skips_removed_subentry_without_reload(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -136,6 +138,7 @@ async def test_ha_force_update_skips_removed_subentry_without_reload(
 async def test_ha_force_update_refreshes_multiple_location_subentries(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -168,7 +171,7 @@ async def test_ha_force_update_refreshes_multiple_location_subentries(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 
@@ -193,6 +196,7 @@ async def test_ha_force_update_refreshes_multiple_location_subentries(
 async def test_ha_force_update_continues_after_one_location_failure(
     hass: HomeAssistant,
     enable_custom_integrations: None,
+    socket_enabled: None,
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
@@ -225,7 +229,7 @@ async def test_ha_force_update_continues_after_one_location_failure(
     )
     entry.add_to_hass(hass)
 
-    with aioresponses() as mocked:
+    async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
         await async_setup_config_entry(hass, entry)
 


### PR DESCRIPTION
## Summary

- Replace `aioresponses` test mocks with `aiointercept`.
- Allow `pytest-homeassistant-custom-component>=0.13.341` and its Home Assistant/aiohttp 3.14 dependency stack.
- Remove the incompatible `aioresponses` test dependency.
- Enable the Home Assistant harness socket fixture only for tests that start aiointercept's local test server.

## Validation

- `python -m pytest -q tests/` — 524 passed
- Focused Home Assistant tests — 24 passed
- `python -m ruff check --fix --select I`
- `python -m ruff check .`
- `python -m black .`
- `python -m black --check .`
- `python -m compileall -q sitecustomize.py custom_components tests`
- Hassfest and HACS validation were not available locally; the repository workflows will run them.

## Notes

- Tests-only change plus test dependency updates.
- Production integration code is untouched.
- v3 migration logic is untouched.
- Runtime behavior, unique IDs, translations, services, and diagnostics contracts are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Tests**
  * Migrated Home Assistant test HTTP mocking from `aioresponses` to `aiointercept` across setup, platform, service, diagnostics, and config flow test suites.
  * Updated related test fixtures/parameters (including socket handling) to match the new mocking behavior.
  * Refreshed test dependency versions in `requirements_test.txt` for compatibility.
  * Updated the `CHANGELOG.md` entry (RC2 date and added a note about the test harness migration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->