### PR TITLE
Trigger reauth for expired Google API keys

### DIFF
--- a/custom_components/pollenlevels/const.py
+++ b/custom_components/pollenlevels/const.py
@@ -48,5 +48,6 @@ def is_invalid_api_key_message(message: str | None) -> bool:
         "api_key_invalid",
         "apikeynotvalid",
         "api key is not valid",
+        "api key expired",
     )
     return any(signal in msg for signal in signals)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -333,6 +333,29 @@ async def test_client_treats_400_invalid_api_key_as_auth_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "API key expired. Please renew the API key.",
+        "aPi KeY eXpIrEd. PlEaSe ReNeW tHe ApI kEy.",
+    ],
+)
+async def test_client_treats_400_expired_api_key_as_auth_failure(
+    client_module: ModuleType,
+    message: str,
+) -> None:
+    """Expired-key messages on HTTP 400 responses should trigger re-auth."""
+
+    response = FakeResponse(
+        status=400,
+        json_results=[{"error": {"message": message}}],
+    )
+
+    with pytest.raises(client_module.ConfigEntryAuthFailed, match="HTTP 400"):
+        await _fetch_with_response(client_module, response)
+
+
+@pytest.mark.asyncio
 async def test_client_treats_400_non_auth_error_as_update_failed(
     client_module: ModuleType,
 ) -> None:

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -164,14 +164,16 @@ async def test_ha_expired_api_key_reload_preserves_registry_identity(
     assert flow["context"]["entry_id"] == ha_config_entry.entry_id
     assert flow["step_id"] == "reauth_confirm"
 
+    recovery_params: list[dict[str, Any]] = []
     async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        mock_pollen_api(mocked, google_pollen_5_day_payload, recovery_params)
         result = await hass.config_entries.flow.async_configure(
             flow["flow_id"],
             {CONF_API_KEY: "replacement-key"},
         )
         await hass.async_block_till_done()
 
+    assert {params["key"] for params in recovery_params} == {"replacement-key"}
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert ha_config_entry.data[CONF_API_KEY] == "replacement-key"

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -8,7 +8,11 @@ from aiointercept import CallbackResult, aiointercept
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 
 from custom_components.pollenlevels.const import CONF_API_KEY, DOMAIN
 from tests._ha_stubs import clear_integration_modules
@@ -78,16 +82,65 @@ async def test_ha_setup_unload_reload_smoke(
         assert ha_config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_ha_expired_api_key_setup_starts_reauth_and_recovers(
+async def test_ha_expired_api_key_reload_preserves_registry_identity(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
-    """An expired API key should start reauth and recover with a valid key."""
+    """A loaded entry should preserve registry identity through expired-key reauth."""
     clear_integration_modules()
     ha_config_entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, ha_config_entry)
+
+    assert ha_config_entry.state is ConfigEntryState.LOADED
+    assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    def _registry_identity_snapshot() -> dict[str, Any]:
+        entity_entries = [
+            entity
+            for entity in er.async_entries_for_config_entry(
+                entity_registry, ha_config_entry.entry_id
+            )
+            if entity.platform == DOMAIN
+        ]
+        device_entries = dr.async_entries_for_config_entry(
+            device_registry, ha_config_entry.entry_id
+        )
+        return {
+            "entities": {
+                (
+                    entity.entity_id,
+                    entity.unique_id,
+                    entity.device_id,
+                    getattr(entity, "config_subentry_id", None),
+                )
+                for entity in entity_entries
+            },
+            "devices": {
+                device.id: {
+                    "identifiers": frozenset(device.identifiers),
+                    "config_entries_subentries": {
+                        config_entry_id: frozenset(subentry_ids)
+                        for config_entry_id, subentry_ids in getattr(
+                            device, "config_entries_subentries", {}
+                        ).items()
+                    },
+                }
+                for device in device_entries
+            },
+        }
+
+    identities_before = _registry_identity_snapshot()
+    assert identities_before["entities"]
+    assert identities_before["devices"]
 
     async with aiointercept(mock_external_urls=True) as mocked:
         mocked.get(
@@ -100,7 +153,7 @@ async def test_ha_expired_api_key_setup_starts_reauth_and_recovers(
             ),
             repeat=True,
         )
-        assert not await hass.config_entries.async_setup(ha_config_entry.entry_id)
+        assert not await hass.config_entries.async_reload(ha_config_entry.entry_id)
         await hass.async_block_till_done()
 
     assert ha_config_entry.state is ConfigEntryState.SETUP_ERROR
@@ -124,6 +177,7 @@ async def test_ha_expired_api_key_setup_starts_reauth_and_recovers(
     assert ha_config_entry.data[CONF_API_KEY] == "replacement-key"
     assert ha_config_entry.state is ConfigEntryState.LOADED
     assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
+    assert _registry_identity_snapshot() == identities_before
 
 
 async def test_ha_stale_location_repairs_are_discovered_from_registry(

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from aiointercept import aiointercept
-from homeassistant.config_entries import ConfigEntryState
+from aiointercept import CallbackResult, aiointercept
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
+from custom_components.pollenlevels.const import CONF_API_KEY, DOMAIN
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
+    POLLEN_API_URL_RE,
     assert_fixed_forecast_days,
     async_setup_config_entry,
     mock_pollen_api,
@@ -73,6 +76,54 @@ async def test_ha_setup_unload_reload_smoke(
         assert await hass.config_entries.async_setup(ha_config_entry.entry_id)
         await hass.async_block_till_done()
         assert ha_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_ha_expired_api_key_setup_starts_reauth_and_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """An expired API key should start reauth and recover with a valid key."""
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mocked.get(
+            POLLEN_API_URL_RE,
+            callback=lambda *_args, **_kwargs: CallbackResult(
+                status=400,
+                payload={
+                    "error": {"message": "API key expired. Please renew the API key."}
+                },
+            ),
+            repeat=True,
+        )
+        assert not await hass.config_entries.async_setup(ha_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert ha_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == ha_config_entry.entry_id
+    assert flow["step_id"] == "reauth_confirm"
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            {CONF_API_KEY: "replacement-key"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert ha_config_entry.data[CONF_API_KEY] == "replacement-key"
+    assert ha_config_entry.state is ConfigEntryState.LOADED
+    assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
 
 
 async def test_ha_stale_location_repairs_are_discovered_from_registry(


### PR DESCRIPTION
Fixes #230.

## Summary

- recognize Google’s `API key expired` response case-insensitively
- preserve `UpdateFailed` for unrelated HTTP 400 responses
- cover client classification and the full loaded-entry → expired-key reload → reauth recovery lifecycle
- verify entity and device registry identities and subentry associations remain unchanged after recovery

## Root cause

The invalid-key message classifier did not recognize Google’s live expired-key wording, so HTTP 400 fell through to a generic update failure instead of starting reauthentication.

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m black --check --target-version py314 custom_components/pollenlevels/const.py tests/test_client.py tests/test_ha_init.py`
- `python -m pytest -q` (**571 passed**)

A repository-wide Black check also identified existing formatting differences in `tests/test_metadata.py` and `tests/test_translations.py`; those unrelated files were intentionally left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired API keys are now correctly detected, including case variations.
  * Home Assistant setup now prompts for a replacement API key when the current key has expired.
  * Reauthentication restores the integration to a working state after a valid key is provided while preserving existing entity and device identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->