### PR TITLE
fix: report force_update coordinator failures

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -295,6 +295,53 @@ def _schedule_parent_reload(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 # ---- Service -------------------------------------------------------------
 
 
+def _log_force_update_failure(
+    entry: ConfigEntry,
+    subentry_id: str,
+    coordinator: Any,
+    result: BaseException | None,
+) -> None:
+    """Log one redacted force_update location failure."""
+    api_key = (entry.data or {}).get(CONF_API_KEY)
+    latitude = getattr(
+        coordinator,
+        "lat",
+        (entry.data or {}).get(CONF_LATITUDE),
+    )
+    longitude = getattr(
+        coordinator,
+        "lon",
+        (entry.data or {}).get(CONF_LONGITUDE),
+    )
+    if result is not None:
+        safe_message = redact_sensitive_values(
+            result,
+            api_key=api_key,
+            latitude=latitude,
+            longitude=longitude,
+        )
+        error_type = type(result).__name__
+    else:
+        safe_message = "coordinator reported an unsuccessful update"
+        error_type = "UpdateFailed"
+    safe_text = safe_message or "no error details"
+    if subentry_id == entry.entry_id:
+        _LOGGER.warning(
+            "Manual refresh failed for entry %s (%s): %s",
+            entry.entry_id,
+            error_type,
+            safe_text,
+        )
+    else:
+        _LOGGER.warning(
+            "Manual refresh failed for entry %s subentry %s (%s): %s",
+            entry.entry_id,
+            subentry_id,
+            error_type,
+            safe_text,
+        )
+
+
 async def _refresh_force_update_target(
     entry: ConfigEntry, subentry_id: str, coordinator: Any
 ) -> None:
@@ -309,36 +356,15 @@ async def _refresh_force_update_target(
         )
         raise
     except Exception as result:  # noqa: BLE001
-        api_key = (entry.data or {}).get(CONF_API_KEY)
-        safe_message = redact_sensitive_values(
-            result,
-            api_key=api_key,
-            latitude=getattr(
-                coordinator,
-                "lat",
-                (entry.data or {}).get(CONF_LATITUDE),
-            ),
-            longitude=getattr(
-                coordinator,
-                "lon",
-                (entry.data or {}).get(CONF_LONGITUDE),
-            ),
-        )
-        if subentry_id == entry.entry_id:
-            _LOGGER.warning(
-                "Manual refresh failed for entry %s (%s): %s",
-                entry.entry_id,
-                type(result).__name__,
-                safe_message or "no error details",
-            )
-        else:
-            _LOGGER.warning(
-                "Manual refresh failed for entry %s subentry %s (%s): %s",
-                entry.entry_id,
-                subentry_id,
-                type(result).__name__,
-                safe_message or "no error details",
-            )
+        _log_force_update_failure(entry, subentry_id, coordinator, result)
+        return
+
+    if getattr(coordinator, "last_update_success", True) is not False:
+        return
+    last_exception = getattr(coordinator, "last_exception", None)
+    if not isinstance(last_exception, BaseException):
+        last_exception = None
+    _log_force_update_failure(entry, subentry_id, coordinator, last_exception)
 
 
 async def _refresh_force_update_targets(

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -407,9 +407,7 @@ async def test_ha_force_update_failure_log_redacts_secrets(
     secret_lat = 12.345678
     secret_lon = -98.765432
 
-    hass.config_entries.async_update_entry(
-        entry, data={CONF_API_KEY: secret_key}
-    )
+    hass.config_entries.async_update_entry(entry, data={CONF_API_KEY: secret_key})
     await hass.async_block_till_done()
 
     orig_lat = coord.lat

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from types import MappingProxyType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -31,6 +32,7 @@ async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
     socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
+    caplog,
     monkeypatch,
 ) -> None:
     """force_update should refresh active subentries and skip stale runtimes."""
@@ -52,11 +54,13 @@ async def test_ha_force_update_refreshes_active_locations_and_skips_stale(
             coordinator=SimpleNamespace(async_request_refresh=stale_refresh),
         )
 
+        caplog.set_level(logging.WARNING)
         await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
         await hass.async_block_till_done()
 
     active_refresh.assert_awaited_once()
     stale_refresh.assert_not_awaited()
+    assert "Manual refresh failed" not in caplog.text
 
 
 async def test_ha_force_update_skips_removed_subentry_without_reload(
@@ -283,3 +287,149 @@ async def test_ha_force_update_parent_without_locations_is_noop(
 
     await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
     await hass.async_block_till_done()
+
+
+async def test_ha_force_update_reports_absorbed_coordinator_failure_and_continues(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+    caplog,
+    monkeypatch,
+) -> None:
+    """force_update reports coordinator-absorbed UpdateFailed and continues."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[
+            sample_location_subentry_data,
+            location_subentry_data(
+                subentry_id="location-barcelona",
+                title="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+        locations = entry.runtime_data.locations
+        failing_coord = locations["location-madrid"].coordinator
+        healthy_coord = locations["location-barcelona"].coordinator
+
+        healthy_data = healthy_coord.data
+
+        failing_update = AsyncMock(
+            side_effect=UpdateFailed("synthetic pollen refresh failure")
+        )
+        healthy_update = AsyncMock(return_value=healthy_data)
+
+        monkeypatch.setattr(failing_coord, "_async_update_data", failing_update)
+        monkeypatch.setattr(healthy_coord, "_async_update_data", healthy_update)
+
+        caplog.set_level(logging.WARNING)
+
+        await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    failing_update.assert_awaited_once()
+    healthy_update.assert_awaited_once()
+
+    assert failing_coord.last_update_success is False
+    assert isinstance(failing_coord.last_exception, UpdateFailed)
+
+    assert healthy_coord.last_update_success is not False
+    assert healthy_coord.last_exception is None
+
+    log_text = caplog.text
+    assert "pollenlevels-entry" in log_text
+    assert "location-madrid" in log_text
+    assert "UpdateFailed" in log_text
+    assert "synthetic" in log_text
+
+
+async def test_ha_force_update_failure_log_redacts_secrets(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+    caplog,
+) -> None:
+    """_log_force_update_failure redacts API keys and coordinates."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        unique_id=api_key_unique_id(fake_api_key),
+        subentries_data=[sample_location_subentry_data],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+    coord = entry.runtime_data.locations["location-madrid"].coordinator
+    assert coord is not None
+
+    import custom_components.pollenlevels as integration_mod
+
+    secret_key = "sk-secret-12345"
+    secret_lat = 12.345678
+    secret_lon = -98.765432
+
+    hass.config_entries.async_update_entry(
+        entry, data={CONF_API_KEY: secret_key}
+    )
+    await hass.async_block_till_done()
+
+    orig_lat = coord.lat
+    orig_lon = coord.lon
+    coord.lat = secret_lat
+    coord.lon = secret_lon
+
+    caplog.set_level(logging.WARNING)
+    integration_mod._log_force_update_failure(
+        entry,
+        "location-madrid",
+        coord,
+        RuntimeError("boom: key=sk-secret-12345 lat=12.345678 lon=-98.765432"),
+    )
+
+    coord.lat = orig_lat
+    coord.lon = orig_lon
+
+    log_text = caplog.text
+    assert "sk-secret-12345" not in log_text
+    assert "12.345678" not in log_text
+    assert "-98.765432" not in log_text
+    assert "boom" in log_text


### PR DESCRIPTION
## Summary

Reports per-location failures from the global `pollenlevels.force_update` action when Home Assistant's `DataUpdateCoordinator` handles `UpdateFailed` internally.

### Changes

- Detect refresh failures through `last_update_success` after `async_request_refresh()` returns.
- Use `last_exception` for privacy-safe per-location failure reporting.
- Preserve direct exception and cancellation handling.
- Continue refreshing healthy locations when another location fails.
- Add Home Assistant harness coverage for coordinator-absorbed `UpdateFailed`.

### Safety

- No migration changes.
- No entity ID, unique ID, or device identifier changes.
- No entity additions or removals.
- No service name or schema changes.
- No stale-runtime filtering changes.
- No refresh concurrency changes.
- No Repair changes.
- No translation changes.
- No documentation or release metadata changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual refresh handling when a location update fails.
  * Refreshes for other active locations now continue even if one location encounters an error.
  * Added clearer warning logs for failed refreshes, including the affected location and error details.
  * Sensitive credentials and location data are now protected in refresh failure messages.
  * Avoided reporting failures when refreshes complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->