### PR TITLE
[codex] Fix persistent location Repair cleanup

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -40,6 +40,7 @@ from .issue_helpers import (
     create_location_setup_failed_issue,
     create_per_day_forecast_sensors_removed_issue,
     delete_entry_invalid_stored_location_issue,
+    delete_entry_location_issues,
     delete_invalid_stored_location_issue,
     delete_location_setup_failed_issue,
     delete_stale_location_subentry_issues,
@@ -669,3 +670,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unloaded:
         entry.runtime_data = None
     return unloaded
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Delete entry-owned location Repairs and retry bookkeeping."""
+    delete_entry_location_issues(hass, entry_id=entry.entry_id)
+    _prune_setup_retry_failures(hass, entry.entry_id, set())

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -15,6 +15,14 @@ LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
 _LOCATION_REPAIR_ISSUES_DATA_KEY = "location_repair_issue_ids"
 
 
+def _location_issue_prefixes(entry_id: str) -> tuple[str, str]:
+    """Return deterministic location Repair issue prefixes for an entry."""
+    return (
+        f"invalid_stored_location_{entry_id}_",
+        f"location_setup_failed_{entry_id}_",
+    )
+
+
 def _entry_location_issue_ids(hass: HomeAssistant, entry_id: str) -> set[str]:
     """Return location Repair issue ids owned by this runtime entry."""
     domain_data = hass.data.setdefault(DOMAIN, {})
@@ -29,6 +37,17 @@ def _known_entry_location_issue_ids(
     domain_data = hass.data.get(DOMAIN, {})
     issue_ids = domain_data.get(_LOCATION_REPAIR_ISSUES_DATA_KEY, {})
     return issue_ids.get(entry_id)
+
+
+def _registry_location_issue_ids(hass: HomeAssistant, entry_id: str) -> set[str]:
+    """Return location Repair issue ids persisted for an entry."""
+    prefixes = _location_issue_prefixes(entry_id)
+    registry = ir.async_get(hass)
+    return {
+        issue.issue_id
+        for issue in registry.issues.values()
+        if issue.domain == DOMAIN and issue.issue_id.startswith(prefixes)
+    }
 
 
 def _remember_location_issue(hass: HomeAssistant, entry_id: str, issue_id: str) -> None:
@@ -53,11 +72,7 @@ def _forget_location_issue(hass: HomeAssistant, entry_id: str, issue_id: str) ->
 
 def _subentry_id_from_location_issue_id(entry_id: str, issue_id: str) -> str | None:
     """Return the subentry id encoded in a known location Repair issue id."""
-    prefixes = (
-        f"invalid_stored_location_{entry_id}_",
-        f"location_setup_failed_{entry_id}_",
-    )
-    for prefix in prefixes:
+    for prefix in _location_issue_prefixes(entry_id):
         if issue_id.startswith(prefix):
             return issue_id.removeprefix(prefix) or None
     return None
@@ -124,19 +139,34 @@ def delete_stale_location_subentry_issues(
     *,
     entry_id: str,
     active_subentry_ids: Collection[str],
+    include_legacy: bool = False,
 ) -> None:
     """Delete location Repair issues for subentries no longer configured."""
     active_ids = set(active_subentry_ids)
-    entry_issue_ids = _known_entry_location_issue_ids(hass, entry_id)
+    legacy_issue_id = invalid_stored_location_issue_id(entry_id)
+    entry_issue_ids = set(_known_entry_location_issue_ids(hass, entry_id) or ())
+    entry_issue_ids.update(_registry_location_issue_ids(hass, entry_id))
     if not entry_issue_ids:
         return
 
     for issue_id in tuple(entry_issue_ids):
+        if not include_legacy and issue_id == legacy_issue_id:
+            continue
         subentry_id = _subentry_id_from_location_issue_id(entry_id, issue_id)
         if subentry_id is None or subentry_id in active_ids:
             continue
         ir.async_delete_issue(hass, DOMAIN, issue_id)
         _forget_location_issue(hass, entry_id, issue_id)
+
+
+def delete_entry_location_issues(hass: HomeAssistant, *, entry_id: str) -> None:
+    """Delete all location Repair issues owned by a config entry."""
+    delete_stale_location_subentry_issues(
+        hass,
+        entry_id=entry_id,
+        active_subentry_ids=(),
+        include_legacy=True,
+    )
 
 
 def create_location_setup_failed_issue(

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -297,15 +297,29 @@ def stub_update_coordinator_module(
     return module
 
 
+class StubIssueEntry(dict):
+    """Dictionary-compatible issue entry with Home Assistant attributes."""
+
+    def __init__(self, hass, domain, issue_id, **kwargs):
+        super().__init__(hass=hass, domain=domain, **kwargs)
+        self.domain = domain
+        self.issue_id = issue_id
+
+
 class StubIssueRegistry:
     """Minimal issue registry stub for inspecting Repair calls."""
 
     def __init__(self):
-        self.issues: dict[str, dict] = {}
+        self.issues: dict[str, StubIssueEntry] = {}
         self.deleted: list[tuple[object, str, str]] = []
 
     def async_create_issue(self, hass, domain, issue_id, **kwargs):
-        self.issues[issue_id] = {"hass": hass, "domain": domain, **kwargs}
+        self.issues[issue_id] = StubIssueEntry(
+            hass,
+            domain,
+            issue_id,
+            **kwargs,
+        )
 
     def async_delete_issue(self, hass, domain, issue_id):
         self.deleted.append((hass, domain, issue_id))
@@ -324,6 +338,7 @@ def stub_issue_registry_module(
     module = ModuleType("homeassistant.helpers.issue_registry")
     registry = StubIssueRegistry()
     module.registry = registry
+    module.async_get = lambda _hass: registry
     module.async_create_issue = registry.async_create_issue
     module.async_delete_issue = registry.async_delete_issue
     module.IssueSeverity = StubIssueSeverity

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -7,7 +7,7 @@ from typing import Any
 from aiointercept import aiointercept
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
@@ -15,6 +15,25 @@ from tests.ha_helpers import (
     async_setup_config_entry,
     mock_pollen_api,
 )
+
+
+def _create_test_repair(
+    hass: HomeAssistant,
+    domain: str,
+    issue_id: str,
+    *,
+    is_persistent: bool = True,
+) -> None:
+    """Create a minimal Repair issue for registry cleanup tests."""
+    ir.async_create_issue(
+        hass,
+        domain,
+        issue_id,
+        is_fixable=False,
+        is_persistent=is_persistent,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="location_setup_failed",
+    )
 
 
 async def test_ha_setup_unload_reload_smoke(
@@ -54,3 +73,112 @@ async def test_ha_setup_unload_reload_smoke(
         assert await hass.config_entries.async_setup(ha_config_entry.entry_id)
         await hass.async_block_till_done()
         assert ha_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_ha_stale_location_repairs_are_discovered_from_registry(
+    hass: HomeAssistant,
+) -> None:
+    """Stale Repairs should be deleted without runtime issue bookkeeping."""
+    clear_integration_modules()
+    from custom_components.pollenlevels.const import DOMAIN
+    from custom_components.pollenlevels.issue_helpers import (
+        delete_stale_location_subentry_issues,
+        invalid_stored_location_issue_id,
+        location_setup_failed_issue_id,
+    )
+
+    entry_id = "entry-target"
+    active_issue_id = location_setup_failed_issue_id(entry_id, "active-location")
+    stale_issue_id = location_setup_failed_issue_id(entry_id, "stale-location")
+    stale_invalid_issue_id = invalid_stored_location_issue_id(
+        entry_id, "stale-location"
+    )
+    legacy_issue_id = invalid_stored_location_issue_id(entry_id)
+    other_entry_issue_id = location_setup_failed_issue_id(
+        "entry-other", "stale-location"
+    )
+
+    _create_test_repair(hass, DOMAIN, active_issue_id)
+    _create_test_repair(hass, DOMAIN, stale_issue_id)
+    _create_test_repair(
+        hass,
+        DOMAIN,
+        stale_invalid_issue_id,
+        is_persistent=False,
+    )
+    _create_test_repair(hass, DOMAIN, legacy_issue_id, is_persistent=False)
+    _create_test_repair(hass, DOMAIN, other_entry_issue_id)
+    _create_test_repair(hass, "other_domain", stale_issue_id)
+
+    assert "location_repair_issue_ids" not in hass.data.get(DOMAIN, {})
+
+    delete_stale_location_subentry_issues(
+        hass,
+        entry_id=entry_id,
+        active_subentry_ids={"active-location"},
+    )
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, stale_issue_id) is None
+    assert registry.async_get_issue(DOMAIN, stale_invalid_issue_id) is None
+    assert registry.async_get_issue(DOMAIN, legacy_issue_id) is not None
+    assert registry.async_get_issue(DOMAIN, active_issue_id) is not None
+    assert registry.async_get_issue(DOMAIN, other_entry_issue_id) is not None
+    assert registry.async_get_issue("other_domain", stale_issue_id) is not None
+
+
+async def test_ha_remove_entry_clears_only_owned_location_repairs(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    ha_config_entry,
+) -> None:
+    """Removing a config entry should delete only its location Repairs."""
+    clear_integration_modules()
+    from custom_components.pollenlevels.const import DOMAIN
+    from custom_components.pollenlevels.issue_helpers import (
+        PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
+        invalid_stored_location_issue_id,
+        location_setup_failed_issue_id,
+    )
+
+    ha_config_entry.add_to_hass(hass)
+    entry_id = ha_config_entry.entry_id
+    setup_issue_id = location_setup_failed_issue_id(entry_id, "location-madrid")
+    invalid_issue_id = invalid_stored_location_issue_id(entry_id, "location-madrid")
+    legacy_issue_id = invalid_stored_location_issue_id(entry_id)
+    other_entry_issue_id = location_setup_failed_issue_id(
+        "entry-other", "location-madrid"
+    )
+
+    _create_test_repair(hass, DOMAIN, setup_issue_id)
+    _create_test_repair(hass, DOMAIN, invalid_issue_id, is_persistent=False)
+    _create_test_repair(hass, DOMAIN, legacy_issue_id, is_persistent=False)
+    _create_test_repair(hass, DOMAIN, other_entry_issue_id)
+    _create_test_repair(
+        hass,
+        DOMAIN,
+        PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
+    )
+    hass.data.setdefault(DOMAIN, {})["setup_retry_failures"] = {
+        entry_id: {"location-madrid"},
+        "entry-other": {"other-location"},
+    }
+
+    await hass.config_entries.async_remove(entry_id)
+    await hass.async_block_till_done()
+
+    registry = ir.async_get(hass)
+    assert registry.async_get_issue(DOMAIN, setup_issue_id) is None
+    assert registry.async_get_issue(DOMAIN, invalid_issue_id) is None
+    assert registry.async_get_issue(DOMAIN, legacy_issue_id) is None
+    assert registry.async_get_issue(DOMAIN, other_entry_issue_id) is not None
+    assert (
+        registry.async_get_issue(
+            DOMAIN,
+            PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
+        )
+        is not None
+    )
+    assert hass.data[DOMAIN]["setup_retry_failures"] == {
+        "entry-other": {"other-location"}
+    }


### PR DESCRIPTION
## Summary

- discover entry-owned location Repairs from Home Assistant's persistent issue registry as well as runtime bookkeeping
- preserve active subentry Repairs and the legacy entry-level invalid-location Repair during normal stale cleanup
- remove all entry-owned location Repairs and retry bookkeeping when the config entry is deleted
- extend the Home Assistant issue registry stub and add real harness regression coverage

## Root cause

`location_setup_failed` Repairs became persistent for RC2, but stale cleanup only consulted `hass.data`. That runtime index is lost on restart, so removing a location or the full config entry could leave an orphaned Repair. The integration also had no `async_remove_entry` hook.

## Impact

Persistent setup-failure Repairs are now cleared after a location is removed, including after restart, and when the owning config entry is deleted. Repairs from other domains, other config entries, active subentries, and unrelated global Repairs remain untouched.

## Validation

- `py -3.14 -m ruff check --fix --select I .`
- `py -3.14 -m ruff check .`
- `py -3.14 -m black custom_components/pollenlevels/issue_helpers.py custom_components/pollenlevels/__init__.py tests/_ha_stubs.py tests/test_ha_init.py`
- `py -3.14 -m compileall -q sitecustomize.py custom_components tests`
- `py -3.14 -m pytest -q tests/test_ha_init.py tests/test_init.py` — 82 passed
- `py -3.14 -m pytest tests/` — 526 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stale repair notifications for location issues are now cleaned up more reliably when entries change or are removed.
  * Removing a configuration entry now clears only the repair items that belong to it, while preserving unrelated issues.
  * Setup retry tracking is updated more accurately after entry removal, reducing leftover retry state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->