### PR TITLE
release: prepare 3.0.0rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ### Fixed
 
-- Google HTTP 400 responses containing
-  `API key expired. Please renew the API key.` are now classified as
-  authentication failures.
+- Google HTTP 400 responses containing `API key expired. Please renew the API key.`
+  are now classified as authentication failures instead of generic update failures.
 - Home Assistant now starts the automatic reauthentication flow instead of
   leaving the parent entry in setup retry.
 - Recovery with a valid replacement API key reloads the parent and active

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [3.0.0rc4] - 2026-08-01
+
+### Fixed
+
+- Google HTTP 400 responses containing
+  `API key expired. Please renew the API key.` are now classified as
+  authentication failures.
+- Home Assistant now starts the automatic reauthentication flow instead of
+  leaving the parent entry in setup retry.
+- Recovery with a valid replacement API key reloads the parent and active
+  location subentries.
+- Regression coverage verifies that entity IDs, unique IDs, device IDs, config
+  subentry associations, device identifiers, and device registry identities
+  remain unchanged.
+- Unrelated HTTP 400 responses remain `UpdateFailed`.
+
 ## [3.0.0rc3] - 2026-07-11
 
 ### Added

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0rc3"
+    "version": "3.0.0rc4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0rc3"
+version = "3.0.0rc4"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
## Summary

- bump the integration and project versions from `3.0.0rc3` to `3.0.0rc4`
- add the RC4 changelog entry for expired Google API-key reauthentication and registry identity regression coverage
- keep unrelated HTTP 400 responses documented as `UpdateFailed`

## Validation

- `python -m compileall -q sitecustomize.py custom_components tests`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q tests/test_metadata.py` (**6 passed**)
- `python -m pytest -q` (**571 passed**)
- verified `manifest.json` and `pyproject.toml` each contain exactly `3.0.0rc4`

## Safety

- No runtime changes.
- No migration changes.
- No entity or device identity changes.
- No parent/subentry architecture changes.
- No service, forecast, diagnostics, or translation changes.
- No Git tag or GitHub release created by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google API responses indicating an expired API key are now handled as authentication failures.
  * Home Assistant prompts for reauthentication and restores affected locations after a replacement key succeeds.
  * Other HTTP 400 errors continue to be reported as update failures.
* **Release**
  * Updated the integration version to 3.0.0rc4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->