### PR TITLE
ci: prepare release assets before publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.event.outputs.skip_release != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ steps.event.outputs.selected_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.event.outputs.selected_ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
-            echo "Prepare Release must run from refs/heads/main, not $WORKFLOW_REF." >&2
+            echo "Release must run from refs/heads/main, not $WORKFLOW_REF." >&2
             exit 1
           fi
 
@@ -93,8 +93,34 @@ jobs:
         if: steps.event.outputs.skip_release != 'true'
         id: release-commit
         shell: bash
+        env:
+          EVENT_MODE: ${{ steps.event.outputs.event_mode }}
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           set -euo pipefail
+          if [[ "$EVENT_MODE" == "prepare" && -n "$RELEASE_REF" ]]; then
+            if [[ "$RELEASE_REF" == *$'\n'* || "$RELEASE_REF" == refs/pull/* || "$RELEASE_REF" == pull/* || "$RELEASE_REF" == *:* ]]; then
+              echo "Unsupported release_ref." >&2
+              exit 1
+            fi
+            git fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
+            if [[ "$RELEASE_REF" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+              selected_commit="$(git rev-parse --verify "$RELEASE_REF^{commit}")"
+            else
+              branch="refs/remotes/origin/${RELEASE_REF#refs/heads/}"
+              tag="refs/tags/${RELEASE_REF#refs/tags/}"
+              branch_commit="$(git rev-parse --verify "$branch^{commit}" 2>/dev/null || true)"
+              tag_commit="$(git rev-parse --verify "$tag^{commit}" 2>/dev/null || true)"
+              if [[ -n "$branch_commit" && -n "$tag_commit" && "$branch_commit" != "$tag_commit" ]]; then echo "Ambiguous release_ref." >&2; exit 1; fi
+              selected_commit="${branch_commit:-$tag_commit}"
+              test -n "$selected_commit"
+            fi
+            if ! git branch -r --contains "$selected_commit" | grep -q . && ! git tag --contains "$selected_commit" | grep -q .; then
+              echo "release_ref commit is not reachable from a normal repository branch or tag." >&2
+              exit 1
+            fi
+            git checkout --detach "$selected_commit"
+          fi
           selected_commit="$(git rev-parse HEAD)"
           printf 'release_commit=%s\n' "$selected_commit" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            printf 'event_mode=prepare\nselected_ref=%s\nskip_release=false\n' "${INPUT_RELEASE_REF:-$GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            printf 'event_mode=prepare\nskip_release=false\n' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ jobs:
             echo "Selected release commit is not reachable from dispatched main." >&2
             exit 1
           fi
-          if ! git rev-list --first-parent "$DISPATCHED_MAIN_COMMIT" | grep -Fxq -- "$selected_commit"; then
+          first_parent_commits="$(mktemp)"
+          trap 'rm -f "$first_parent_commits"' EXIT
+          git rev-list --first-parent "$DISPATCHED_MAIN_COMMIT" > "$first_parent_commits"
+          if ! grep -Fxq -- "$selected_commit" "$first_parent_commits"; then
             echo "Selected release commit is not on dispatched main's first-parent history." >&2
             exit 1
           fi
@@ -315,6 +318,23 @@ jobs:
           actual_sha256="$(sha256sum pollenlevels.zip | awk '{print $1}')"
           if [[ "$actual_sha256" != "$VALIDATED_ZIP_SHA256" ]]; then
             echo "Downloaded ZIP digest does not match the validated artifact." >&2
+            exit 1
+          fi
+
+      - name: Validate GitHub CLI capability
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI is required but is not installed." >&2
+            exit 1
+          }
+          gh --version
+          gh_api_help="$(mktemp)"
+          trap 'rm -f "$gh_api_help"' EXIT
+          gh api --help > "$gh_api_help"
+          if ! grep -Fq -- "--slurp" "$gh_api_help"; then
+            echo "The installed GitHub CLI does not support required gh api --slurp." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
               echo "Published release has multiple pollenlevels.zip assets; inspect manually" >&2
               exit 1
             fi
-            printf 'event_mode=published-fallback\nselected_ref=%s\nskip_release=%s\n' "$EVENT_TAG" "$( (( ${#matches[@]} == 1 )) && echo true || echo false )" >> "$GITHUB_OUTPUT"
+            printf 'event_mode=published-fallback\nselected_ref=refs/tags/%s\nskip_release=%s\n' "$EVENT_TAG" "$( (( ${#matches[@]} == 1 )) && echo true || echo false )" >> "$GITHUB_OUTPUT"
             if (( ${#matches[@]} == 1 )); then
               {
                 echo "## Release fallback"
@@ -69,14 +69,6 @@ jobs:
             printf 'event_mode=prepare\nskip_release=false\n' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check out repository
-        if: steps.event.outputs.skip_release != 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.event.outputs.selected_ref }}
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Require the main branch
         if: github.event_name == 'workflow_dispatch'
         shell: bash
@@ -88,6 +80,14 @@ jobs:
             echo "Release must run from refs/heads/main, not $WORKFLOW_REF." >&2
             exit 1
           fi
+
+      - name: Check out repository
+        if: steps.event.outputs.skip_release != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || steps.event.outputs.selected_ref }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve selected snapshot
         if: steps.event.outputs.skip_release != 'true'
@@ -258,6 +258,18 @@ jobs:
               file.write(f"tag=v{version}\n")
               file.write(f"prerelease={str(prerelease).lower()}\n")
           PY
+
+      - name: Validate derived release tag
+        if: steps.event.outputs.skip_release != 'true'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! git check-ref-format "refs/tags/$RELEASE_TAG" >/dev/null; then
+            echo "Derived release tag is not a valid Git ref." >&2
+            exit 1
+          fi
 
       - name: Compile Python sources
         if: steps.event.outputs.skip_release != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_RELEASE_REF: ${{ inputs.release_ref }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           EVENT_RELEASE_ID: ${{ github.event.release.id }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Prepare Release
 on:
   workflow_dispatch:
     inputs:
-      release_commit:
-        description: "Full release PR squash commit SHA. Leave empty only when main still points to the release commit."
+      release_ref:
+        description: "Branch, tag, or full commit SHA to release. Leave empty for the current main commit."
         required: false
         type: string
 
@@ -32,7 +32,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -47,107 +47,13 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve and validate release commit
+      - name: Resolve selected snapshot
         id: release-commit
         shell: bash
-        env:
-          DISPATCHED_MAIN_COMMIT: ${{ github.sha }}
-          REQUESTED_RELEASE_COMMIT: ${{ inputs.release_commit }}
         run: |
           set -euo pipefail
-          if [[ -n "$REQUESTED_RELEASE_COMMIT" ]]; then
-            if [[ ! "$REQUESTED_RELEASE_COMMIT" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-              echo "release_commit must be a full 40-character hexadecimal SHA." >&2
-              exit 1
-            fi
-            selected_commit="$(git rev-parse --verify "$REQUESTED_RELEASE_COMMIT^{commit}")"
-          else
-            selected_commit="$(git rev-parse --verify "$DISPATCHED_MAIN_COMMIT^{commit}")"
-          fi
-
-          if ! git merge-base --is-ancestor "$selected_commit" "$DISPATCHED_MAIN_COMMIT"; then
-            echo "Selected release commit is not reachable from dispatched main." >&2
-            exit 1
-          fi
-          first_parent_commits="$(mktemp)"
-          trap 'rm -f "$first_parent_commits"' EXIT
-          git rev-list --first-parent "$DISPATCHED_MAIN_COMMIT" > "$first_parent_commits"
-          if ! grep -Fxq -- "$selected_commit" "$first_parent_commits"; then
-            echo "Selected release commit is not on dispatched main's first-parent history." >&2
-            exit 1
-          fi
-
-          SELECTED_COMMIT="$selected_commit" python - <<'PY'
-          import os
-          import subprocess
-
-          expected = {
-              "custom_components/pollenlevels/manifest.json",
-              "pyproject.toml",
-              "CHANGELOG.md",
-          }
-          selected = os.environ["SELECTED_COMMIT"]
-          parents = subprocess.check_output(
-              ["git", "rev-list", "--parents", "-n", "1", selected], text=True
-          ).split()
-          if len(parents) != 2:
-              raise SystemExit(
-                  "Selected release commit must be a normal single-parent commit"
-              )
-          parent = parents[1]
-          raw = subprocess.check_output(
-              [
-                  "git",
-                  "diff-tree",
-                  "--no-commit-id",
-                  "--name-status",
-                  "-r",
-                  "-z",
-                  parent,
-                  selected,
-              ]
-          )
-          fields = raw.split(b"\0")
-          if fields[-1:] == [b""]:
-              fields.pop()
-          changes: list[tuple[str, str]] = []
-          index = 0
-          while index < len(fields):
-              status = fields[index].decode("utf-8", "surrogateescape")
-              index += 1
-              if status[:1] in {"R", "C"}:
-                  old_path = fields[index].decode("utf-8", "surrogateescape")
-                  new_path = fields[index + 1].decode("utf-8", "surrogateescape")
-                  index += 2
-                  changes.append((status, f"{old_path} -> {new_path}"))
-              else:
-                  path = fields[index].decode("utf-8", "surrogateescape")
-                  index += 1
-                  changes.append((status, path))
-
-          actual_paths = {path for _, path in changes}
-          valid = (
-              len(changes) == 3
-              and actual_paths == expected
-              and all(status == "M" for status, _ in changes)
-          )
-          if not valid:
-              actual = ", ".join(f"{status} {path}" for status, path in changes)
-              raise SystemExit(
-                  "Selected release commit must change exactly manifest.json, "
-                  "pyproject.toml, and CHANGELOG.md as modifications. "
-                  f"Actual changes: {actual or '(none)'}"
-              )
-          PY
+          selected_commit="$(git rev-parse HEAD)"
           printf 'release_commit=%s\n' "$selected_commit" >> "$GITHUB_OUTPUT"
-
-      - name: Check out selected release commit
-        shell: bash
-        env:
-          SELECTED_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
-        run: |
-          set -euo pipefail
-          git checkout --detach "$SELECTED_COMMIT"
 
       - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -221,7 +127,7 @@ jobs:
           prerelease = bool(
               re.search(r"(?:a|b|rc)\d+", version, flags=re.IGNORECASE)
               or re.search(
-                  r"(?:alpha|beta|pre|preview|dev)", version, flags=re.IGNORECASE
+                  r"(?:alpha|beta|pre|preview|dev|test)", version, flags=re.IGNORECASE
               )
           )
           output = Path(os.environ["GITHUB_OUTPUT"])

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Prepare Release
+name: Release
 
 on:
   workflow_dispatch:
@@ -7,6 +7,8 @@ on:
         description: "Branch, tag, or full commit SHA to release. Leave empty for the current main commit."
         required: false
         type: string
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -27,16 +29,50 @@ jobs:
       prerelease: ${{ steps.metadata.outputs.prerelease }}
       zip_sha256: ${{ steps.zip-sha256.outputs.zip_sha256 }}
       release_commit: ${{ steps.release-commit.outputs.release_commit }}
+      event_mode: ${{ steps.event.outputs.event_mode }}
+      skip_release: ${{ steps.event.outputs.skip_release }}
 
     steps:
+      - name: Resolve release event
+        id: event
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RELEASE_REF: ${{ inputs.release_ref }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          EVENT_RELEASE_ID: ${{ github.event.release.id }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            command -v gh >/dev/null 2>&1
+            assets="$(mktemp)"
+            gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$EVENT_RELEASE_ID/assets?per_page=100" > "$assets"
+            ASSETS="$assets" python - <<'PY' >> "$GITHUB_OUTPUT"
+            import json, os
+            from pathlib import Path
+            assets = json.loads(Path(os.environ["ASSETS"]).read_text())
+            matches = [asset for asset in assets if asset.get("name") == "pollenlevels.zip"]
+            if len(matches) > 1:
+                raise SystemExit("Published release has multiple pollenlevels.zip assets; inspect manually")
+            print("event_mode=published-fallback")
+            print("selected_ref=" + os.environ["EVENT_TAG"])
+            print(f"skip_release={str(len(matches) == 1).lower()}")
+          PY
+          else
+            printf 'event_mode=prepare\nselected_ref=%s\nskip_release=false\n' "${INPUT_RELEASE_REF:-$GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out repository
+        if: steps.event.outputs.skip_release != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.release_ref || github.sha }}
+          ref: ${{ steps.event.outputs.selected_ref }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Require the main branch
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         env:
           WORKFLOW_REF: ${{ github.ref }}
@@ -48,6 +84,7 @@ jobs:
           fi
 
       - name: Resolve selected snapshot
+        if: steps.event.outputs.skip_release != 'true'
         id: release-commit
         shell: bash
         run: |
@@ -56,6 +93,7 @@ jobs:
           printf 'release_commit=%s\n' "$selected_commit" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.14
+        if: steps.event.outputs.skip_release != 'true'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.14"
@@ -63,6 +101,7 @@ jobs:
           cache-dependency-path: requirements_test.txt
 
       - name: Install validation dependencies
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -72,8 +111,12 @@ jobs:
           ruff --version
 
       - name: Validate release metadata
+        if: steps.event.outputs.skip_release != 'true'
         id: metadata
         shell: bash
+        env:
+          EVENT_MODE: ${{ steps.event.outputs.event_mode }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -123,6 +166,8 @@ jobs:
                   "Version mismatch: "
                   f"manifest={version!r} pyproject={project_version!r}"
               )
+          if os.environ["EVENT_MODE"] == "published-fallback" and os.environ["EVENT_TAG"] != f"v{version}":
+              raise SystemExit("Published release tag does not match the selected snapshot version")
 
           prerelease = bool(
               re.search(r"(?:a|b|rc)\d+", version, flags=re.IGNORECASE)
@@ -138,24 +183,28 @@ jobs:
           PY
 
       - name: Compile Python sources
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         run: |
           set -euo pipefail
           python -m compileall -q sitecustomize.py custom_components scripts tests
 
       - name: Ruff validation
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         run: |
           set -euo pipefail
           ruff check .
 
       - name: Ruff format validation
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         run: |
           set -euo pipefail
           ruff format --check .
 
       - name: Run tests
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         env:
           PYTHONPATH: .
@@ -164,12 +213,14 @@ jobs:
           python -m pytest -q
 
       - name: Build release ZIP (integration root at ZIP root)
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         run: |
           set -euo pipefail
           git archive --format=zip --output=pollenlevels.zip HEAD:custom_components/pollenlevels
 
       - name: Validate ZIP package
+        if: steps.event.outputs.skip_release != 'true'
         shell: bash
         env:
           EXPECTED_RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
@@ -179,6 +230,7 @@ jobs:
           python scripts/validate_release_zip.py "$ZIP_PATH"
 
       - name: Calculate ZIP SHA-256
+        if: steps.event.outputs.skip_release != 'true'
         id: zip-sha256
         shell: bash
         run: |
@@ -186,6 +238,7 @@ jobs:
           printf 'zip_sha256=%s\n' "$(sha256sum pollenlevels.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Upload validated ZIP
+        if: steps.event.outputs.skip_release != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pollenlevels-release-asset
@@ -193,8 +246,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  prepare-draft:
+  finalize-release:
     needs: validate-release
+    if: needs.validate-release.outputs.skip_release != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -245,6 +299,7 @@ jobs:
           fi
 
       - name: Preflight release state
+        if: needs.validate-release.outputs.event_mode == 'prepare'
         id: preflight
         shell: bash
         env:
@@ -338,7 +393,7 @@ jobs:
           PY
 
       - name: Create and verify release tag
-        if: steps.preflight.outputs.create_tag == 'true'
+        if: needs.validate-release.outputs.event_mode == 'prepare' && steps.preflight.outputs.create_tag == 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -368,7 +423,7 @@ jobs:
 
       - name: Create draft release
         id: create-draft
-        if: steps.preflight.outputs.release_mode == 'new'
+        if: needs.validate-release.outputs.event_mode == 'prepare' && steps.preflight.outputs.release_mode == 'new'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.validate-release.outputs.tag }}
@@ -382,7 +437,7 @@ jobs:
 
       - name: Update draft release asset
         id: update-draft
-        if: steps.preflight.outputs.release_mode == 'update'
+        if: needs.validate-release.outputs.event_mode == 'prepare' && steps.preflight.outputs.release_mode == 'update'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.validate-release.outputs.tag }}
@@ -392,6 +447,7 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Write release summary
+        if: needs.validate-release.outputs.event_mode == 'prepare'
         shell: bash
         env:
           RELEASE_MODE: ${{ steps.preflight.outputs.release_mode }}
@@ -432,3 +488,28 @@ jobs:
             echo
             echo "Next manual step: Review the draft release and publish it from the GitHub Releases page."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload missing published release ZIP
+        if: needs.validate-release.outputs.event_mode == 'published-fallback'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          assets="$(mktemp)"
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" > "$assets"
+          ASSETS="$assets" python - <<'PY' > "$RUNNER_TEMP/release_asset_state"
+          import json, os
+          from pathlib import Path
+          matches = [asset for asset in json.loads(Path(os.environ["ASSETS"]).read_text()) if asset.get("name") == "pollenlevels.zip"]
+          if len(matches) > 1:
+              raise SystemExit("Published release has multiple pollenlevels.zip assets; inspect manually")
+          print(len(matches))
+          PY
+          if [[ "$(cat "$RUNNER_TEMP/release_asset_state")" == "1" ]]; then
+            echo "Published release already contains pollenlevels.zip; skipping upload." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          gh release upload "$RELEASE_TAG" pollenlevels.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,9 +292,12 @@ jobs:
       - name: Build release ZIP (integration root at ZIP root)
         if: steps.event.outputs.skip_release != 'true'
         shell: bash
+        env:
+          RELEASE_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
         run: |
           set -euo pipefail
-          git archive --format=zip --output=pollenlevels.zip HEAD:custom_components/pollenlevels
+          git archive --format=zip --output=pollenlevels.zip \
+            "${RELEASE_COMMIT}:custom_components/pollenlevels"
 
       - name: Validate ZIP package
         if: steps.event.outputs.skip_release != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Prepare Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_commit:
+        description: "Full release PR squash commit SHA. Leave empty only when main still points to the release commit."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -21,12 +26,14 @@ jobs:
       tag: ${{ steps.metadata.outputs.tag }}
       prerelease: ${{ steps.metadata.outputs.prerelease }}
       zip_sha256: ${{ steps.zip-sha256.outputs.zip_sha256 }}
+      release_commit: ${{ steps.release-commit.outputs.release_commit }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Require the main branch
@@ -39,6 +46,105 @@ jobs:
             echo "Prepare Release must run from refs/heads/main, not $WORKFLOW_REF." >&2
             exit 1
           fi
+
+      - name: Resolve and validate release commit
+        id: release-commit
+        shell: bash
+        env:
+          DISPATCHED_MAIN_COMMIT: ${{ github.sha }}
+          REQUESTED_RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$REQUESTED_RELEASE_COMMIT" ]]; then
+            if [[ ! "$REQUESTED_RELEASE_COMMIT" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+              echo "release_commit must be a full 40-character hexadecimal SHA." >&2
+              exit 1
+            fi
+            selected_commit="$(git rev-parse --verify "$REQUESTED_RELEASE_COMMIT^{commit}")"
+          else
+            selected_commit="$(git rev-parse --verify "$DISPATCHED_MAIN_COMMIT^{commit}")"
+          fi
+
+          if ! git merge-base --is-ancestor "$selected_commit" "$DISPATCHED_MAIN_COMMIT"; then
+            echo "Selected release commit is not reachable from dispatched main." >&2
+            exit 1
+          fi
+          if ! git rev-list --first-parent "$DISPATCHED_MAIN_COMMIT" | grep -Fxq -- "$selected_commit"; then
+            echo "Selected release commit is not on dispatched main's first-parent history." >&2
+            exit 1
+          fi
+
+          SELECTED_COMMIT="$selected_commit" python - <<'PY'
+          import os
+          import subprocess
+
+          expected = {
+              "custom_components/pollenlevels/manifest.json",
+              "pyproject.toml",
+              "CHANGELOG.md",
+          }
+          selected = os.environ["SELECTED_COMMIT"]
+          parents = subprocess.check_output(
+              ["git", "rev-list", "--parents", "-n", "1", selected], text=True
+          ).split()
+          if len(parents) != 2:
+              raise SystemExit(
+                  "Selected release commit must be a normal single-parent commit"
+              )
+          parent = parents[1]
+          raw = subprocess.check_output(
+              [
+                  "git",
+                  "diff-tree",
+                  "--no-commit-id",
+                  "--name-status",
+                  "-r",
+                  "-z",
+                  parent,
+                  selected,
+              ]
+          )
+          fields = raw.split(b"\0")
+          if fields[-1:] == [b""]:
+              fields.pop()
+          changes: list[tuple[str, str]] = []
+          index = 0
+          while index < len(fields):
+              status = fields[index].decode("utf-8", "surrogateescape")
+              index += 1
+              if status[:1] in {"R", "C"}:
+                  old_path = fields[index].decode("utf-8", "surrogateescape")
+                  new_path = fields[index + 1].decode("utf-8", "surrogateescape")
+                  index += 2
+                  changes.append((status, f"{old_path} -> {new_path}"))
+              else:
+                  path = fields[index].decode("utf-8", "surrogateescape")
+                  index += 1
+                  changes.append((status, path))
+
+          actual_paths = {path for _, path in changes}
+          valid = (
+              len(changes) == 3
+              and actual_paths == expected
+              and all(status == "M" for status, _ in changes)
+          )
+          if not valid:
+              actual = ", ".join(f"{status} {path}" for status, path in changes)
+              raise SystemExit(
+                  "Selected release commit must change exactly manifest.json, "
+                  "pyproject.toml, and CHANGELOG.md as modifications. "
+                  f"Actual changes: {actual or '(none)'}"
+              )
+          PY
+          printf 'release_commit=%s\n' "$selected_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Check out selected release commit
+        shell: bash
+        env:
+          SELECTED_COMMIT: ${{ steps.release-commit.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "$SELECTED_COMMIT"
 
       - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -189,7 +295,7 @@ jobs:
       - name: Check out validated commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.validate-release.outputs.release_commit }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -218,7 +324,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
-          VALIDATED_COMMIT: ${{ github.sha }}
+          VALIDATED_COMMIT: ${{ needs.validate-release.outputs.release_commit }}
         run: |
           set -euo pipefail
 
@@ -277,6 +383,8 @@ jobs:
           if not matches:
               print("release_mode=new")
               print("release_url=")
+              print(f"tag_exists={os.environ['TAG_EXISTS']}")
+              print(f"create_tag={str(os.environ['TAG_EXISTS'] != 'true').lower()}")
               raise SystemExit(0)
 
           release = matches[0]
@@ -299,6 +407,37 @@ jobs:
 
           print("release_mode=update")
           print(f"release_url={url}")
+          print(f"tag_exists={os.environ['TAG_EXISTS']}")
+          print(f"create_tag={str(os.environ['TAG_EXISTS'] != 'true').lower()}")
+          PY
+
+      - name: Create and verify release tag
+        if: steps.preflight.outputs.create_tag == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+          VALIDATED_COMMIT: ${{ needs.validate-release.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+          gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f "ref=refs/tags/$RELEASE_TAG" -f "sha=$VALIDATED_COMMIT" >/dev/null
+          tag_response="$(mktemp)"
+          gh api --method GET "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+            > "$tag_response"
+          TAG_RESPONSE="$tag_response" VALIDATED_COMMIT="$VALIDATED_COMMIT" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          reference = json.loads(Path(os.environ["TAG_RESPONSE"]).read_text())
+          object_data = reference.get("object") if isinstance(reference, dict) else None
+          if (
+              not isinstance(object_data, dict)
+              or object_data.get("type") != "commit"
+              or object_data.get("sha") != os.environ["VALIDATED_COMMIT"]
+          ):
+              raise SystemExit("Created Git tag does not resolve to the validated commit")
           PY
 
       - name: Create draft release
@@ -307,7 +446,6 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.validate-release.outputs.tag }}
-          target_commitish: ${{ github.sha }}
           name: ${{ needs.validate-release.outputs.tag }}
           draft: true
           prerelease: ${{ needs.validate-release.outputs.prerelease }}
@@ -315,7 +453,6 @@ jobs:
           files: pollenlevels.zip
           overwrite_files: true
           fail_on_unmatched_files: true
-          make_latest: false
 
       - name: Update draft release asset
         id: update-draft
@@ -338,7 +475,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
           RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
           PRERELEASE: ${{ needs.validate-release.outputs.prerelease }}
-          VALIDATED_COMMIT: ${{ github.sha }}
+          VALIDATED_COMMIT: ${{ needs.validate-release.outputs.release_commit }}
           ZIP_SHA256: ${{ needs.validate-release.outputs.zip_sha256 }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,25 +99,70 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$EVENT_MODE" == "prepare" && -n "$RELEASE_REF" ]]; then
-            if [[ "$RELEASE_REF" == *$'\n'* || "$RELEASE_REF" == refs/pull/* || "$RELEASE_REF" == pull/* || "$RELEASE_REF" == *:* ]]; then
+            if [[ "$RELEASE_REF" == *$'\n'* || "$RELEASE_REF" == *$'\r'* || "$RELEASE_REF" == refs/pull/* || "$RELEASE_REF" == pull/* || "$RELEASE_REF" == *:* ]]; then
               echo "Unsupported release_ref." >&2
               exit 1
             fi
             git fetch --no-tags origin '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*'
             if [[ "$RELEASE_REF" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-              selected_commit="$(git rev-parse --verify "$RELEASE_REF^{commit}")"
+              selected_commit="$(git rev-parse --verify "$RELEASE_REF^{commit}" 2>/dev/null)" || {
+                echo "release_ref does not identify an existing commit." >&2
+                exit 1
+              }
+              containing_ref="$(git for-each-ref --count=1 --format='%(refname)' \
+                --contains "$selected_commit" refs/remotes/origin refs/tags)"
+              if [[ -z "$containing_ref" ]]; then
+                echo "release_ref commit is not reachable from a normal repository branch or tag." >&2
+                exit 1
+              fi
+            elif [[ "$RELEASE_REF" =~ ^[0-9A-Fa-f]{4,39}$ ]]; then
+              echo "Abbreviated commit SHAs are not supported." >&2
+              exit 1
+            elif [[ "$RELEASE_REF" == refs/heads/* ]]; then
+              branch_name="${RELEASE_REF#refs/heads/}"
+              git check-ref-format --branch "$branch_name" >/dev/null || {
+                echo "Invalid branch release_ref." >&2
+                exit 1
+              }
+              selected_commit="$(git rev-parse --verify \
+                "refs/remotes/origin/$branch_name^{commit}" 2>/dev/null)" || {
+                echo "Unknown branch release_ref." >&2
+                exit 1
+              }
+            elif [[ "$RELEASE_REF" == refs/tags/* ]]; then
+              tag_name="${RELEASE_REF#refs/tags/}"
+              git check-ref-format "refs/tags/$tag_name" >/dev/null || {
+                echo "Invalid tag release_ref." >&2
+                exit 1
+              }
+              selected_commit="$(git rev-parse --verify \
+                "refs/tags/$tag_name^{commit}" 2>/dev/null)" || {
+                echo "Unknown tag release_ref." >&2
+                exit 1
+              }
             else
-              branch="refs/remotes/origin/${RELEASE_REF#refs/heads/}"
-              tag="refs/tags/${RELEASE_REF#refs/tags/}"
-              branch_commit="$(git rev-parse --verify "$branch^{commit}" 2>/dev/null || true)"
-              tag_commit="$(git rev-parse --verify "$tag^{commit}" 2>/dev/null || true)"
+              if [[ "$RELEASE_REF" == refs/* ]]; then
+                echo "Unsupported release_ref namespace." >&2
+                exit 1
+              fi
+              git check-ref-format --branch "$RELEASE_REF" >/dev/null || {
+                echo "Invalid branch or tag release_ref." >&2
+                exit 1
+              }
+              git check-ref-format "refs/tags/$RELEASE_REF" >/dev/null || {
+                echo "Invalid branch or tag release_ref." >&2
+                exit 1
+              }
+              branch_commit="$(git rev-parse --verify \
+                "refs/remotes/origin/$RELEASE_REF^{commit}" 2>/dev/null || true)"
+              tag_commit="$(git rev-parse --verify \
+                "refs/tags/$RELEASE_REF^{commit}" 2>/dev/null || true)"
               if [[ -n "$branch_commit" && -n "$tag_commit" && "$branch_commit" != "$tag_commit" ]]; then echo "Ambiguous release_ref." >&2; exit 1; fi
               selected_commit="${branch_commit:-$tag_commit}"
-              test -n "$selected_commit"
-            fi
-            if ! git branch -r --contains "$selected_commit" | grep -q . && ! git tag --contains "$selected_commit" | grep -q .; then
-              echo "release_ref commit is not reachable from a normal repository branch or tag." >&2
-              exit 1
+              if [[ -z "$selected_commit" ]]; then
+                echo "Unknown branch or tag release_ref." >&2
+                exit 1
+              fi
             fi
             git checkout --detach "$selected_commit"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,19 +46,25 @@ jobs:
           set -euo pipefail
           if [[ "$EVENT_NAME" == "release" ]]; then
             command -v gh >/dev/null 2>&1
-            assets="$(mktemp)"
-            gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$EVENT_RELEASE_ID/assets?per_page=100" > "$assets"
-            ASSETS="$assets" python - <<'PY' >> "$GITHUB_OUTPUT"
-            import json, os
-            from pathlib import Path
-            assets = json.loads(Path(os.environ["ASSETS"]).read_text())
-            matches = [asset for asset in assets if asset.get("name") == "pollenlevels.zip"]
-            if len(matches) > 1:
-                raise SystemExit("Published release has multiple pollenlevels.zip assets; inspect manually")
-            print("event_mode=published-fallback")
-            print("selected_ref=" + os.environ["EVENT_TAG"])
-            print(f"skip_release={str(len(matches) == 1).lower()}")
-          PY
+            asset_ids="$(mktemp)"
+            trap 'rm -f "$asset_ids"' EXIT
+            gh api --paginate --jq '.[] | select(.name == "pollenlevels.zip") | .id' \
+              "repos/$GITHUB_REPOSITORY/releases/$EVENT_RELEASE_ID/assets?per_page=100" > "$asset_ids"
+            mapfile -t matches < "$asset_ids"
+            if (( ${#matches[@]} > 1 )); then
+              echo "Published release has multiple pollenlevels.zip assets; inspect manually" >&2
+              exit 1
+            fi
+            printf 'event_mode=published-fallback\nselected_ref=%s\nskip_release=%s\n' "$EVENT_TAG" "$( (( ${#matches[@]} == 1 )) && echo true || echo false )" >> "$GITHUB_OUTPUT"
+            if (( ${#matches[@]} == 1 )); then
+              {
+                echo "## Release fallback"
+                echo "- Release tag: \`$EVENT_TAG\`"
+                echo "- Release ID: \`$EVENT_RELEASE_ID\`"
+                echo "- Result: existing \`pollenlevels.zip\` detected."
+                echo "- No validation, build, or upload was required; the existing asset was not modified."
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           else
             printf 'event_mode=prepare\nselected_ref=%s\nskip_release=false\n' "${INPUT_RELEASE_REF:-$GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi
@@ -498,17 +504,16 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          assets="$(mktemp)"
-          gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" > "$assets"
-          ASSETS="$assets" python - <<'PY' > "$RUNNER_TEMP/release_asset_state"
-          import json, os
-          from pathlib import Path
-          matches = [asset for asset in json.loads(Path(os.environ["ASSETS"]).read_text()) if asset.get("name") == "pollenlevels.zip"]
-          if len(matches) > 1:
-              raise SystemExit("Published release has multiple pollenlevels.zip assets; inspect manually")
-          print(len(matches))
-          PY
-          if [[ "$(cat "$RUNNER_TEMP/release_asset_state")" == "1" ]]; then
+          asset_ids="$(mktemp)"
+          trap 'rm -f "$asset_ids"' EXIT
+          gh api --paginate --jq '.[] | select(.name == "pollenlevels.zip") | .id' \
+            "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100" > "$asset_ids"
+          mapfile -t matches < "$asset_ids"
+          if (( ${#matches[@]} > 1 )); then
+            echo "Published release has multiple pollenlevels.zip assets; inspect manually" >&2
+            exit 1
+          fi
+          if (( ${#matches[@]} == 1 )); then
             echo "Published release already contains pollenlevels.zip; skipping upload." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,44 @@
-name: Release Asset
+name: Prepare Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.event.release.tag_name || github.ref_name }}
+  group: prepare-release
   cancel-in-progress: false
 
 jobs:
-  package-and-upload:
+  validate-release:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      tag: ${{ steps.metadata.outputs.tag }}
+      prerelease: ${{ steps.metadata.outputs.prerelease }}
+      zip_sha256: ${{ steps.zip-sha256.outputs.zip_sha256 }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.sha }}
           persist-credentials: false
+
+      - name: Require the main branch
+        shell: bash
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Prepare Release must run from refs/heads/main, not $WORKFLOW_REF." >&2
+            exit 1
+          fi
 
       - name: Set up Python 3.14
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
@@ -38,6 +55,72 @@ jobs:
           python -m pip install --upgrade "ruff>=0.15"
           python -m pip install -r requirements_test.txt
           ruff --version
+
+      - name: Validate release metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("custom_components/pollenlevels/manifest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if not isinstance(manifest, dict):
+              raise SystemExit("manifest.json root is not an object")
+          if manifest.get("domain") != "pollenlevels":
+              raise SystemExit("manifest.domain must be 'pollenlevels'")
+
+          version = manifest.get("version")
+          if (
+              not isinstance(version, str)
+              or not version.strip()
+              or version != version.strip()
+              or "\n" in version
+              or "\r" in version
+          ):
+              raise SystemExit("manifest.version must be a non-empty single-line string")
+
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          project_section = project.get("project")
+          if not isinstance(project_section, dict):
+              raise SystemExit("pyproject.toml is missing [project]")
+          project_version = project_section.get("version")
+          if (
+              not isinstance(project_version, str)
+              or not project_version.strip()
+              or project_version != project_version.strip()
+              or "\n" in project_version
+              or "\r" in project_version
+          ):
+              raise SystemExit(
+                  "[project].version must be a non-empty single-line string"
+              )
+          if project_version != version:
+              raise SystemExit(
+                  "Version mismatch: "
+                  f"manifest={version!r} pyproject={project_version!r}"
+              )
+
+          prerelease = bool(
+              re.search(r"(?:a|b|rc)\d+", version, flags=re.IGNORECASE)
+              or re.search(
+                  r"(?:alpha|beta|pre|preview|dev)", version, flags=re.IGNORECASE
+              )
+          )
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as file:
+              file.write(f"version={version}\n")
+              file.write(f"tag=v{version}\n")
+              file.write(f"prerelease={str(prerelease).lower()}\n")
+          PY
 
       - name: Compile Python sources
         shell: bash
@@ -59,31 +142,211 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          PYTHONPATH: .
         run: |
           set -euo pipefail
           python -m pytest -q
-        env:
-          PYTHONPATH: .
 
       - name: Build release ZIP (integration root at ZIP root)
         shell: bash
         run: |
           set -euo pipefail
-          rm -f "${{ github.workspace }}/pollenlevels.zip"
-          git archive --format=zip --output="${{ github.workspace }}/pollenlevels.zip" HEAD:custom_components/pollenlevels
+          git archive --format=zip --output=pollenlevels.zip HEAD:custom_components/pollenlevels
 
       - name: Validate ZIP package
         shell: bash
         env:
-          EXPECTED_RELEASE_TAG: ${{ github.event.release.tag_name }}
-          ZIP_PATH: ${{ github.workspace }}/pollenlevels.zip
+          EXPECTED_RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+          ZIP_PATH: pollenlevels.zip
         run: |
           set -euo pipefail
           python scripts/validate_release_zip.py "$ZIP_PATH"
 
-      - name: Upload ZIP to release
+      - name: Calculate ZIP SHA-256
+        id: zip-sha256
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'zip_sha256=%s\n' "$(sha256sum pollenlevels.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Upload validated ZIP
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pollenlevels-release-asset
+          path: pollenlevels.zip
+          if-no-files-found: error
+          retention-days: 1
+
+  prepare-draft:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download validated ZIP
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pollenlevels-release-asset
+          path: .
+
+      - name: Verify validated ZIP digest
+        shell: bash
+        env:
+          VALIDATED_ZIP_SHA256: ${{ needs.validate-release.outputs.zip_sha256 }}
+        run: |
+          set -euo pipefail
+          test -f pollenlevels.zip
+          actual_sha256="$(sha256sum pollenlevels.zip | awk '{print $1}')"
+          if [[ "$actual_sha256" != "$VALIDATED_ZIP_SHA256" ]]; then
+            echo "Downloaded ZIP digest does not match the validated artifact." >&2
+            exit 1
+          fi
+
+      - name: Preflight release state
+        id: preflight
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+          VALIDATED_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          release_response="$(mktemp)"
+          release_error="$(mktemp)"
+
+          tag_refs="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}")"
+          if [[ -n "$tag_refs" ]]; then
+            tag_exists=true
+            tag_commit="$(printf '%s\n' "$tag_refs" | awk '
+              $2 ~ /\^\{\}$/ { peeled = $1 }
+              $2 !~ /\^\{\}$/ { direct = $1 }
+              END { print peeled ? peeled : direct }
+            ')"
+            if [[ "$tag_commit" != "$VALIDATED_COMMIT" ]]; then
+              echo "Existing tag $RELEASE_TAG points to $tag_commit, not $VALIDATED_COMMIT." >&2
+              exit 1
+            fi
+          else
+            tag_exists=false
+          fi
+
+          set +e
+          gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            >"$release_response" 2>"$release_error"
+          api_exit=$?
+          set -e
+          api_status="$(sed -n '1s/HTTP\/[0-9.]* \([0-9][0-9]*\).*/\1/p' "$release_response")"
+
+          if [[ "$api_exit" -ne 0 && "$api_status" != "404" ]]; then
+            cat "$release_error" >&2
+            exit "$api_exit"
+          fi
+
+          if [[ "$api_status" == "404" ]]; then
+            printf 'release_mode=new\nrelease_url=\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$tag_exists" != true ]]; then
+            echo "A release exists for $RELEASE_TAG but its Git tag is missing." >&2
+            exit 1
+          fi
+
+          RELEASE_RESPONSE="$release_response" python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+          from pathlib import Path
+
+          raw = Path(os.environ["RELEASE_RESPONSE"]).read_bytes()
+          for separator in (b"\r\n\r\n", b"\n\n"):
+              if separator in raw:
+                  raw = raw.split(separator, 1)[1]
+                  break
+          release = json.loads(raw)
+          if not release.get("draft"):
+              raise SystemExit("Release is already published; refusing to modify it")
+          url = release.get("html_url")
+          if not isinstance(url, str):
+              raise SystemExit("Draft release response does not include html_url")
+          print("release_mode=update")
+          print(f"release_url={url}")
+          PY
+
+      - name: Create draft release
+        id: create-draft
+        if: steps.preflight.outputs.release_mode == 'new'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          tag_name: ${{ needs.validate-release.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          name: ${{ needs.validate-release.outputs.tag }}
+          draft: true
+          prerelease: ${{ needs.validate-release.outputs.prerelease }}
+          generate_release_notes: true
           files: pollenlevels.zip
           overwrite_files: true
           fail_on_unmatched_files: true
+          make_latest: false
+
+      - name: Update draft release asset
+        id: update-draft
+        if: steps.preflight.outputs.release_mode == 'update'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
+        with:
+          tag_name: ${{ needs.validate-release.outputs.tag }}
+          draft: true
+          files: pollenlevels.zip
+          overwrite_files: true
+          fail_on_unmatched_files: true
+
+      - name: Write release summary
+        shell: bash
+        env:
+          RELEASE_MODE: ${{ steps.preflight.outputs.release_mode }}
+          PREEXISTING_RELEASE_URL: ${{ steps.preflight.outputs.release_url }}
+          CREATED_RELEASE_URL: ${{ steps.create-draft.outputs.url }}
+          UPDATED_RELEASE_URL: ${{ steps.update-draft.outputs.url }}
+          RELEASE_VERSION: ${{ needs.validate-release.outputs.version }}
+          RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+          PRERELEASE: ${{ needs.validate-release.outputs.prerelease }}
+          VALIDATED_COMMIT: ${{ github.sha }}
+          ZIP_SHA256: ${{ needs.validate-release.outputs.zip_sha256 }}
+        run: |
+          set -euo pipefail
+          release_url="$PREEXISTING_RELEASE_URL"
+          if [[ -z "$release_url" ]]; then
+            release_url="$CREATED_RELEASE_URL"
+          fi
+          if [[ -z "$release_url" ]]; then
+            release_url="$UPDATED_RELEASE_URL"
+          fi
+          if [[ "$RELEASE_MODE" == "new" ]]; then
+            release_action="Created a new draft release"
+          else
+            release_action="Updated the existing draft release asset"
+          fi
+          {
+            echo "## Prepare Release"
+            echo
+            echo "- Version: \`$RELEASE_VERSION\`"
+            echo "- Tag: \`$RELEASE_TAG\`"
+            echo "- Commit: \`$VALIDATED_COMMIT\`"
+            echo "- Prerelease: \`$PRERELEASE\`"
+            echo "- ZIP SHA-256: \`$ZIP_SHA256\`"
+            echo "- Result: $release_action"
+            if [[ -n "$release_url" ]]; then
+              echo "- Draft release: $release_url"
+            fi
+            echo
+            echo "Next manual step: Review the draft release and publish it from the GitHub Releases page."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,8 +221,6 @@ jobs:
           VALIDATED_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
-          release_response="$(mktemp)"
-          release_error="$(mktemp)"
 
           tag_refs="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG" "refs/tags/$RELEASE_TAG^{}")"
           if [[ -n "$tag_refs" ]]; then
@@ -240,44 +238,65 @@ jobs:
             tag_exists=false
           fi
 
-          set +e
-          gh api --include "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
-            >"$release_response" 2>"$release_error"
-          api_exit=$?
-          set -e
-          api_status="$(sed -n '1s/HTTP\/[0-9.]* \([0-9][0-9]*\).*/\1/p' "$release_response")"
+          releases_response="$(mktemp)"
+          gh api --paginate --slurp --method GET \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" > "$releases_response"
 
-          if [[ "$api_exit" -ne 0 && "$api_status" != "404" ]]; then
-            cat "$release_error" >&2
-            exit "$api_exit"
-          fi
-
-          if [[ "$api_status" == "404" ]]; then
-            printf 'release_mode=new\nrelease_url=\n' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "$tag_exists" != true ]]; then
-            echo "A release exists for $RELEASE_TAG but its Git tag is missing." >&2
-            exit 1
-          fi
-
-          RELEASE_RESPONSE="$release_response" python - <<'PY' >> "$GITHUB_OUTPUT"
+          RELEASES_RESPONSE="$releases_response" \
+          TAG_EXISTS="$tag_exists" \
+          TAG_COMMIT="${tag_commit:-}" \
+          RELEASE_TAG="$RELEASE_TAG" \
+          VALIDATED_COMMIT="$VALIDATED_COMMIT" \
+          python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os
           from pathlib import Path
 
-          raw = Path(os.environ["RELEASE_RESPONSE"]).read_bytes()
-          for separator in (b"\r\n\r\n", b"\n\n"):
-              if separator in raw:
-                  raw = raw.split(separator, 1)[1]
-                  break
-          release = json.loads(raw)
-          if not release.get("draft"):
+          try:
+              pages = json.loads(Path(os.environ["RELEASES_RESPONSE"]).read_text())
+          except (OSError, json.JSONDecodeError) as error:
+              raise SystemExit(f"Unable to parse paginated releases response: {error}")
+
+          if not isinstance(pages, list) or not all(isinstance(page, list) for page in pages):
+              raise SystemExit("Paginated releases response is not a list of pages")
+
+          releases = [release for page in pages for release in page]
+          if not all(isinstance(release, dict) for release in releases):
+              raise SystemExit("Paginated releases response contains an invalid record")
+          matches = [
+              release
+              for release in releases
+              if release.get("tag_name") == os.environ["RELEASE_TAG"]
+          ]
+          if len(matches) > 1:
+              raise SystemExit(
+                  "Multiple release records use tag "
+                  f"{os.environ['RELEASE_TAG']!r}; clean them up manually"
+              )
+
+          if not matches:
+              print("release_mode=new")
+              print("release_url=")
+              raise SystemExit(0)
+
+          release = matches[0]
+          if release.get("draft") is not True:
               raise SystemExit("Release is already published; refusing to modify it")
           url = release.get("html_url")
-          if not isinstance(url, str):
+          if not isinstance(url, str) or not url:
               raise SystemExit("Draft release response does not include html_url")
+
+          if os.environ["TAG_EXISTS"] == "true":
+              if os.environ["TAG_COMMIT"] != os.environ["VALIDATED_COMMIT"]:
+                  raise SystemExit("Existing Git tag does not match the validated commit")
+          else:
+              target_commitish = release.get("target_commitish")
+              if target_commitish != os.environ["VALIDATED_COMMIT"]:
+                  raise SystemExit(
+                      "Draft release has no Git ref and target_commitish does not "
+                      "match the validated commit"
+                  )
+
           print("release_mode=update")
           print(f"release_url={url}")
           PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,10 @@
   - `ruff format .`
   - `ruff format --check .`
   - `python -m pytest -q`
+
+## Releases
+
+Release preparation is restricted to maintainers. See
+[`RELEASING.md`](RELEASING.md) for the version, validation, draft-release,
+publication, and post-release verification process. Contributors must not
+manually create tags or releases as part of a normal pull request.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,16 +30,21 @@ Before merging, ensure that all required checks are green and all reviews and
 conversations are resolved. Use **Squash and merge**, then confirm that the
 exact release commit is on `main`.
 
-## 3. Prepare the draft release
+## 3. Release
 
-Normal stable release:
+Recommended draft-first mode:
 
 1. Open **Actions**.
-2. Open **Prepare Release**.
+2. Open **Release**.
 3. Select **Run workflow**.
 4. Select branch `main`.
 5. Leave `release_ref` empty to release the current `main` snapshot.
-6. Run the workflow.
+6. Run the workflow. It validates, builds the ZIP, creates or reuses the tag,
+   and prepares a draft.
+
+Review the draft and publish manually. The resulting `release: published` run
+detects the existing `pollenlevels.zip` and exits successfully without
+replacing it.
 
 Specific snapshot:
 
@@ -78,12 +83,23 @@ intended prerelease version, and verify GitHub marks the draft as a prerelease.
 - Confirm no unexpected asset is present.
 - Confirm the workflow completed successfully.
 
+## Emergency published fallback
+
+A trusted maintainer may manually create a tag and publish a GitHub release.
+The `release: published` event starts the same Release workflow. When
+`pollenlevels.zip` is absent, it validates the tagged snapshot, builds and
+validates the ZIP, and attaches it. The release is already public while this
+runs, so a failure leaves a public release requiring maintainer action.
+
+Prepare mode refuses to alter an already published release. Published-fallback
+mode may attach exactly one missing `pollenlevels.zip`, but never moves a tag,
+replaces an existing ZIP, or changes release metadata. Draft-first remains the
+recommended path; the published fallback is for exceptional use.
+
 ## 5. Publish
 
 Publication is always manual. For prereleases, ensure the pre-release option is
 enabled. For stable releases, ensure it is disabled.
-
-Do not manually create a tag or an empty release.
 
 ## 6. Verify the published package
 
@@ -114,7 +130,7 @@ after publication do not necessarily require a new release.
 - [ ] Changelog is complete.
 - [ ] Release PR checks are green.
 - [ ] Release PR was squash merged.
-- [ ] Prepare Release ran on `main`.
+- [ ] Release ran through either the draft-first or published-fallback route.
 - [ ] Draft review is complete.
 - [ ] `pollenlevels.zip` is attached.
 - [ ] Prerelease status is correct.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,87 @@
+# Releasing Pollen Levels
+
+## Release model
+
+Pollen Levels releases are prepared as GitHub drafts. A maintainer publishes a
+release manually only after all validation and package asset checks have passed.
+
+## 1. Prepare the release pull request
+
+Create a release-only pull request. It should normally modify only:
+
+- `custom_components/pollenlevels/manifest.json`
+- `pyproject.toml`
+- `CHANGELOG.md`
+
+The manifest and project versions must match exactly. The release tag is
+derived automatically: version `3.0.1` maps to tag `v3.0.1`, and version
+`3.0.1rc1` maps to tag `v3.0.1rc1`.
+
+Include backup, no-downgrade, migration, and prerelease notes where applicable.
+
+## 2. Merge the release pull request
+
+Before merging, ensure that all required checks are green and all reviews and
+conversations are resolved. Use **Squash and merge**, then confirm that the
+exact release commit is on `main`.
+
+## 3. Prepare the draft release
+
+1. Open **Actions**.
+2. Open **Prepare Release**.
+3. Select **Run workflow**.
+4. Select branch `main`.
+5. Run the workflow.
+
+No version or tag needs to be typed. The workflow reads and validates both
+version files, runs tests, builds and validates the ZIP, creates the correct
+tag, prepares a draft, and attaches `pollenlevels.zip`.
+
+## 4. Review the draft
+
+- Confirm the tag matches the intended version.
+- Confirm the target commit is the release PR squash commit.
+- Confirm the prerelease status is correct.
+- Review and edit generated notes as needed.
+- Confirm backup and downgrade warnings are present for v3 where applicable.
+- Confirm `pollenlevels.zip` is attached.
+- Confirm no unexpected asset is present.
+- Confirm the workflow completed successfully.
+
+## 5. Publish
+
+Publication is always manual. For prereleases, ensure the pre-release option is
+enabled. For stable releases, ensure it is disabled.
+
+Do not manually create a tag or an empty release.
+
+## 6. Verify the published package
+
+- Confirm the published release contains `pollenlevels.zip`.
+- Confirm HACS installation or Redownload uses the published asset.
+- Confirm Home Assistant restarts cleanly.
+- Confirm the displayed integration version is correct.
+- Complete smoke tests appropriate to the release.
+
+## Recovery and reruns
+
+Rerunning Prepare Release before publication is supported: it replaces the ZIP
+asset on an existing draft while preserving manually edited draft notes. The
+workflow refuses to change an already published release. A tag pointing to a
+different commit is a hard failure. Failed validation does not create a public
+release.
+
+Do not manually move or delete a release tag to bypass validation.
+
+## Release checklist
+
+- [ ] Manifest and project version files match.
+- [ ] Changelog is complete.
+- [ ] Release PR checks are green.
+- [ ] Release PR was squash merged.
+- [ ] Prepare Release ran on `main`.
+- [ ] Draft review is complete.
+- [ ] `pollenlevels.zip` is attached.
+- [ ] Prerelease status is correct.
+- [ ] The release was published manually.
+- [ ] HACS package verification is complete.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,22 +27,45 @@ exact release commit is on `main`.
 
 ## 3. Prepare the draft release
 
+Normal path:
+
 1. Open **Actions**.
 2. Open **Prepare Release**.
 3. Select **Run workflow**.
 4. Select branch `main`.
+5. Leave `release_commit` empty when the release PR squash commit is still the
+   tip of `main`.
+6. Run the workflow.
+
+Delayed or recovery path:
+
+1. Open the merged release PR and copy its full squash commit SHA.
+2. Open **Actions** and select **Prepare Release**.
+3. Select branch `main`.
+4. Enter the full SHA in `release_commit`.
 5. Run the workflow.
 
 No version or tag needs to be typed. The workflow reads and validates both
-version files, runs tests, builds and validates the ZIP, prepares a draft for
-the derived tag bound to the validated commit, and attaches `pollenlevels.zip`.
-The Git ref may not exist until the draft is published.
+version files, verifies that the selected commit is a single-parent release
+squash commit on `main` that changes exactly the three release files, runs
+tests, builds and validates the ZIP, and prepares a draft for the derived tag.
+Later unrelated commits are not included in the ZIP or release.
+
+Validation, ZIP construction, tag creation, draft creation, and the workflow
+summary all use the selected commit. The workflow creates the derived tag
+automatically after validation, never moves or force-updates tags, and does not
+require manual tag creation. A matching tag can remain after a failed draft
+creation attempt; a rerun reuses it safely. Published releases remain immutable
+to this workflow.
 
 ## 4. Review the draft
 
 - Confirm the tag matches the intended version.
-- Confirm the target commit is the release PR squash commit.
+- Confirm the tag points to the selected release PR squash commit.
+- Confirm the selected commit shown in the workflow summary.
 - Confirm the prerelease status is correct.
+- For a stable release, review GitHub's latest-release setting before manual
+  publication. Prereleases must not be marked latest.
 - Review and edit generated notes as needed.
 - Confirm backup and downgrade warnings are present for v3 where applicable.
 - Confirm `pollenlevels.zip` is attached.
@@ -70,7 +93,7 @@ Rerunning Prepare Release before publication is supported: it replaces the ZIP
 asset on an existing draft while preserving manually edited draft notes. No
 manual tag creation is required. The workflow refuses to change an already
 published release, and a tag or draft target pointing to a different commit is
-a hard failure. Failed validation does not create a public release.
+a hard failure. Failed validation does not create a tag or public release.
 
 Do not manually move or delete a release tag to bypass validation.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,10 @@ Only trusted maintainers with write access should dispatch Release. The workflow
 definition runs from `main`, while `release_ref` intentionally permits an
 unmerged same-repository branch, tag, or SHA for prerelease, express, and
 historical-snapshot releases; branch protection on `main` does not review it.
+Pull-request pseudo-refs and Git revision expressions are rejected. A full SHA
+must be reachable from a normal repository branch or tag; unmerged
+same-repository branches remain supported, and ancestry from `main` is not
+required.
 
 ## 1. Prepare the release pull request
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,9 +15,10 @@ must be reachable from a normal repository branch or tag; unmerged
 same-repository branches remain supported, and ancestry from `main` is not
 required.
 
-## 1. Prepare the release pull request
+## 1. Prepare a release pull request (recommended)
 
-Create a release-only pull request. It should normally modify only:
+For normal stable releases, a release-only pull request is recommended. It
+should normally modify only:
 
 - `custom_components/pollenlevels/manifest.json`
 - `pyproject.toml`
@@ -29,11 +30,11 @@ derived automatically: version `3.0.1` maps to tag `v3.0.1`, and version
 
 Include backup, no-downgrade, migration, and prerelease notes where applicable.
 
-## 2. Merge the release pull request
+## 2. Merge the release pull request (if used)
 
-Before merging, ensure that all required checks are green and all reviews and
-conversations are resolved. Use **Squash and merge**, then confirm that the
-exact release commit is on `main`.
+If a release PR was used, ensure that all required checks are green and all
+reviews and conversations are resolved. Use **Squash and merge**, then confirm
+that the exact release commit is on `main`.
 
 ## 3. Release
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,8 +135,8 @@ after publication do not necessarily require a new release.
 - [ ] Selected ref and resolved SHA were reviewed.
 - [ ] Manifest and project version files match.
 - [ ] Changelog is complete.
-- [ ] Release PR checks are green.
-- [ ] Release PR was squash merged.
+- [ ] For normal stable releases, release PR checks are green.
+- [ ] For normal stable releases, the release PR was squash merged.
 - [ ] Release completed through either the draft-first or emergency fallback route.
 - [ ] For draft-first releases, draft review is complete.
 - [ ] `pollenlevels.zip` is attached before HACS verification.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,8 +34,9 @@ exact release commit is on `main`.
 5. Run the workflow.
 
 No version or tag needs to be typed. The workflow reads and validates both
-version files, runs tests, builds and validates the ZIP, creates the correct
-tag, prepares a draft, and attaches `pollenlevels.zip`.
+version files, runs tests, builds and validates the ZIP, prepares a draft for
+the derived tag bound to the validated commit, and attaches `pollenlevels.zip`.
+The Git ref may not exist until the draft is published.
 
 ## 4. Review the draft
 
@@ -66,10 +67,10 @@ Do not manually create a tag or an empty release.
 ## Recovery and reruns
 
 Rerunning Prepare Release before publication is supported: it replaces the ZIP
-asset on an existing draft while preserving manually edited draft notes. The
-workflow refuses to change an already published release. A tag pointing to a
-different commit is a hard failure. Failed validation does not create a public
-release.
+asset on an existing draft while preserving manually edited draft notes. No
+manual tag creation is required. The workflow refuses to change an already
+published release, and a tag or draft target pointing to a different commit is
+a hard failure. Failed validation does not create a public release.
 
 Do not manually move or delete a release tag to bypass validation.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,10 +58,10 @@ Enter a branch, tag, or full commit SHA in `release_ref`. The workflow resolves
 it to an exact commit; validation, packaging, tagging, and draft preparation
 all use that SHA.
 
-No version or tag needs to be typed. The workflow reads and validates both
-version files, validates the selected snapshot, runs tests, builds and validates
-the ZIP, and prepares a draft for the derived tag. A dedicated release-only PR
-is recommended for normal stable releases but is not technically required.
+For a specific snapshot, enter only `release_ref`; no separate version or
+release-tag field is required. The workflow reads and validates both version
+files, validates the selected snapshot, runs tests, builds and validates the
+ZIP, and prepares a draft for the derived tag.
 
 Validation, ZIP construction, tag creation, draft creation, and the workflow
 summary all use the resolved commit. The workflow creates the derived tag

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,8 +135,8 @@ after publication do not necessarily require a new release.
 - [ ] Selected ref and resolved SHA were reviewed.
 - [ ] Manifest and project version files match.
 - [ ] Changelog is complete.
-- [ ] For normal stable releases, release PR checks are green.
-- [ ] For normal stable releases, the release PR was squash merged.
+- [ ] If a release PR was used, its checks are green.
+- [ ] If a release PR was used, it was squash merged.
 - [ ] Release completed through either the draft-first or emergency fallback route.
 - [ ] For draft-first releases, draft review is complete.
 - [ ] `pollenlevels.zip` is attached before HACS verification.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,9 @@
 
 ## Release model
 
-Pollen Levels releases are prepared as GitHub drafts. A maintainer publishes a
-release manually only after all validation and package asset checks have passed.
+Draft-first preparation is the recommended release path. An emergency
+post-publication fallback is also supported, while publication itself is always
+initiated manually by a maintainer.
 
 Only trusted maintainers with write access should dispatch Release. The workflow
 definition runs from `main`, while `release_ref` intentionally permits an
@@ -61,8 +62,10 @@ Validation, ZIP construction, tag creation, draft creation, and the workflow
 summary all use the resolved commit. The workflow creates the derived tag
 automatically after validation, never moves or force-updates tags, and does not
 require manual tag creation. A matching tag can remain after a failed draft
-creation attempt; a rerun reuses it safely. Published releases remain immutable
-to this workflow. External fork refs are not supported.
+creation attempt; a rerun reuses it safely. Prepare mode refuses to alter an
+already published release; published-fallback mode may attach exactly one
+missing ZIP without replacing an existing ZIP, moving a tag, or changing release
+metadata. External fork refs are not supported.
 
 RC, alpha, beta, dev, preview, and test snapshots may be prepared from an
 unmerged same-repository branch: run the workflow from `main`, enter that
@@ -111,11 +114,11 @@ enabled. For stable releases, ensure it is disabled.
 
 ## Recovery and reruns
 
-Rerunning Prepare Release before publication is supported: it replaces the ZIP
-asset on an existing draft while preserving manually edited draft notes. No
-manual tag creation is required. The workflow refuses to change an already
-published release, and a tag or draft target pointing to a different commit is
-a hard failure. Failed validation does not create a tag or public release.
+Rerunning Release in draft-first mode before publication replaces the ZIP asset
+on an existing draft while preserving manually edited notes. Prepare mode
+refuses already published releases; a `release: published` fallback run may
+attach one missing ZIP. A tag or draft target pointing to another commit remains
+a hard failure.
 
 Do not manually move or delete a release tag to bypass validation.
 
@@ -130,9 +133,9 @@ after publication do not necessarily require a new release.
 - [ ] Changelog is complete.
 - [ ] Release PR checks are green.
 - [ ] Release PR was squash merged.
-- [ ] Release ran through either the draft-first or published-fallback route.
-- [ ] Draft review is complete.
-- [ ] `pollenlevels.zip` is attached.
+- [ ] Release completed through either the draft-first or emergency fallback route.
+- [ ] For draft-first releases, draft review is complete.
+- [ ] `pollenlevels.zip` is attached before HACS verification.
 - [ ] Prerelease status is correct.
 - [ ] The release was published manually.
 - [ ] HACS package verification is complete.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,42 +27,43 @@ exact release commit is on `main`.
 
 ## 3. Prepare the draft release
 
-Normal path:
+Normal stable release:
 
 1. Open **Actions**.
 2. Open **Prepare Release**.
 3. Select **Run workflow**.
 4. Select branch `main`.
-5. Leave `release_commit` empty when the release PR squash commit is still the
-   tip of `main`.
+5. Leave `release_ref` empty to release the current `main` snapshot.
 6. Run the workflow.
 
-Delayed or recovery path:
+Specific snapshot:
 
-1. Open the merged release PR and copy its full squash commit SHA.
-2. Open **Actions** and select **Prepare Release**.
-3. Select branch `main`.
-4. Enter the full SHA in `release_commit`.
-5. Run the workflow.
+Enter a branch, tag, or full commit SHA in `release_ref`. The workflow resolves
+it to an exact commit; validation, packaging, tagging, and draft preparation
+all use that SHA.
 
 No version or tag needs to be typed. The workflow reads and validates both
-version files, verifies that the selected commit is a single-parent release
-squash commit on `main` that changes exactly the three release files, runs
-tests, builds and validates the ZIP, and prepares a draft for the derived tag.
-Later unrelated commits are not included in the ZIP or release.
+version files, validates the selected snapshot, runs tests, builds and validates
+the ZIP, and prepares a draft for the derived tag. A dedicated release-only PR
+is recommended for normal stable releases but is not technically required.
 
 Validation, ZIP construction, tag creation, draft creation, and the workflow
-summary all use the selected commit. The workflow creates the derived tag
+summary all use the resolved commit. The workflow creates the derived tag
 automatically after validation, never moves or force-updates tags, and does not
 require manual tag creation. A matching tag can remain after a failed draft
 creation attempt; a rerun reuses it safely. Published releases remain immutable
-to this workflow.
+to this workflow. External fork refs are not supported.
+
+RC, alpha, beta, dev, preview, and test snapshots may be prepared from an
+unmerged same-repository branch: run the workflow from `main`, enter that
+branch or commit in `release_ref`, confirm both version files contain the
+intended prerelease version, and verify GitHub marks the draft as a prerelease.
 
 ## 4. Review the draft
 
 - Confirm the tag matches the intended version.
-- Confirm the tag points to the selected release PR squash commit.
-- Confirm the selected commit shown in the workflow summary.
+- Confirm the tag points to the resolved selected SHA.
+- Confirm the selected ref and resolved SHA shown in the workflow summary.
 - Confirm the prerelease status is correct.
 - For a stable release, review GitHub's latest-release setting before manual
   publication. Prereleases must not be marked latest.
@@ -97,8 +98,13 @@ a hard failure. Failed validation does not create a tag or public release.
 
 Do not manually move or delete a release tag to bypass validation.
 
+Once a version is published, its tag must not be moved. Code changes after a
+published version require a new version; documentation-only repository changes
+after publication do not necessarily require a new release.
+
 ## Release checklist
 
+- [ ] Selected ref and resolved SHA were reviewed.
 - [ ] Manifest and project version files match.
 - [ ] Changelog is complete.
 - [ ] Release PR checks are green.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,7 +81,8 @@ intended prerelease version, and verify GitHub marks the draft as a prerelease.
 
 - Confirm the tag matches the intended version.
 - Confirm the tag points to the resolved selected SHA.
-- Confirm the selected ref and resolved SHA shown in the workflow summary.
+- Confirm the resolved SHA shown in the workflow summary matches the intended
+  selected ref.
 - Confirm the prerelease status is correct.
 - For a stable release, review GitHub's latest-release setting before manual
   publication. Prereleases must not be marked latest.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,11 @@
 Pollen Levels releases are prepared as GitHub drafts. A maintainer publishes a
 release manually only after all validation and package asset checks have passed.
 
+Only trusted maintainers with write access should dispatch Release. The workflow
+definition runs from `main`, while `release_ref` intentionally permits an
+unmerged same-repository branch, tag, or SHA for prerelease, express, and
+historical-snapshot releases; branch protection on `main` does not review it.
+
 ## 1. Prepare the release pull request
 
 Create a release-only pull request. It should normally modify only:


### PR DESCRIPTION
## Summary

- Keep one Release workflow file with two entry modes and one shared validation/package pipeline.
- `workflow_dispatch` provides recommended draft-first preparation; `release: published` retains the emergency post-publication ZIP fallback.
- An existing exact `pollenlevels.zip` is a successful no-op; fallback never overwrites the ZIP or changes release metadata.
- `release_ref` may intentionally select an unmerged same-repository branch, tag, or SHA. Only trusted maintainers with write access should dispatch Release, and they review the selected ref and resolved SHA.
- Provenance validation accepts only normal same-repository branch or tag refs, or full SHAs reachable from one; pull-request pseudo-refs and revision expressions are rejected before selected snapshot code runs.

## Validation

- Markdown structural review and `git diff --check`: passed.
- Pagination/no-op fixtures, actionlint, zizmor, Ruff, compileall, ZIP validation, and 571 pytest tests passed in prior commits.
- No real tag, draft, release, or asset was created during development.

## Preserved behavior

- Runtime and migration remain unchanged.
- Draft-first publication remains manual; the emergency fallback only attaches one missing ZIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated and manually initiated release workflows with validation for references, versions, tags, packages, tests, and checksums.
  - Release packages are prepared as draft releases for review before publication.
  - Added fallback handling for published releases and safe recovery for interrupted or repeated release runs.

- **Documentation**
  - Added comprehensive release guidance covering preparation, validation, review, publication, verification, and recovery.
  - Updated contribution guidelines with release procedures and safeguards against manual release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
