### PR TITLE
ci: harden GitHub Actions supply chain

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -171,7 +171,11 @@ reviews:
         Check:
         - Minimal permissions.
         - concurrency is present where appropriate.
-        - actions are pinned to versioned major tags.
+        - All external Actions are pinned to verified full-length commit SHAs.
+        - Human-readable version or branch comments remain after each SHA.
+        - Renovate annotations and digest-update compatibility are preserved.
+        - actionlint and zizmor remain blocking checks.
+        - No broad zizmor ignores or unnecessary write permissions are added.
         - setup-python uses python-version "3.14" unless intentionally changed.
         - shell: bash is present when using set -euo pipefail.
         - ruff check and ruff format --check fail the job on issues.

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       # Checkout so hassfest can read manifests and structure
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       # Official hassfest action (Home Assistant recommends @master)
       - name: Run hassfest
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@ab22029681aa532bfe7de5774a9972d67bfbd2c0 # master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,14 +25,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref || github.ref }}
           persist-credentials: false
 
       - name: Setup Python 3.14 (latest patch)
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
 
@@ -46,7 +46,7 @@ jobs:
           python scripts/validate_release_zip.py "$ZIP_PATH"
 
       - name: Upload ZIP artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pollenlevels-zip
           path: pollenlevels.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Set up Python 3.14
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
           cache: "pip"
@@ -82,7 +82,7 @@ jobs:
           python scripts/validate_release_zip.py "$ZIP_PATH"
 
       - name: Upload ZIP to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: pollenlevels.zip
           overwrite_files: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
           cache: "pip"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa" # main
         with:
           category: "integration"

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -19,6 +19,8 @@ env:
   ACTIONLINT_VERSION: "v1.7.12"
   # renovate: datasource=pypi depName=zizmor versioning=pep440
   ZIZMOR_VERSION: "1.29.0"
+  # renovate: datasource=github-releases depName=astral-sh/uv
+  UV_VERSION: "0.12.1"
 
 jobs:
   actionlint:
@@ -31,9 +33,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26.5"
+          cache: false
 
       - name: Install actionlint
         shell: bash
@@ -65,7 +68,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: false
 
       - name: Run zizmor
         shell: bash

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -21,6 +21,9 @@ env:
   ZIZMOR_VERSION: "1.29.0"
   # renovate: datasource=github-releases depName=astral-sh/uv
   UV_VERSION: "0.12.1"
+  # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.*)$
+  SHELLCHECK_VERSION: "0.11.0"
+  SHELLCHECK_SHA256: "b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
 
 jobs:
   actionlint:
@@ -45,12 +48,30 @@ jobs:
           go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
+      - name: Install ShellCheck
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive_path="${RUNNER_TEMP}/shellcheck.tar.gz"
+          tool_dir="${RUNNER_TEMP}/shellcheck-${SHELLCHECK_VERSION}"
+          download_url="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.gz"
+          curl --fail --location --retry 3 --output "$archive_path" "$download_url"
+          printf '%s  %s\n' "$SHELLCHECK_SHA256" "$archive_path" | sha256sum --check
+          mkdir -p "$tool_dir"
+          tar --extract --gzip --file "$archive_path" \
+            --directory "$tool_dir" \
+            --strip-components=1 \
+            "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          echo "$tool_dir" >> "$GITHUB_PATH"
+
       - name: Show validator versions
         shell: bash
         run: |
           set -euo pipefail
           actionlint -version
           shellcheck --version
+          installed_shellcheck_version="$(shellcheck --version | awk '/^version:/ {print $2}')"
+          test "$installed_shellcheck_version" = "$SHELLCHECK_VERSION"
 
       - name: Run actionlint
         shell: bash

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,82 @@
+name: Workflow Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=github-releases depName=rhysd/actionlint
+  ACTIONLINT_VERSION: "v1.7.12"
+  # renovate: datasource=pypi depName=zizmor versioning=pep440
+  ZIZMOR_VERSION: "1.29.0"
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+
+      - name: Install actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Show validator versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          actionlint -version
+          shellcheck --version
+
+      - name: Run actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          actionlint
+
+  zizmor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Run zizmor
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          uvx "zizmor@${ZIZMOR_VERSION}" \
+            --format=github \
+            --min-severity=high \
+            --min-confidence=medium \
+            --collect=workflows \
+            --strict-collection \
+            .

