### PR TITLE
chore(tooling): replace Black with Ruff formatter

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -71,10 +71,10 @@ reviews:
   path_instructions:
     - path: "**/*.py"
       instructions: |
-        This repository targets Python 3.14+ and CI formats with Black using
-        target-version py314. Black 26+ may format multi-exception handlers as
-        `except A, B:`. Treat that syntax as valid for this repository; do not
-        flag it as a SyntaxError or request `except (A, B):` unless CI fails.
+        This repository targets Python 3.14+. Ruff is the formatter, targets
+        py314, and has preview formatting disabled. Python 3.14 unparenthesized
+        multi-exception handler syntax such as `except A, B:` must not be
+        flagged solely because older Python versions reject it.
 
     - path: "custom_components/pollenlevels/**/*.py"
       instructions: |
@@ -174,7 +174,7 @@ reviews:
         - actions are pinned to versioned major tags.
         - setup-python uses python-version "3.14" unless intentionally changed.
         - shell: bash is present when using set -euo pipefail.
-        - ruff check and black --check fail the job on issues.
+        - ruff check and ruff format --check fail the job on issues.
         - YAML syntax is valid.
         - No placeholders, TODOs, or empty keys.
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,12 +40,20 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: Install Ruff
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install --upgrade "ruff>=0.15"
           ruff --version
 
       - name: Ruff lint
-        run: ruff check .
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruff check .
 
       - name: Ruff format
-        run: ruff format --check .
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruff format --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,12 +39,13 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Install linters
+      - name: Install Ruff
         run: |
-          python -m pip install --upgrade "black>=26" "ruff>=0.15"
+          python -m pip install --upgrade "ruff>=0.15"
+          ruff --version
 
-      - name: Ruff (check only)
+      - name: Ruff lint
         run: ruff check .
 
-      - name: Black (check only)
-        run: black --check .
+      - name: Ruff format
+        run: ruff format --check .

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=26" "ruff>=0.15" "pytest>=9"
+          python -m pip install --upgrade "ruff>=0.15" "pytest>=9"
           python -m pip install -r requirements_test.txt
+          ruff --version
 
       - name: Compile Python sources
         shell: bash
@@ -49,11 +50,11 @@ jobs:
           set -euo pipefail
           ruff check .
 
-      - name: Black validation
+      - name: Ruff format validation
         shell: bash
         run: |
           set -euo pipefail
-          black --check .
+          ruff format --check .
 
       - name: Run tests
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,9 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install --upgrade "black>=26" "ruff>=0.15" "pytest>=9"
+          python -m pip install --upgrade "ruff>=0.15" "pytest>=9"
           python -m pip install -r requirements_test.txt
+          ruff --version
 
       - name: Compile Python sources
         shell: bash
@@ -48,11 +49,11 @@ jobs:
           set -euo pipefail
           ruff check .
 
-      - name: Black validation
+      - name: Ruff format validation
         shell: bash
         run: |
           set -euo pipefail
-          black --check .
+          ruff format --check .
 
       - name: Run tests
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,9 @@
 
 ## Tooling
 - Tooling (CI, lint, format) runs on **Python 3.14**. The `pyproject.toml` targets packaging/tooling and also pins `requires-python = ">=3.14"`. All code under `custom_components/pollenlevels/` targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
-- Format code with Black (line length 88, target-version `py314`) with minimum `black>=26` (enforced via CI; version pin not stored in `pyproject.toml`).
-- Black 26+ may format multi-exception handlers as `except A, B:` for Python 3.14; keep the formatter output unless CI changes.
-- Lint and sort imports with Ruff targeting `py314`, with minimum `ruff>=0.15` (enforced via CI), matching the configuration in `pyproject.toml`.
-- Every change must pass `ruff check --fix --select I` (for import order) and `ruff check` before submission.
-- Run `black .` (or the narrowest possible path) to ensure formatting.
+- Ruff is the single tool for linting, import sorting, and formatting. CI uses the rolling minimum `ruff>=0.15`, and `pyproject.toml` uses Ruff's `required-version` to reject older versions without pinning an exact release.
+- Ruff targets `py314`, line length 88, and stable formatting with preview disabled. Python 3.14 syntax must not be reported as invalid merely because it is unsupported by older Python versions.
+- Future stable Ruff versions may require mechanical formatting updates; this is intentional under the rolling tooling policy.
 - Tests run with pytest>=9 on Python 3.14.
 - Home Assistant integration-surface tests should use
   `pytest-homeassistant-custom-component` when practical, especially for config
