### PR TITLE
docs: add Google Maps terms and privacy notices

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # ❓ Frequently Asked Questions (FAQ)
 
-*Last verified: 2026-06-12 (UTC). Pricing and quota limits may change; always confirm the current values in the official Google Maps Platform pages linked below.*
+*Last verified: 2026-07-10 (UTC). Pricing and quota limits may change; always confirm the current values in the official Google Maps Platform pages linked below.*
 
 ## 1. How many requests can I make to the Google Maps Pollen API?
 
@@ -100,7 +100,10 @@ No. The integration requires internet access to reach the Google Maps Pollen API
 
 ## 9. Does the integration store my API key?
 
-The API key is stored securely by Home Assistant and is **never shared** with third parties.
+The API key is stored by Home Assistant in the parent Pollen Levels config entry
+and is sent directly from your Home Assistant instance to the Google Maps Pollen
+API when requesting pollen data. It is not sent to the Pollen Levels project
+maintainer.
 
 ---
 
@@ -235,12 +238,49 @@ entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.
 
 ---
 
+## 15. Does Home Assistant Recorder store pollen forecast data?
+
+Live forecast attributes remain available in Home Assistant for dashboards,
+templates, automations, and compatible custom cards. Future forecast-derived
+attributes such as `forecast`, `tomorrow_*`, `d2_*`, `trend`, and
+`expected_peak` are excluded from Recorder persistence by Pollen Levels.
+
+Current states and non-forecast attributes may still be recorded according to
+your Home Assistant Recorder configuration.
+
+Under the current Pollen API service-specific terms, today's forecast values may
+be cached for up to 365 consecutive calendar days, and future forecast values may
+be cached for no more than 24 hours. Users with Recorder retention above 365
+days should exclude Pollen Levels entities or otherwise ensure compliant
+retention.
+
+Pollen Levels does not automatically purge existing Recorder history.
+
+---
+
+## 16. What data is sent to Google?
+
+Your Home Assistant instance sends requests directly to the Google Maps Pollen
+API. Requests include your API key, coordinates, requested forecast days, an
+optional language code, and normal network metadata such as the source IP
+address.
+
+See [PRIVACY.md](PRIVACY.md) and Google's
+[Privacy Policy](https://policies.google.com/privacy) for more detail.
+
+---
+
 ## References (official)
 
 - **Core services pricing list (Environment → Pollen Usage)** — last updated shown on page: https://developers.google.com/maps/billing-and-pricing/pricing  
 - **Pollen API usage & billing (quota editing steps)**: https://developers.google.com/maps/documentation/pollen/usage-and-billing  
 - **Pollen API — Forecast endpoint**: https://developers.google.com/maps/documentation/pollen/forecast  
 - **Pollen API — Heatmap tiles**: https://developers.google.com/maps/documentation/pollen/heatmap-tiles  
+- **Pollen API policies and attribution**: https://developers.google.com/maps/documentation/pollen/policies
+- **Google Maps End User Additional Terms**: https://maps.google.com/help/terms_maps/
+- **Google Privacy Policy**: https://policies.google.com/privacy
+- **Google Maps Platform Service Specific Terms**: https://cloud.google.com/maps-platform/terms/maps-service-terms
+- **Google Maps Platform EEA Service Specific Terms**: https://cloud.google.com/terms/maps-platform/eea/maps-service-terms
 - **Cap API usage (daily/minute/per-user caps)**: https://cloud.google.com/apis/docs/capping-api-usage  
 - **View/manage quotas in Console**: https://cloud.google.com/docs/quotas/view-manage  
 - **Pollen API FAQ (6,000 QPM)**: https://developers.google.com/maps/documentation/pollen/faq

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,124 @@
+# Privacy Policy
+
+Last updated: July 10, 2026
+
+This policy describes how the Pollen Levels Home Assistant custom integration
+handles data. It is not legal advice and does not state that the project has
+received legal review, Google certification, or guaranteed legal compliance.
+
+## Scope
+
+This policy applies to the Pollen Levels custom integration and the project's
+maintainer-operated support channels, such as GitHub Issues.
+
+It does not replace the privacy policies of Google, Home Assistant, GitHub,
+HACS, or your Home Assistant hosting provider or network provider.
+
+## Project-operated collection
+
+Pollen Levels has no project-operated backend service. The maintainer does not
+automatically receive your Home Assistant configuration, API keys, coordinates,
+sensor states, or usage data.
+
+The integration does not contain project-operated analytics, advertising, or
+telemetry.
+
+## Data stored locally in Home Assistant
+
+Pollen Levels stores configuration in Home Assistant config entries and config
+subentries:
+
+- the Google API key is stored in the parent config entry;
+- location names, latitude, and longitude are stored in location subentries;
+- integration options such as update interval and language are stored with the
+  integration entry;
+- entity states and attributes are available in Home Assistant;
+- diagnostics can be generated on request;
+- Home Assistant Recorder may store history according to your Recorder
+  configuration.
+
+Removing an integration config entry does not necessarily purge existing
+Recorder history automatically.
+
+## Data sent to Google
+
+Your Home Assistant instance sends requests directly to the Google Maps Pollen
+API. Relevant request information includes:
+
+- API key;
+- latitude and longitude;
+- requested forecast days;
+- optional language code;
+- normal network metadata such as the source IP address.
+
+Google's handling of this data is governed by the
+[Google Privacy Policy](https://policies.google.com/privacy) and applicable
+Google Maps Platform terms.
+
+## Home Assistant Recorder and retention
+
+Future forecast-derived attributes such as `forecast`, `tomorrow_*`, `d2_*`,
+`trend`, and `expected_peak` remain available in the live Home Assistant entity
+state for dashboards, templates, automations, and compatible custom cards.
+Pollen Levels marks those attributes as excluded from Recorder persistence.
+
+Current states and other non-excluded attributes may still be stored by Home
+Assistant Recorder according to your Recorder configuration.
+
+Stale Google Pollen forecast payload reuse by the integration is capped at 24
+hours.
+
+You are responsible for configuring Recorder so today's pollen values are not
+retained for more than 365 days where the applicable Google terms require that
+limit. If your Recorder retention is longer than 365 days, exclude Pollen Levels
+entities or use an equivalent retention strategy.
+
+Pollen Levels cannot centrally delete or control your Recorder database.
+
+## Logs and diagnostics
+
+API keys are redacted from integration logs and diagnostics. Diagnostics use
+approximate coordinates rounded to one decimal.
+
+Diagnostics may contain Home Assistant entry IDs, subentry IDs, registry
+summaries, runtime summaries, and pollen-related status data. Review diagnostics
+and logs before sharing them publicly.
+
+## Voluntary support information
+
+The maintainer receives data only when you voluntarily submit it, such as in:
+
+- a GitHub issue;
+- logs;
+- diagnostics;
+- screenshots;
+- configuration excerpts.
+
+GitHub processes data under its own privacy terms. Do not submit secrets or
+precise private coordinates.
+
+## User control
+
+You can:
+
+- remove location subentries;
+- remove the parent integration entry;
+- delete or rotate your Google API key;
+- change Home Assistant Recorder configuration;
+- remove locally stored history using Home Assistant's own tools;
+- delete or edit information you posted to GitHub, subject to GitHub's
+  capabilities and policies.
+
+## Data security
+
+The integration uses Home Assistant's shared asynchronous HTTP session and local
+config-entry storage. No system can guarantee absolute security.
+
+## Changes and contact
+
+Changes to this policy will be published in this repository and reflected in the
+last-updated date.
+
+Use the repository's [GitHub Issues](https://github.com/eXPerience83/pollenlevels/issues)
+page for contact and support. Do not post API keys, complete authenticated API
+URLs, unreviewed diagnostics, or precise private coordinates in public issues.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 [![License](https://img.shields.io/github/license/eXPerience83/pollenlevels?logo=github)](https://github.com/eXPerience83/pollenlevels/blob/main/LICENSE)
 [![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 [![FAQ](https://img.shields.io/badge/FAQ-Read%20Here-blue?logo=readthedocs&logoColor=white)](https://github.com/eXPerience83/pollenlevels/blob/main/FAQ.md)
+[![Terms](https://img.shields.io/badge/Terms-Read-blue)](https://github.com/eXPerience83/pollenlevels/blob/main/TERMS.md)
+[![Privacy](https://img.shields.io/badge/Privacy-Read-blue)](https://github.com/eXPerience83/pollenlevels/blob/main/PRIVACY.md)
 [![Ko-fi](https://img.shields.io/badge/Ko%E2%80%91fi-Support%20this%20project-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/experience83)
 [![PayPal](https://img.shields.io/badge/PayPal-Donate-blue?logo=paypal)](https://paypal.me/eXPerience83)
 
@@ -69,6 +71,17 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
   API URLs containing `key=...` into public issues. If a key was exposed,
   rotate it in Google Cloud Console and restrict it to the required API and
   allowed referrers/IPs where possible.
+
+Requests go directly from your Home Assistant instance to the Google Maps Pollen
+API. The project maintainer does not operate a data-collection backend; Google
+processes request data under its own privacy policy. See [PRIVACY.md](PRIVACY.md)
+for details.
+
+Live forecast attributes remain available to dashboards, templates, automations,
+and compatible custom cards. Pollen Levels excludes `forecast`, `tomorrow_*`,
+`d2_*`, `trend`, and `expected_peak` from Home Assistant Recorder persistence,
+while current states and non-excluded attributes remain subject to your Recorder
+configuration.
 
 ---
 
@@ -417,4 +430,15 @@ If this integration helps you, consider supporting development:
 ## 📜 License
 
 MIT © 2025 [eXPerience83](LICENSE)
-**Data Source:** [Google Maps Pollen API](https://developers.google.com/maps/documentation/pollen)
+
+---
+
+## Data source, attribution, and terms
+
+Google Maps — Source: Includes pollen data from Google
+
+Pollen Levels uses the [Google Maps Pollen API](https://developers.google.com/maps/documentation/pollen)
+and follows the [Pollen API policies and attribution](https://developers.google.com/maps/documentation/pollen/policies)
+guidance. Use of Google Maps features and content is subject to Google's
+applicable terms and privacy policy. See [TERMS.md](TERMS.md) and
+[PRIVACY.md](PRIVACY.md).

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 [![License](https://img.shields.io/github/license/eXPerience83/pollenlevels?logo=github)](https://github.com/eXPerience83/pollenlevels/blob/main/LICENSE)
 [![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 [![FAQ](https://img.shields.io/badge/FAQ-Read%20Here-blue?logo=readthedocs&logoColor=white)](https://github.com/eXPerience83/pollenlevels/blob/main/FAQ.md)
-[![Terms](https://img.shields.io/badge/Terms-Read-blue)](https://github.com/eXPerience83/pollenlevels/blob/main/TERMS.md)
-[![Privacy](https://img.shields.io/badge/Privacy-Read-blue)](https://github.com/eXPerience83/pollenlevels/blob/main/PRIVACY.md)
+[![Terms](https://img.shields.io/badge/Terms-Read-blue)](TERMS.md)
+[![Privacy](https://img.shields.io/badge/Privacy-Read-blue)](PRIVACY.md)
 [![Ko-fi](https://img.shields.io/badge/Ko%E2%80%91fi-Support%20this%20project-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/experience83)
 [![PayPal](https://img.shields.io/badge/PayPal-Donate-blue?logo=paypal)](https://paypal.me/eXPerience83)
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,123 @@
+# Terms of Use
+
+Last updated: July 10, 2026
+
+These terms are provided for the Pollen Levels Home Assistant custom integration.
+They are not legal advice and do not state that the project has received legal
+review, Google certification, or guaranteed legal compliance.
+
+## Scope
+
+These terms cover use of the Pollen Levels custom integration.
+
+Pollen Levels is an independent open-source project. It is not affiliated with,
+sponsored by, or endorsed by Google or the Home Assistant project.
+
+## Google Maps features and content
+
+Pollen Levels includes Google Maps features and content supplied through the
+Google Maps Pollen API. Use of those features and content is subject to the
+current [Google Maps End User Additional Terms](https://maps.google.com/help/terms_maps/)
+and the [Google Privacy Policy](https://policies.google.com/privacy).
+
+Google Maps Platform terms and service-specific terms may also apply to your
+Google Cloud account and use of the API, including:
+
+- [Pollen API policies and attribution](https://developers.google.com/maps/documentation/pollen/policies)
+- [Google Maps Platform Terms](https://cloud.google.com/maps-platform/terms)
+- [Google Maps Platform Service Specific Terms](https://cloud.google.com/maps-platform/terms/maps-service-terms)
+- [Google Maps Platform EEA Terms](https://cloud.google.com/terms/maps-platform/eea)
+- [Google Maps Platform EEA Service Specific Terms](https://cloud.google.com/terms/maps-platform/eea/maps-service-terms)
+
+The Google agreement applicable to you can depend on your Google Cloud account,
+billing address, and relationship with Google. These terms do not replace or
+reinterpret Google's terms.
+
+## Attribution
+
+Pollen Levels uses the following project attribution for Google Maps Pollen API
+content:
+
+Google Maps — Source: Includes pollen data from Google
+
+Google Maps attribution must remain visible. Users must not remove, hide,
+obscure, or misrepresent Google Maps or pollen-source attribution when presenting
+data produced by the integration.
+
+## API key, billing, and quotas
+
+You are responsible for:
+
+- supplying your own Google Cloud API key;
+- enabling the required API and billing;
+- restricting and protecting the key;
+- monitoring requests, quotas, budgets, alerts, and charges;
+- rotating a key if it is exposed;
+- complying with the agreement attached to your Google Cloud account.
+
+Pollen Levels cannot guarantee free usage or prevent Google charges.
+
+## Permitted use and data retention
+
+Data from the Google Maps Pollen API must be used in accordance with Google's
+applicable terms.
+
+Under the current Pollen API service-specific caching terms:
+
+- future Pollen API forecast values must not be retained for more than 24 hours;
+- today's forecast values must not be retained for more than 365 consecutive
+  calendar days;
+- heatmap values must not be retained for more than 24 hours.
+
+Pollen Levels does not use Pollen API heatmap tiles.
+
+Pollen Levels excludes future forecast-derived attributes from Home Assistant
+Recorder persistence, but it does not automatically purge Home Assistant
+Recorder history. Users configuring Home Assistant Recorder retention beyond 365
+days must exclude Pollen Levels entities or otherwise prevent current pollen data
+from being retained beyond the applicable limit.
+
+You must not use the integration to scrape, bulk-export, rehost, resell, or
+create an independent historical pollen database from Google Maps Content.
+
+## Health and safety
+
+Pollen data, risk levels, health recommendations, trends, and forecasts are
+informational. They may be delayed, incomplete, unavailable, or inaccurate.
+
+They are not medical advice. Consult qualified healthcare professionals for
+medical decisions.
+
+Do not use the integration for emergency, safety-critical, or life-critical
+decisions.
+
+## Availability and changes
+
+Google can change API output, pricing, quotas, coverage, terms, or availability.
+Home Assistant and Pollen Levels can also change. Uninterrupted operation is not
+guaranteed.
+
+## Open-source license and warranty
+
+Pollen Levels is distributed under the repository's [MIT License](LICENSE).
+
+The software is provided without warranties to the extent allowed by the
+applicable license and law.
+
+## Termination
+
+You can stop using Pollen Levels by removing the integration from Home Assistant
+and revoking or deleting the associated Google Cloud API key.
+
+## Changes to these terms
+
+Material changes to these terms will be published in this repository and
+reflected by the file's last-updated date.
+
+## Contact
+
+Use the repository's [GitHub Issues](https://github.com/eXPerience83/pollenlevels/issues)
+page for project contact and support.
+
+Do not post API keys, complete authenticated API URLs, unreviewed diagnostics,
+or precise private coordinates in public issues.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -73,10 +73,9 @@ def test_google_maps_legal_documents_are_publicly_linked() -> None:
     assert "https://policies.google.com/privacy" in terms
     assert "https://developers.google.com/maps/documentation/pollen/policies" in terms
     assert "https://policies.google.com/privacy" in privacy
-    assert (
-        "Google Maps — Source: Includes pollen data from Google" in readme
-        or "Google Maps — Source: Includes pollen data from Google" in terms
-    )
+    attribution = "Google Maps — Source: Includes pollen data from Google"
+    assert attribution in readme
+    assert attribution in terms
 
 
 def test_google_maps_retention_limits_are_documented() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,6 +10,7 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 MANIFEST_PATH = ROOT / "custom_components" / "pollenlevels" / "manifest.json"
 README_PATH = ROOT / "README.md"
+FAQ_PATH = ROOT / "FAQ.md"
 TERMS_PATH = ROOT / "TERMS.md"
 PRIVACY_PATH = ROOT / "PRIVACY.md"
 
@@ -88,3 +89,14 @@ def test_google_maps_retention_limits_are_documented() -> None:
         "today's forecast values must not be retained for more than "
         "365 consecutive calendar days"
     ) in terms
+
+
+def test_faq_documents_privacy_and_retention_guidance() -> None:
+    """Ensure FAQ keeps its privacy and retention guidance."""
+    faq = " ".join(_read_text(FAQ_PATH).split())
+
+    assert "[PRIVACY.md](PRIVACY.md)" in faq
+    assert (
+        "today's forecast values may be cached for up to 365 consecutive calendar days"
+    ) in faq
+    assert "future forecast values may be cached for no more than 24 hours" in faq

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -9,6 +9,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 MANIFEST_PATH = ROOT / "custom_components" / "pollenlevels" / "manifest.json"
+README_PATH = ROOT / "README.md"
+FAQ_PATH = ROOT / "FAQ.md"
+TERMS_PATH = ROOT / "TERMS.md"
+PRIVACY_PATH = ROOT / "PRIVACY.md"
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
 
 def _load_pyproject() -> dict:
@@ -48,3 +56,34 @@ def test_pyproject_requires_python_is_314_plus() -> None:
     assert isinstance(requires, str) and requires.startswith(">=3.14"), (
         "requires-python must stay aligned with the 3.14+ tooling story"
     )
+
+
+def test_google_maps_legal_documents_are_publicly_linked() -> None:
+    """Ensure public Google Maps legal notices stay linked and attributed."""
+    assert TERMS_PATH.exists()
+    assert PRIVACY_PATH.exists()
+
+    readme = _read_text(README_PATH)
+    terms = _read_text(TERMS_PATH)
+    privacy = _read_text(PRIVACY_PATH)
+
+    assert "TERMS.md" in readme
+    assert "PRIVACY.md" in readme
+    assert "https://maps.google.com/help/terms_maps/" in terms
+    assert "https://policies.google.com/privacy" in terms
+    assert "https://developers.google.com/maps/documentation/pollen/policies" in terms
+    assert "https://policies.google.com/privacy" in privacy
+    assert (
+        "Google Maps — Source: Includes pollen data from Google" in readme
+        or "Google Maps — Source: Includes pollen data from Google" in terms
+    )
+
+
+def test_google_maps_retention_limits_are_documented() -> None:
+    """Ensure Google Maps Pollen retention limits remain documented."""
+    docs = "\n".join(
+        _read_text(path) for path in (README_PATH, TERMS_PATH, PRIVACY_PATH, FAQ_PATH)
+    )
+
+    assert "24 hours" in docs
+    assert "365" in docs

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -10,7 +10,6 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT_PATH = ROOT / "pyproject.toml"
 MANIFEST_PATH = ROOT / "custom_components" / "pollenlevels" / "manifest.json"
 README_PATH = ROOT / "README.md"
-FAQ_PATH = ROOT / "FAQ.md"
 TERMS_PATH = ROOT / "TERMS.md"
 PRIVACY_PATH = ROOT / "PRIVACY.md"
 
@@ -67,8 +66,8 @@ def test_google_maps_legal_documents_are_publicly_linked() -> None:
     terms = _read_text(TERMS_PATH)
     privacy = _read_text(PRIVACY_PATH)
 
-    assert "TERMS.md" in readme
-    assert "PRIVACY.md" in readme
+    assert "[TERMS.md](TERMS.md)" in readme
+    assert "[PRIVACY.md](PRIVACY.md)" in readme
     assert "https://maps.google.com/help/terms_maps/" in terms
     assert "https://policies.google.com/privacy" in terms
     assert "https://developers.google.com/maps/documentation/pollen/policies" in terms
@@ -80,9 +79,12 @@ def test_google_maps_legal_documents_are_publicly_linked() -> None:
 
 def test_google_maps_retention_limits_are_documented() -> None:
     """Ensure Google Maps Pollen retention limits remain documented."""
-    docs = "\n".join(
-        _read_text(path) for path in (README_PATH, TERMS_PATH, PRIVACY_PATH, FAQ_PATH)
-    )
+    terms = " ".join(_read_text(TERMS_PATH).split())
 
-    assert "24 hours" in docs
-    assert "365" in docs
+    assert (
+        "future Pollen API forecast values must not be retained for more than 24 hours"
+    ) in terms
+    assert (
+        "today's forecast values must not be retained for more than "
+        "365 consecutive calendar days"
+    ) in terms


### PR DESCRIPTION
## Summary

Adds public Terms of Use and a Privacy Policy for Pollen Levels and documents Google Maps Pollen API attribution, data flow, caching limits, and Home Assistant Recorder behavior.

### Changes

- Add project Terms of Use.
- Add a project Privacy Policy.
- Link both documents from the README.
- Document the required Google Maps and pollen data attribution.
- Explain direct request data sent from Home Assistant to Google.
- Explain Recorder behavior for live and future forecast attributes.
- Document the 24-hour future-forecast and 365-day current-value retention limits.
- Add metadata regression tests for the required documents, links, and attribution.

### Safety

- No runtime changes.
- No migration changes.
- No entity ID, unique ID, or device identifier changes.
- No entity additions or removals.
- No service changes.
- No API-request changes.
- No translation changes.
- No workflow changes.
- No release metadata or CHANGELOG changes.

## Validation

- `python -m compileall -q sitecustomize.py custom_components tests`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q tests/test_metadata.py`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added complete **PRIVACY.md** and **TERMS.md** detailing local storage, what’s sent to the Google Maps Pollen API, security/redaction, attribution, retention/caching limits, and user responsibilities.
  * Updated **FAQ.md** with a new “Last verified” date and expanded Recorder persistence guidance and Google data-sharing details.
  * Updated **README.md** with prominent links and clarified security/privacy and Recorder behavior (forecast-related attributes excluded).
  * Refreshed official references list.

* **Tests**
  * Added metadata tests to ensure legal/attribution and retention-limit wording stays present across documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->