--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -21,8 +21,8 @@ env:
   ZIZMOR_VERSION: "1.29.0"
   # renovate: datasource=github-releases depName=astral-sh/uv
   UV_VERSION: "0.12.1"
-  # renovate: datasource=github-releases depName=koalaman/shellcheck extractVersion=^v(?<version>.*)$
-  SHELLCHECK_VERSION: "0.11.0"
+  # renovate: shellcheck-release
+  SHELLCHECK_TAG: "v0.11.0"
   SHELLCHECK_SHA256: "b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6"
 
 jobs:
@@ -52,16 +52,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          shellcheck_version="${SHELLCHECK_TAG#v}"
           archive_path="${RUNNER_TEMP}/shellcheck.tar.gz"
-          tool_dir="${RUNNER_TEMP}/shellcheck-${SHELLCHECK_VERSION}"
-          download_url="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.gz"
+          tool_dir="${RUNNER_TEMP}/shellcheck-${shellcheck_version}"
+          download_url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_TAG}/shellcheck-${SHELLCHECK_TAG}.linux.x86_64.tar.gz"
           curl --fail --location --retry 3 --output "$archive_path" "$download_url"
           printf '%s  %s\n' "$SHELLCHECK_SHA256" "$archive_path" | sha256sum --check
           mkdir -p "$tool_dir"
           tar --extract --gzip --file "$archive_path" \
             --directory "$tool_dir" \
             --strip-components=1 \
-            "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+            "shellcheck-${SHELLCHECK_TAG}/shellcheck"
           echo "$tool_dir" >> "$GITHUB_PATH"
 
       - name: Show validator versions
@@ -70,8 +71,9 @@ jobs:
           set -euo pipefail
           actionlint -version
           shellcheck --version
+          expected_shellcheck_version="${SHELLCHECK_TAG#v}"
           installed_shellcheck_version="$(shellcheck --version | awk '/^version:/ {print $2}')"
-          test "$installed_shellcheck_version" = "$SHELLCHECK_VERSION"
+          test "$installed_shellcheck_version" = "$expected_shellcheck_version"
 
       - name: Run actionlint
         shell: bash

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "dependencyDashboard": true,
   "timezone": "Europe/Madrid",
   "schedule": [
-    "before 6am on Monday"
+    "* 0-5 * * 1"
   ],
   "prConcurrentLimit": 5,
   "automerge": false,
@@ -32,6 +32,9 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchDepTypes": [
+        "action"
+      ],
       "matchUpdateTypes": [
         "digest",
         "patch",
@@ -40,20 +43,47 @@
       "groupName": "GitHub Actions non-major updates"
     },
     {
+      "description": "Delay workflow security tooling updates",
+      "matchDepNames": [
+        "rhysd/actionlint",
+        "zizmor",
+        "astral-sh/uv",
+        "koalaman/shellcheck",
+        "go"
+      ],
+      "minimumReleaseAge": "3 days",
+      "internalChecksFilter": "strict"
+    },
+    {
       "description": "Group non-major workflow security tooling updates",
       "matchDepNames": [
         "rhysd/actionlint",
         "zizmor",
         "astral-sh/uv",
-        "koalaman/shellcheck"
+        "koalaman/shellcheck",
+        "go"
       ],
       "matchUpdateTypes": [
         "patch",
         "minor"
       ],
-      "groupName": "Workflow security tooling",
-      "minimumReleaseAge": "3 days",
-      "internalChecksFilter": "strict"
+      "groupName": "Workflow security tooling"
+    },
+    {
+      "description": "Keep workflow Python on 3.14",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepTypes": [
+        "uses-with"
+      ],
+      "matchDepNames": [
+        "python"
+      ],
+      "matchPackageNames": [
+        "actions/python-versions"
+      ],
+      "allowedVersions": "/^3\\.14(?:\\.|$)/"
     },
     {
       "description": "Delay newly released Python tooling",

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,20 @@
   ],
   "prConcurrentLimit": 5,
   "automerge": false,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github\\/workflows\\/workflow-security\\.yml$/"