@@ -63,6 +61,9 @@
 ## Verification
 - Ensure the integration still loads within Home Assistant with the existing config flows and maintains parity with the current logic paths for entity updates and notifications.
 - Before submitting changes, run the following checks:
-  - `ruff check --fix --select I && ruff check` — lint and import ordering.
-  - `black .` — code formatting.
-  - `pytest tests/` — unit and Home Assistant harness tests.
+  - `python -m pip install --upgrade "ruff>=0.15"`
+  - `ruff check --fix --select I .`
+  - `ruff check .`
+  - `ruff format .`
+  - `ruff format --check .`
+  - `python -m pytest -q`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 - The integration targets Python 3.14+, matching the Home Assistant 2026.3 runtime baseline.
   Use Python 3.14 for local development and CI parity.
-- Format code with Black (line length 88, target-version `py314`) and sort/lint imports with Ruff (`ruff check --fix --select I` followed
-  by `ruff check`).
+- Ruff handles linting, import ordering, and formatting. Upgrade Ruff before validating to match CI's rolling minimum policy: `python -m pip install --upgrade "ruff>=0.15"`.
+- Tooling targets Python 3.14 with line length 88, and Ruff preview formatting is disabled.
 - The translation source of truth is `custom_components/pollenlevels/translations/en.json`. Keep every other locale file in
   sync with it.
 - Do not add or rely on a `strings.json` file; translation updates should flow from `en.json` to the other language files.
@@ -16,6 +16,8 @@
   parsing, API client behavior, redaction helpers, malformed payloads, and
   targeted failure injection.
 - Before submitting changes, run:
-  - `ruff check --fix --select I && ruff check` — lint and import ordering.
-  - `black .` — code formatting.
-  - `pytest tests/` — unit and Home Assistant harness tests.
+  - `ruff check --fix --select I .`
+  - `ruff check .`
+  - `ruff format .`
+  - `ruff format --check .`
+  - `python -m pytest -q`

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -253,7 +253,7 @@ class GooglePollenApiClient:
                         attempt=attempt,
                         max_retries=max_retries,
                         message=(
-                            "Pollen API timeout — retrying in %.2fs " "(attempt %d/%d)"
+                            "Pollen API timeout — retrying in %.2fs (attempt %d/%d)"
                         ),
                     )
                     continue

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -56,7 +56,7 @@ def _rgb_from_api(color: dict[str, Any] | None) -> tuple[int, int, int] | None:
     Rules:
     - If color is not a dict, or an empty dict, return None
       (meaning "no color provided by API").
