### PR TITLE
docs: finalize stable v3 wording

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -41,7 +41,7 @@ billing credits on your account.
 
 Yes. You can use either method:
 - Press the per-location **Update now** button entity created by the integration to refresh one configured location.
-- Call the `pollenlevels.force_update` service from **Developer Tools → Services** to refresh all configured locations.
+- Call the `pollenlevels.force_update` action from **Developer Tools → Actions** to refresh all configured locations.
 Both methods request an immediate coordinator refresh. The normal scheduled polling interval remains managed by Home Assistant's DataUpdateCoordinator.
 
 ---
@@ -214,7 +214,7 @@ backup.
 
 ## 13. Can I choose how many forecast days Pollen Levels requests?
 
-No. Starting with v3 beta 4, Pollen Levels always requests 5 forecast days. This
+No. Pollen Levels v3 always requests 5 forecast days. This
 keeps the integration simpler and gives all existing sensors the maximum
 available forecast attributes.
 
@@ -232,8 +232,8 @@ forecast data is available on the base pollen sensors through the `forecast`,
 If the integration detects legacy per-day forecast entities or settings during
 upgrade, it also creates a persistent Repair warning in Home Assistant.
 
-This cleanup has been brought forward in v3 beta 4 so the migration can be
-tested before the release candidate.
+In Pollen Levels v3, this cleanup is part of the stable migration to the fixed
+5-day forecast model.
 
 Update any dashboards, automations, templates or custom cards that reference
 entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
   - **Plants** (Oak, Pine, Birch, etc.)
   - **Pollen Info** (Region / Date metadata)  
 - **Configurable updates** — Change update interval and API response language without reinstalling.
-- **Manual refresh** — Use the per-location **Update now** button entity to refresh a single configured location, or call the global `pollenlevels.force_update` service to refresh all configured locations.
+- **Manual refresh** — Use the per-location **Update now** button entity to refresh a single configured location, or call the global `pollenlevels.force_update` action to refresh all configured locations.
 - **Last Updated sensor** — Shows timestamp of last successful update.
 - **Rich attributes** — Includes `inSeason`, index `description`, health `advice`
   for pollen types, `color_hex`, `color_rgb`, and plant details.
@@ -117,8 +117,8 @@ sensor.example_grass_d2
 Forecast data is now exposed on the base pollen type sensor through attributes.
 Existing legacy `_d1` and `_d2` entity registry entries owned by Pollen Levels
 are removed automatically during setup/reload. Recorder history is not purged.
-This beta brings that cleanup forward so the migration can be tested with the
-fixed 5-day forecast model before the release candidate.
+In Pollen Levels v3, this cleanup is part of the stable migration to the fixed
+5-day forecast model.
 
 Before:
 


### PR DESCRIPTION
## Summary

- Remove remaining beta/release-candidate wording from current stable v3 documentation.
- Update Home Assistant user-facing terminology from Services to Actions.
- Perform an additional stable-release documentation consistency review.

References #217.

## Additional review findings

Reviewed:

- `README.md`
- `FAQ.md`
- `CHANGELOG.md`
- `TERMS.md`
- `PRIVACY.md`
- `hacs.json`
- `custom_components/pollenlevels/manifest.json`

No additional stable-release blockers were found.

The remaining matches for beta, pre-release, and release-candidate wording are historical entries in `CHANGELOG.md` for earlier beta, release-candidate, and alpha releases. They are valid release history and were intentionally left unchanged.

## Validation

- `git diff --check` — passed.
- `python -m compileall -q sitecustomize.py custom_components tests` — passed.
- `python -m ruff check .` — passed.
- `python -m ruff format --check .` — passed; 54 files already formatted.
- `python -m pytest -q tests/test_metadata.py` — passed; 6 tests.
- `python -m pytest -q` — passed; 571 tests.
- Repository stale-phrase search across all requested user-facing files — inspected manually; only historical changelog matches remain.
- Final changed-file check — exactly `README.md` and `FAQ.md`.

## Safety

- Documentation only.
- No runtime changes.
- No migration changes.
- No entity, device, service identifier, translation, or config-flow changes.
- No version metadata changes.
- No tag or GitHub release created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the FAQ and README to reference the current pollen forecast update action.
  * Clarified that version 3 consistently provides five forecast days.
  * Documented that legacy per-day forecast cleanup is included in the stable migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->