### PR TITLE
docs: frame v3 as stable in user documentation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -205,7 +205,8 @@ can create a Repair warning after they repeat. If no configured location can
 load successfully, the parent entry is marked not ready so Home Assistant can
 retry setup.
 
-Create a Home Assistant backup before upgrading from Pollen Levels 2.x to v3.
+Create a full Home Assistant backup before upgrading from Pollen Levels 2.x to
+v3.
 Downgrading from v3 to Pollen Levels 2.x is not supported without restoring that
 backup.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -154,13 +154,13 @@ FAQ: https://developers.google.com/maps/documentation/pollen/faq
 
 ---
 
-## 12. What happens to my entries when upgrading to the v3 pre-release?
+## 12. What happens to my entries when upgrading to Pollen Levels v3?
 
-The v3 pre-release migrates Pollen Levels to Home Assistant config subentries.
-Legacy 2.x entries that share the same Google API key are grouped under one
-parent API-key entry, and each migrated location becomes one location subentry.
-The API key is stored once on the parent instead of duplicated across legacy
-entries.
+Pollen Levels v3 introduces a breaking architectural migration to Home
+Assistant config subentries. Legacy 2.x entries that share the same Google API
+key are grouped under one parent API-key entry, and each migrated location
+becomes one location subentry. The API key is stored once on the parent instead
+of duplicated across legacy entries.
 
 Duplicate legacy entries are marked as merged and removed after their
 locations, entities, and devices are moved to the parent entry. If Home
@@ -205,8 +205,9 @@ can create a Repair warning after they repeat. If no configured location can
 load successfully, the parent entry is marked not ready so Home Assistant can
 retry setup.
 
-Create a Home Assistant backup before upgrading. Downgrading to Pollen Levels
-2.x after this migration is not supported.
+Create a Home Assistant backup before upgrading from Pollen Levels 2.x to v3.
+Downgrading from v3 to Pollen Levels 2.x is not supported without restoring that
+backup.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ with offsets `1` to `4`, depending on the data returned by the API.
 
 ## Multiple locations and upgrades
 
-The v3 pre-release line migrates Pollen Levels to Home Assistant config
-subentries. Configuration is stored as one parent API-key entry with one or more
-location subentries. Existing 2.x entries are consolidated by API key during
-migration:
+Pollen Levels v3 introduces a breaking architectural migration to Home
+Assistant config subentries. Configuration is stored as one parent API-key entry
+with one or more location subentries. Existing 2.x entries are consolidated by
+API key during migration:
 
 - Legacy entries with the same Google API key are grouped under one parent
   entry, so the API key is stored once on the parent instead of duplicated.
@@ -189,8 +189,9 @@ a repeated retryable failure, the integration creates a Repair warning for the
 affected location. If no configured location can load successfully, the parent
 entry is marked not ready so Home Assistant can retry setup.
 
-Create a Home Assistant backup before installing the v3 pre-release.
-Downgrading to Pollen Levels 2.x after the subentry migration is not supported.
+Create a Home Assistant backup before upgrading from Pollen Levels 2.x to v3.
+Downgrading from v3 to Pollen Levels 2.x is not supported without restoring that
+backup.
 
 ### Diagnostics after the v3 migration
 

--- a/README.md
+++ b/README.md
@@ -182,14 +182,15 @@ When reauthenticating or reconfiguring the parent API key, the integration tries
 the configured locations until one returns usable pollen data. Authentication
 and quota errors are treated as key-level failures.
 
-During startup, the v3 beta keeps the parent entry available when at least one
-configured location loads successfully. Locations that fail their initial
+During startup, Pollen Levels v3 keeps the parent entry available when at least
+one configured location loads successfully. Locations that fail their initial
 non-auth refresh are isolated in diagnostics and retried on parent reload; after
 a repeated retryable failure, the integration creates a Repair warning for the
 affected location. If no configured location can load successfully, the parent
 entry is marked not ready so Home Assistant can retry setup.
 
-Create a Home Assistant backup before upgrading from Pollen Levels 2.x to v3.
+Create a full Home Assistant backup before upgrading from Pollen Levels 2.x to
+v3.
 Downgrading from v3 to Pollen Levels 2.x is not supported without restoring that
 backup.
 


### PR DESCRIPTION
## Summary

- update README and FAQ wording so Pollen Levels v3 is no longer presented as a pre-release
- describe v3 as a breaking architectural migration to config subentries
- clarify the required backup and unsupported downgrade path

## Scope

Documentation only. No runtime, migration, configuration, translation, workflow, test, or version metadata changes.

## Validation

- `git diff --check`
- reviewed the complete README/FAQ diff
- confirmed historical beta and release-candidate references remain intact

Closes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Pollen Levels v3 migration as a breaking architectural change involving Home Assistant config subentries.
  * Explained how legacy 2.x entries are consolidated by API key during migration.
  * Added explicit guidance to create a Home Assistant backup before upgrading; downgrading to 2.x requires restoring that backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