-    - If only some channels are present, missing ones are treated as 0 (black baseline)
+    - If only some channels are present, missing ones are treated as 0 (zero baseline)
       but ONLY when at least one channel exists. This preserves partial colors like
       {green, blue} without inventing a color for {}.
     """

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -56,7 +56,7 @@ def _rgb_from_api(color: dict[str, Any] | None) -> tuple[int, int, int] | None:
     Rules:
     - If color is not a dict, or an empty dict, return None
       (meaning "no color provided by API").
-    - If only some channels are present, missing ones are treated as 0 (zero baseline)
+    - If only some channels are present, missing ones are treated as 0 (black baseline)
       but ONLY when at least one channel exists. This preserves partial colors like
       {green, blue} without inventing a color for {}.
     """

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -197,12 +197,13 @@ async def async_setup_entry(
     legacy_entities_found = False
     for location in runtime.locations.values():
         identity_id = coordinator_identity_id(location.coordinator)
-        found_legacy_entities, _removed_legacy_entities = (
-            await _remove_legacy_per_day_entities(
-                hass,
-                config_entry.entry_id,
-                identity_id,
-            )
+        (
+            found_legacy_entities,
+            _removed_legacy_entities,
+        ) = await _remove_legacy_per_day_entities(
+            hass,
+            config_entry.entry_id,
+            identity_id,
         )
         legacy_entities_found = legacy_entities_found or found_legacy_entities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 # Tooling aligned to the Home Assistant Python floor (>=3.14.0).
-# NOTE: We purposely DO NOT set [tool.black].required-version; CI installs
-# Black/Ruff from minimum supported versions to keep tooling forward-compatible.
-# Minimums: black>=26, ruff>=0.15 (set in CI workflows).
-# If you ever need an exact lock, set both:
-#   - pyproject: required-version = "<desired black version>"
-#   - CI: pip install "black==<desired black version>" "ruff==<desired ruff version>"
+# CI installs Ruff from the rolling minimum version, while required-version
+# rejects older local versions and allows future compatible stable releases.
 
 [project]
 name = "pollenlevels"
@@ -12,24 +8,28 @@ version = "3.0.0rc2"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 
-[tool.black]
-line-length = 88
-# Black supports py314; keep a single target since the project requires 3.14+.
-target-version = ["py314"]
-# Do NOT set required-version here to stay compatible with CI's rolling installs.
-
 [tool.ruff]
+required-version = ">=0.15"
 line-length = 88
 # Match runtime: Python 3.14
 target-version = "py314"
+preview = false
 # Do not set a default global 'fix' here; workflows control fixing with CLI flags.
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false
+preview = false
 
 [tool.ruff.lint]
 # Core rule sets: pycodestyle/pyflakes/isort/pyupgrade/bugbear
 select = ["E", "F", "W", "I", "UP", "B"]
 ignore = [
-  "E203", # Whitespace before ':' (conflicts with Black on slicing)
-  "E501", # Line length (Black handles wrapping)
+  "E203", # Whitespace before ':' in slicing
+  "E501", # Line length (Ruff formatter handles wrapping)
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1815,8 +1815,7 @@ def test_validate_input_unexpected_exception_sets_unknown(
 
     def _raise_session(hass):
         raise RuntimeError(
-            "boom test-key at location.latitude=48.8566123 "
-            "location.longitude=2.3522456"
+            "boom test-key at location.latitude=48.8566123 location.longitude=2.3522456"
         )
 
     monkeypatch.setattr(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -115,7 +115,7 @@ def test_safe_setup_failure_text_redacts_secrets_and_coordinates(
     """Setup failure text should not expose API keys or exact coordinates."""
     integration = integration_modules.integration
     reason = RuntimeError(
-        "boom secret-key at location.latitude=1.234567 " "location.longitude=2.345678"
+        "boom secret-key at location.latitude=1.234567 location.longitude=2.345678"
     )
 
     redacted = integration._safe_setup_failure_text(
@@ -764,8 +764,7 @@ def test_setup_entry_loads_healthy_subentries_when_one_subentry_fails(
         async def async_config_entry_first_refresh(self):
             if self.subentry_id == "bad-location":
                 raise RuntimeError(
-                    "boom secret-key at 3.123456,-4.654321 "
-                    "location.latitude=3.123456"
+                    "boom secret-key at 3.123456,-4.654321 location.latitude=3.123456"
                 )
             return None
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -35,9 +35,9 @@ def test_manifest_version_matches_pyproject() -> None:
     project = _load_pyproject().get("project", {})
     manifest = _load_manifest()
 
-    assert manifest.get("version") == project.get(
-        "version"
-    ), "Manifest version must match pyproject version"
+    assert manifest.get("version") == project.get("version"), (
+        "Manifest version must match pyproject version"
+    )
 
 
 def test_pyproject_requires_python_is_314_plus() -> None:
@@ -45,6 +45,6 @@ def test_pyproject_requires_python_is_314_plus() -> None:
     project = _load_pyproject().get("project", {})
     requires = project.get("requires-python")
 
-    assert isinstance(requires, str) and requires.startswith(
-        ">=3.14"
-    ), "requires-python must stay aligned with the 3.14+ tooling story"
+    assert isinstance(requires, str) and requires.startswith(">=3.14"), (
+        "requires-python must stay aligned with the 3.14+ tooling story"
+    )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -948,8 +948,8 @@ def test_summary_sensors_expose_attribution(sensor_modules: SensorModules) -> No
         lambda sensor_modules, coordinator: sensor_modules.sensor.PollenSensor(
             coordinator, "type_grass"
         ),
-        lambda sensor_modules, coordinator: sensor_modules.sensor.OverallPollenRiskTodaySensor(
-            coordinator
+        lambda sensor_modules, coordinator: (
+            sensor_modules.sensor.OverallPollenRiskTodaySensor(coordinator)
         ),
         lambda sensor_modules, coordinator: sensor_modules.sensor.RegionSensor(
             coordinator

--- a/tests/test_stub_hygiene.py
+++ b/tests/test_stub_hygiene.py
@@ -185,8 +185,7 @@ def test_tests_do_not_install_shared_stubs_at_import_time() -> None:
         for line_number, reason in visitor.violations:
             offending_source = source_lines[line_number - 1].strip()
             violations.append(
-                f"{path.relative_to(ROOT)}:{line_number}: {reason}: "
-                f"{offending_source}"
+                f"{path.relative_to(ROOT)}:{line_number}: {reason}: {offending_source}"
             )
 
     assert not violations, "\n".join(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -490,9 +490,9 @@ def test_sensor_translation_keys_present() -> None:
         if tkey not in english:
             missing.append(tkey)
 
-    assert (
-        not missing
-    ), "Missing sensor/device translation keys in en.json: " + ", ".join(missing)
+    assert not missing, (
+        "Missing sensor/device translation keys in en.json: " + ", ".join(missing)
+    )
 
 
 def test_services_translation_keys_present() -> None:
@@ -532,9 +532,9 @@ def test_services_yaml_labels_match_translations() -> None:
             if value is None:
                 continue
             expected = translations.get(key)
-            assert (
-                value == expected
-            ), f"Service {service_name} {key} mismatch: {value!r} != {expected!r}"
+            assert value == expected, (
+                f"Service {service_name} {key} mismatch: {value!r} != {expected!r}"
+            )
 
 
 def test_issues_invalid_stored_location_keys_present() -> None:


### PR DESCRIPTION
## Summary

Replaces Black with Ruff formatter so Ruff provides the repository's linting, import-ordering, and formatting toolchain.

### Changes

- Remove Black configuration and CI installation.
- Add Ruff formatter validation to lint, package, and release workflows.
- Keep a rolling `ruff>=0.15` minimum instead of an exact version pin.
- Enforce the minimum locally through Ruff's `required-version`.
- Keep Python 3.14, line length 88, and stable non-preview formatting.
- Update contributor, agent, and CodeRabbit guidance.
- Establish a Ruff-formatted repository baseline where required.

### Tooling policy

CI deliberately installs the latest available Ruff version satisfying `ruff>=0.15`.

This keeps the project forward-compatible with stable Ruff improvements. Future stable formatting changes may require mechanical formatting updates.

### Safety

- No runtime behavior changes.
- No migration changes.
- No entity ID, unique ID, or device identifier changes.
- No service changes.
- No translation changes.
- No release metadata changes.
- No CHANGELOG changes.

## Validation

- `python -m compileall -q sitecustomize.py custom_components tests`
- `ruff --version`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced Black with Ruff for formatting and lint validation across automated checks.
  * Updated project tooling configuration and contributor guidance for Python 3.14+ and Ruff 0.15+.

* **Bug Fixes**
  * Corrected spacing in API error messages and related validation expectations.

* **Tests**
  * Updated formatting and assertions across the test suite while preserving existing coverage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->