+      ],
+      "matchStrings": [
+        "# renovate: shellcheck-release\\s+SHELLCHECK_TAG:\\s*\"(?<currentValue>v[^\"]+)\"\\s+SHELLCHECK_SHA256:\\s*\"(?<currentDigest>[0-9a-f]{64})\""
+      ],
+      "datasourceTemplate": "github-release-attachments",
+      "depNameTemplate": "koalaman/shellcheck",
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group non-major GitHub Actions updates",
@@ -38,7 +52,8 @@
         "minor"
       ],
       "groupName": "Workflow security tooling",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "3 days",
+      "internalChecksFilter": "strict"
     },
     {
       "description": "Delay newly released Python tooling",

--- a/renovate.json
+++ b/renovate.json
@@ -29,13 +29,15 @@
       "description": "Group non-major workflow security tooling updates",
       "matchDepNames": [
         "rhysd/actionlint",
-        "zizmor"
+        "zizmor",
+        "astral-sh/uv"
       ],
       "matchUpdateTypes": [
         "patch",
         "minor"
       ],
-      "groupName": "Workflow security tooling"
+      "groupName": "Workflow security tooling",
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Delay newly released Python tooling",

--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,8 @@
       "matchDepNames": [
         "rhysd/actionlint",
         "zizmor",
-        "astral-sh/uv"
+        "astral-sh/uv",
+        "koalaman/shellcheck"
       ],
       "matchUpdateTypes": [
         "patch",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "customManagers:githubActionsVersions"
+  ],
+  "dependencyDashboard": true,
+  "timezone": "Europe/Madrid",
+  "schedule": [
+    "before 6am on Monday"
+  ],
+  "prConcurrentLimit": 5,
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor"
+      ],
+      "groupName": "GitHub Actions non-major updates"
+    },
+    {
+      "description": "Group non-major workflow security tooling updates",
+      "matchDepNames": [
+        "rhysd/actionlint",
+        "zizmor"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "Workflow security tooling"
+    },
+    {
+      "description": "Delay newly released Python tooling",
+      "matchManagers": [
+        "pip_requirements",
+        "pep621"
+      ],
+      "minimumReleaseAge": "3 days"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Pin all external GitHub Actions to verified full commit SHAs.
- Add blocking actionlint and zizmor workflow validation.
- Configure Renovate to maintain Action digests and security tool versions.
- Align CodeRabbit guidance with the full-SHA policy.

## Security model

Full 40-character commit SHAs make each workflow dependency immutable at review time. Every pinned ref was resolved through the GitHub API and checked against the canonical, non-fork repository; the retained version or branch comment gives Renovate the update context.

Renovate keeps GitHub Action digests pinned and maintains the annotated actionlint, zizmor, uv, and ShellCheck versions. ShellCheck uses a dedicated regex manager backed by Renovate's native `github-release-attachments` datasource, so its exact GitHub release tag and the digest of the matching official Linux x86_64 asset update atomically. The archive digest is still verified before installation, and a version/digest mismatch fails CI.

Renovate now runs in the Europe/Madrid Monday 00:00–05:59 window. Generic GitHub Action grouping is limited to `depType=action`, while setup-python `uses-with` values are constrained to the Python 3.14 line. Workflow security tools, including the extracted Go runtime, receive a strict three-day release delay for every update; patch and minor updates are additionally grouped, while majors stay separate for manual review.

The zizmor job audits workflows with minimum severity `high`, minimum confidence `medium`, strict workflow collection, GitHub annotations, and normal blocking exit codes. No new write permissions were added; only the existing release workflow retains `contents: write`.

## Validation

- YAML validation: Python/PyYAML parsed every workflow successfully.
- ShellCheck provenance: the final official `shellcheck-v0.11.0.linux.x86_64.tar.gz` passed SHA-256 verification with `b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6` and reported ShellCheck 0.11.0.
- actionlint: v1.7.12 passed all workflows using the explicitly installed ShellCheck 0.11.0.
- zizmor: `GH_TOKEN="$(gh auth token)" uvx 'zizmor@1.29.0' --format=github --min-severity=high --min-confidence=medium --collect=workflows --strict-collection .` passed.
- Renovate JSON: strict JSON parsing passed.
- Renovate config: `npx --yes --package renovate@44.7.1 renovate-config-validator renovate.json` validated successfully. The optional native RE2 module was unavailable locally, so the validator documented its RegExp fallback.
- Renovate extraction: a full local dry-run extracted ShellCheck exactly once with `depName=koalaman/shellcheck`, `datasource=github-release-attachments`, `currentValue=v0.11.0`, and the expected current digest. It was not detected by `customManagers:githubActionsVersions`.
- Atomic update proof: a temporary real v0.10.0 fixture produced one v0.11.0 proposal containing both `newValue` and `newDigest`. Historical releases before v0.11.0 only provide `.tar.xz`, so the fixture validated the corresponding official x86_64 `.tar.xz` asset and digest; the final workflow's v0.11.0 `.tar.gz` asset was separately downloaded, checksum-verified, extracted, and executed. All temporary changes were removed.
- Renovate policy extraction: setup-python is `python` / `actions/python-versions`, `github-releases`, `uses-with`, manager `github-actions`, current value `3.14`, in `lint.yml`, `package-test.yml`, `release.yml`, and `tests.yml`. setup-go is `go` / `actions/go-versions` with the same datasource/manager and `uses-with`, current value `1.26.5`, in `workflow-security.yml`. setup-uv's native expression is skipped as `invalid-value`; the annotated `UV_VERSION=0.12.1` is managed exactly once by the regex manager.
- Renovate duplicate/policy checks: ACTIONLINT_VERSION, ZIZMOR_VERSION, UV_VERSION, ShellCheck, and Go are each managed exactly once. `depType=action` alone receives generic Action grouping. Python remains limited to `3.14`; a temporary Go patch fixture resolved to `renovate/workflow-security-tooling`; patch/minor security tools are grouped and delayed, while majors are ungrouped but retain the delay.
- Full-SHA verification: every external Action reference has a 40-character hexadecimal SHA and a version/branch comment.
- Ruff: `python -m ruff check .` and `python -m ruff format --check .` passed.
- Compile: `python -m compileall custom_components tests` passed.
- Tests: `python -m pytest` passed, 571 tests.
- ZIP: the Package Test `git archive` command produced the integration-root ZIP; `python scripts/validate_release_zip.py <zip>` passed.
- Diff hygiene: `git diff --check` passed.
- Secret review: automated scans found no API keys, token values, credential-bearing URLs, private coordinates, real payloads, placeholders, abbreviated Action SHAs, `@latest`, or unpinned Actions.
- GitHub Actions: `lint`, `tests`, `package`, `validate`, `validate-hacs`, `actionlint`, and `zizmor` all passed on commit `2dd157a1b1a5ddd1a35eed425923b0e3c69ef56c`.

## Preserved behavior

- Integration runtime unchanged.
- Migration unchanged.
- Public entity and service contracts unchanged.
- Release trigger and release behavior unchanged.
- ZIP structure unchanged.
- Existing required check IDs unchanged: `lint`, `tests`, `package`, `validate`, and `validate-hacs`.
- No version metadata changed.

## Follow-ups

- Enable the repository policy requiring full-length Action SHAs after merge.
- Redesign the release workflow in a separate PR.
- Configure the main branch ruleset after the new checks have passed on main.
- Consider CodeQL separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved GitHub Actions security by pinning workflow actions to verified commit versions.
  * Added automated workflow checks for configuration errors and security risks.
  * Added read-only permissions and integrity verification for workflow tooling.

* **Maintenance**
  * Enhanced dependency update management with scheduling, grouping, release delays, and automated checks.
  * Preserved workflow behavior while improving update consistency and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->