### PR TITLE
release: prepare 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [3.0.0] - 2026-08-02
+
+### Added
+
+- Added one parent config entry per API key with one config subentry per
+  location and shared parent options.
+- Added per-location sensors, devices, coordinators, and Update now buttons.
+- Added `registry_summary` and `runtime_summary` diagnostics.
+
+### Changed
+
+- **Breaking change:** Consolidated v2 entries into the v3 parent/subentry
+  architecture by API key while preserving entity IDs, unique IDs, devices,
+  dashboards, automations, and Recorder history.
+- **Breaking change:** Removed separate D+1 and D+2 entities while retaining
+  `forecast`, `tomorrow_*`, `d2_*`, `trend`, and `expected_peak` attributes.
+- A Home Assistant backup is mandatory before upgrading from 2.x. Downgrading
+  to 2.x is unsupported without restoring that backup.
+
+### Fixed
+
+- Filtered stale deleted locations from `pollenlevels.force_update`.
+- Added automatic reauthentication for expired Google API keys.
+
 ## [3.0.0rc4] - 2026-08-01
 
 ### Fixed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0rc4"
+    "version": "3.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0rc4"
+version = "3.0.0"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 


### PR DESCRIPTION
## Summary

- promote package metadata from `3.0.0rc4` to stable `3.0.0`
- add the final stable v3 changelog entry
- document the v3 parent/subentry architecture, migration and identity guarantees, forecast model, diagnostics, force-update filtering, expired-key reauthentication, and 2.x backup/downgrade requirements

References #217.

## Scope

Release metadata only. No runtime, migration, test, workflow, documentation, translation, service, entity, device, or config-flow changes. No Git tag or GitHub release is created by this PR.

## Validation

- `python -m compileall -q sitecustomize.py custom_components tests`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q tests/test_metadata.py` (6 passed)
- `python -m pytest -q` (571 passed)
- verified `manifest.json` and `pyproject.toml` each contain exactly version `3.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted version 3.0.0 from release candidate to stable release.
  * Added release documentation covering the new API-key and location architecture.
  * Documented migration and forecast changes, backup requirements, stale-location filtering, diagnostics, and automatic API-key reauthentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->