### PR TITLE
fix: align forecast retention with Google Pollen terms

### DIFF
--- a/custom_components/pollenlevels/const.py
+++ b/custom_components/pollenlevels/const.py
@@ -31,7 +31,7 @@ RESTRICTING_API_KEYS_URL = (
     "https://developers.google.com/maps/api-security-best-practices"
 )
 
-ATTRIBUTION = "Data provided by Google Maps Pollen API"
+ATTRIBUTION = "Google Maps — Source: Includes pollen data from Google"
 SUBENTRY_TYPE_LOCATION = "location"
 
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 _LOGGER = logging.getLogger(__name__)
-STALE_DATA_MIN_TTL = timedelta(hours=24)
+STALE_DATA_TTL = timedelta(hours=24)
 
 
 def _normalize_channel(v: Any) -> int | None:
@@ -220,11 +220,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         return dt_util.utcnow()
 
     def _stale_data_ttl(self) -> timedelta:
-        """Return how long successful data may be reused after malformed payloads."""
-        update_interval = self.update_interval
-        if update_interval is None:
-            return STALE_DATA_MIN_TTL
-        return max(STALE_DATA_MIN_TTL, update_interval * 2)
+        """Return the fixed maximum stale-data retention, currently 24 hours."""
+        return STALE_DATA_TTL
 
     def _has_fresh_cached_data(self) -> bool:
         """Return whether cached data is still within the stale-data tolerance."""

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -59,6 +59,24 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_FORECAST_UNRECORDED_ATTRIBUTES = frozenset(
+    {
+        "forecast",
+        "tomorrow_has_index",
+        "tomorrow_value",
+        "tomorrow_category",
+        "tomorrow_description",
+        "tomorrow_color_hex",
+        "d2_has_index",
+        "d2_value",
+        "d2_category",
+        "d2_description",
+        "d2_color_hex",
+        "trend",
+        "expected_peak",
+    }
+)
+
 __all__ = [
     "CONF_API_KEY",
     "CONF_LATITUDE",
@@ -255,6 +273,8 @@ async def async_setup_entry(
 class PollenSensor(CoordinatorEntity, SensorEntity):
     """Represent a pollen sensor for a type or plant."""
 
+    # Keep forecast attributes available in live state but exclude from Recorder.
+    _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
     # Enable long-term statistics for numeric pollen index values
     _attr_state_class = SensorStateClass.MEASUREMENT
     # Hint the UI to show integers (does not affect recorder/statistics)
@@ -484,6 +504,9 @@ class PlantsInSeasonTodaySensor(_BaseSummarySensor):
 class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     """Represent the highest current-day pollen type value."""
 
+    # Keep aggregated forecast attributes available in live state but exclude
+    # from Recorder persistence.
+    _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
     _attr_translation_key = "overall_pollen_risk_today"
     _attr_icon = DEFAULT_ICON
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -59,23 +59,23 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
-_FORECAST_UNRECORDED_ATTRIBUTES = frozenset(
-    {
-        "forecast",
-        "tomorrow_has_index",
-        "tomorrow_value",
-        "tomorrow_category",
-        "tomorrow_description",
-        "tomorrow_color_hex",
-        "d2_has_index",
-        "d2_value",
-        "d2_category",
-        "d2_description",
-        "d2_color_hex",
-        "trend",
-        "expected_peak",
-    }
+_FORECAST_ATTRIBUTE_NAMES = (
+    "forecast",
+    "tomorrow_has_index",
+    "tomorrow_value",
+    "tomorrow_category",
+    "tomorrow_description",
+    "tomorrow_color_hex",
+    "d2_has_index",
+    "d2_value",
+    "d2_category",
+    "d2_description",
+    "d2_color_hex",
+    "trend",
+    "expected_peak",
 )
+
+_FORECAST_UNRECORDED_ATTRIBUTES = frozenset(_FORECAST_ATTRIBUTE_NAMES)
 
 __all__ = [
     "CONF_API_KEY",
@@ -348,24 +348,9 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
         # - For PLANT sensors: include as attributes (no per-day plant sensors)
         if info.get("source") == "type":
             if include_forecast:
-                # Add forecast attributes only when forecast is enabled.
-                for k in (
-                    "forecast",
-                    "tomorrow_has_index",
-                    "tomorrow_value",
-                    "tomorrow_category",
-                    "tomorrow_description",
-                    "tomorrow_color_hex",
-                    "d2_has_index",
-                    "d2_value",
-                    "d2_category",
-                    "d2_description",
-                    "d2_color_hex",
-                    "trend",
-                    "expected_peak",
-                ):
-                    if info.get(k) is not None:
-                        attrs[k] = info.get(k)
+                for key in _FORECAST_ATTRIBUTE_NAMES:
+                    if info.get(key) is not None:
+                        attrs[key] = info.get(key)
 
         if info.get("source") == "plant":
             # Plant-specific metadata
@@ -384,23 +369,9 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
 
             # Plant forecast attributes (attributes-only, no per-day plant sensors)
             if include_forecast:
-                for k in (
-                    "forecast",
-                    "tomorrow_has_index",
-                    "tomorrow_value",
-                    "tomorrow_category",
-                    "tomorrow_description",
-                    "tomorrow_color_hex",
-                    "d2_has_index",
-                    "d2_value",
-                    "d2_category",
-                    "d2_description",
-                    "d2_color_hex",
-                    "trend",
-                    "expected_peak",
-                ):
-                    if info.get(k) is not None:
-                        attrs[k] = info.get(k)
+                for key in _FORECAST_ATTRIBUTE_NAMES:
+                    if info.get(key) is not None:
+                        attrs[key] = info.get(key)
 
         return attrs
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -519,6 +519,59 @@ def test_sensor_unique_ids_survive_subentry_title_and_coordinate_changes(
     )
 
 
+def test_pollen_sensor_unrecorded_forecast_attributes(
+    sensor_modules: SensorModules,
+) -> None:
+    """PollenSensor marks forecast-derived attributes as unrecorded."""
+
+    coordinator = _summary_coordinator({"type_grass": {"source": "type"}})
+    entity = sensor_modules.sensor.PollenSensor(coordinator, "type_grass")
+
+    expected = sensor_modules.sensor._FORECAST_UNRECORDED_ATTRIBUTES
+    assert entity._unrecorded_attributes == expected
+
+    current_day_attrs = {
+        "category",
+        "description",
+        "inSeason",
+        "advice",
+        "color_hex",
+        "color_rgb",
+        "family",
+        "season",
+        "cross_reaction",
+        "Attribution",
+    }
+    assert current_day_attrs.isdisjoint(expected)
+
+
+def test_overall_risk_sensor_unrecorded_forecast_attributes(
+    sensor_modules: SensorModules,
+) -> None:
+    """OverallPollenRiskTodaySensor marks forecast-derived attributes as unrecorded."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 3},
+        }
+    )
+    entity = sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator)
+
+    expected = sensor_modules.sensor._FORECAST_UNRECORDED_ATTRIBUTES
+    assert entity._unrecorded_attributes == expected
+
+    current_day_attrs = {
+        "category",
+        "description",
+        "top_pollen_codes",
+        "top_pollen_names",
+        "top_pollen_categories",
+        "tie_count",
+        "Attribution",
+    }
+    assert current_day_attrs.isdisjoint(expected)
+
+
 def test_pollen_sensor_forecast_attributes_do_not_require_coordinator_field(
     sensor_modules: SensorModules,
 ) -> None:
@@ -871,10 +924,43 @@ def test_summary_sensors_expose_attribution(sensor_modules: SensorModules) -> No
         sensor_modules.sensor.TopPollenTypesTodaySensor(coordinator),
     ]
 
-    assert all(
+    for entity in entities:
+        assert (
+            entity.extra_state_attributes["Attribution"]
+            == sensor_modules.sensor.ATTRIBUTION
+        )
+
+
+@pytest.mark.parametrize(
+    "entity_factory",
+    [
+        lambda sensor_modules, coordinator: sensor_modules.sensor.PollenSensor(
+            coordinator, "type_grass"
+        ),
+        lambda sensor_modules, coordinator: sensor_modules.sensor.OverallPollenRiskTodaySensor(
+            coordinator
+        ),
+        lambda sensor_modules, coordinator: sensor_modules.sensor.RegionSensor(
+            coordinator
+        ),
+    ],
+)
+def test_attribution_exact_value(
+    sensor_modules: SensorModules,
+    entity_factory: Any,
+) -> None:
+    """Attribution contains the exact required Google Maps pollen attribution text."""
+
+    coordinator = _summary_coordinator(
+        {
+            "type_grass": {"source": "type", "displayName": "Grass", "value": 3},
+        }
+    )
+    entity = entity_factory(sensor_modules, coordinator)
+
+    assert (
         entity.extra_state_attributes["Attribution"]
-        == sensor_modules.sensor.ATTRIBUTION
-        for entity in entities
+        == "Google Maps \u2014 Source: Includes pollen data from Google"
     )
 
 
@@ -1315,10 +1401,40 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
     assert coordinator.data == first_data
 
 
-def test_coordinator_stale_data_ttl_accounts_for_update_interval(
+def test_coordinator_stale_cached_data_accepted_at_exactly_24_hours(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached data at exactly the 24-hour TTL boundary is still accepted."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload()),
+            ResponseSpec(status=200, payload={}),
+        ]
+    )
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client, hours=6)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        now = start + datetime.timedelta(hours=24)
+        second_data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert second_data == first_data
+
+
+def test_coordinator_stale_data_ttl_is_fixed_24_hours(
     sensor_modules: SensorModules,
 ) -> None:
-    """Effective stale-data TTL uses the larger of 24h and twice the interval."""
+    """Effective stale-data TTL is a fixed 24 hours regardless of update interval."""
 
     loop = asyncio.new_event_loop()
     hass = DummyHass(loop)
@@ -1349,7 +1465,7 @@ def test_coordinator_stale_data_ttl_accounts_for_update_interval(
         loop.close()
 
     assert six_hour._stale_data_ttl() == datetime.timedelta(hours=24)
-    assert twenty_four_hour._stale_data_ttl() == datetime.timedelta(hours=48)
+    assert twenty_four_hour._stale_data_ttl() == datetime.timedelta(hours=24)
 
 
 def test_coordinator_success_after_malformed_response_updates_last_updated(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -540,9 +540,20 @@ def test_pollen_sensor_unrecorded_forecast_attributes(
         "family",
         "season",
         "cross_reaction",
-        "Attribution",
+        sensor_modules.sensor.ATTR_ATTRIBUTION,
     }
     assert current_day_attrs.isdisjoint(expected)
+
+
+def test_forecast_attribute_names_derive_unrecorded_set(
+    sensor_modules: SensorModules,
+) -> None:
+    """The unrecorded set is derived from the ordered attribute name tuple."""
+
+    assert (
+        frozenset(sensor_modules.sensor._FORECAST_ATTRIBUTE_NAMES)
+        == sensor_modules.sensor._FORECAST_UNRECORDED_ATTRIBUTES
+    )
 
 
 def test_overall_risk_sensor_unrecorded_forecast_attributes(
@@ -567,7 +578,7 @@ def test_overall_risk_sensor_unrecorded_forecast_attributes(
         "top_pollen_names",
         "top_pollen_categories",
         "tie_count",
-        "Attribution",
+        sensor_modules.sensor.ATTR_ATTRIBUTION,
     }
     assert current_day_attrs.isdisjoint(expected)
 
@@ -926,7 +937,7 @@ def test_summary_sensors_expose_attribution(sensor_modules: SensorModules) -> No
 
     for entity in entities:
         assert (
-            entity.extra_state_attributes["Attribution"]
+            entity.extra_state_attributes[sensor_modules.sensor.ATTR_ATTRIBUTION]
             == sensor_modules.sensor.ATTRIBUTION
         )
 
@@ -959,7 +970,7 @@ def test_attribution_exact_value(
     entity = entity_factory(sensor_modules, coordinator)
 
     assert (
-        entity.extra_state_attributes["Attribution"]
+        entity.extra_state_attributes[sensor_modules.sensor.ATTR_ATTRIBUTION]
         == "Google Maps \u2014 Source: Includes pollen data from Google"
     )
 


### PR DESCRIPTION
## Summary

Aligns Pollen Levels forecast handling and visible attribution with the current Google Maps Pollen API requirements applicable to EEA billing accounts.

### Changes

- Keep forecast attributes available in live Home Assistant entity state while excluding them from Recorder persistence.
- Apply the Recorder exclusion to pollen type, plant, and aggregated overall-risk forecast attributes.
- Limit stale API payload reuse to a maximum of 24 hours.
- Update entity attribution to identify Google Maps and include the required pollen data source text.
- Add focused regression coverage for live forecast attributes, Recorder exclusions, stale-cache expiry, and attribution.

### Safety

- No migration changes.
- No entity ID changes.
- No unique ID changes.
- No device identifier changes.
- No sensor additions or removals.
- No forecast payload or offset changes.
- No API request horizon changes.
- No service/action changes.
- No translation changes.
- No version or release metadata changes.
- No README, FAQ, CHANGELOG, or workflow changes.

## Validation

- `python -m compileall -q sitecustomize.py custom_components tests`
- `ruff check .`
- `black --check .`
- `python -m pytest -q tests/test_sensor.py tests/test_metadata.py`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached pollen data is retained for up to 24 hours, including exactly at the expiration boundary.
  * Forecast-related details remain visible, but they’re no longer written to long-term recorder history.

* **Updates**
  * Refreshed the displayed Google Maps pollen data attribution text across pollen sensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->