### PR TITLE
release: prepare 3.0.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## [3.0.0rc3] - 2026-07-11
+
+### Added
+
+- Added public Terms of Use and a Privacy Policy covering the integration's
+  local Home Assistant storage, direct Google Maps Pollen API requests,
+  diagnostics, Recorder behavior, data retention, attribution, and user
+  responsibilities.
+- Added focused regression checks to keep the public legal links, Google Maps
+  attribution, and retention guidance present in README, Terms, Privacy, and
+  FAQ documentation.
+
+### Changed
+
+- Updated visible pollen data attribution to
+  `Google Maps — Source: Includes pollen data from Google`.
+- Kept `forecast`, `tomorrow_*`, `d2_*`, `trend`, and `expected_peak`
+  available in live Home Assistant state while excluding those
+  future-forecast-derived attributes from Recorder persistence.
+- Limited stale Google Pollen forecast payload reuse to a maximum of 24 hours.
+- Expanded README and FAQ guidance for API-key handling, data sent directly to
+  Google, Home Assistant Recorder persistence, and the applicable 24-hour and
+  365-day retention limits.
+- Replaced Black with Ruff formatter so Ruff now handles linting, import
+  ordering, and formatting with a rolling minimum version of `ruff>=0.15`.
+- Confirmed RC3 does not change v3 migration behavior, entity IDs, unique IDs,
+  device identifiers, entity count, forecast offsets, service schemas,
+  translation keys, or the parent/subentry architecture.
+
+### Fixed
+
+- Fixed the global `pollenlevels.force_update` action so per-location refresh
+  failures handled internally by Home Assistant's `DataUpdateCoordinator` are
+  still reported.
+- Kept refreshing healthy locations when another location fails, while
+  preserving cancellation handling, stale-location filtering, sequential
+  refresh behavior, and privacy-safe failure messages.
+
 ## [3.0.0rc2] - 2026-06-27
 
 ### Changed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0rc2"
+    "version": "3.0.0rc3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0rc2"
+version = "3.0.0rc3"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
## Summary

Prepares the Pollen Levels `3.0.0rc3` release metadata.

### Changes

- Bump `manifest.json` from `3.0.0rc2` to `3.0.0rc3`.
- Bump `pyproject.toml` from `3.0.0rc2` to `3.0.0rc3`.
- Add the `3.0.0rc3` changelog entry for:
  - Google Maps attribution and forecast-retention compliance;
  - Recorder exclusion of future forecast-derived attributes;
  - privacy and terms documentation;
  - improved `pollenlevels.force_update` failure reporting;
  - migration from Black to Ruff formatter.

### Safety

- No runtime changes.
- No migration changes.
- No entity ID, unique ID, or device identifier changes.
- No entity additions or removals.
- No service or API behavior changes.
- No caching or Recorder implementation changes.
- No diagnostics or translation changes.
- No workflow or dependency changes.
- No Git tag or GitHub release created by this PR.

## Validation

- Version consistency check.
- Changelog structure check.
- `python -m compileall -q sitecustomize.py custom_components tests`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q tests/test_metadata.py`
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public links to the Terms of Use and Privacy Policy.
  - Clarified API key handling and data-retention guidance in the README and FAQ.

- **Bug Fixes**
  - Improved pollen attribution wording.
  - Limited reuse of stale forecasts to 24 hours.
  - Improved refresh behavior and failure reporting across locations.
  - Preserved privacy-safe error messages.

- **Documentation**
  - Added regression checks for legal links and README content.
  - Published release notes for version 3.0.0rc3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->