### PR TITLE
test: share two-location HA entry fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,10 @@ from custom_components.pollenlevels.const import (
     DOMAIN,
     SUBENTRY_TYPE_LOCATION,
 )
-from custom_components.pollenlevels.util import api_key_unique_id
+from custom_components.pollenlevels.util import (
+    api_key_unique_id,
+    format_location_unique_id,
+)
 
 TESTS_DIR = Path(__file__).resolve().parent
 
@@ -157,6 +160,56 @@ def ha_config_entry(
             CONF_LANGUAGE_CODE: "es",
         },
         subentries_data=[sample_location_subentry_data],
+        version=6,
+    )
+
+
+@pytest.fixture
+def ha_two_location_config_entry(fake_api_key: str):
+    """Return a parent MockConfigEntry with Madrid and Barcelona locations."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    madrid_latitude = 40.4168
+    madrid_longitude = -3.7038
+    barcelona_latitude = 41.3874
+    barcelona_longitude = 2.1686
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="pollenlevels-entry",
+        title="Pollen Levels",
+        unique_id=api_key_unique_id(fake_api_key),
+        data={CONF_API_KEY: fake_api_key},
+        options={
+            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+            CONF_LANGUAGE_CODE: "es",
+        },
+        subentries_data=[
+            {
+                "subentry_id": "location-madrid",
+                "subentry_type": SUBENTRY_TYPE_LOCATION,
+                "title": "Madrid",
+                "unique_id": format_location_unique_id(
+                    madrid_latitude, madrid_longitude
+                ),
+                "data": {
+                    CONF_LATITUDE: madrid_latitude,
+                    CONF_LONGITUDE: madrid_longitude,
+                },
+            },
+            {
+                "subentry_id": "location-barcelona",
+                "subentry_type": SUBENTRY_TYPE_LOCATION,
+                "title": "Barcelona",
+                "unique_id": format_location_unique_id(
+                    barcelona_latitude, barcelona_longitude
+                ),
+                "data": {
+                    CONF_LATITUDE: barcelona_latitude,
+                    CONF_LONGITUDE: barcelona_longitude,
+                },
+            },
+        ],
         version=6,
     )
 

--- a/tests/test_ha_diagnostics.py
+++ b/tests/test_ha_diagnostics.py
@@ -11,19 +11,10 @@ from urllib.parse import parse_qsl
 from aiointercept import CallbackResult, aiointercept
 from homeassistant.core import HomeAssistant
 
-from custom_components.pollenlevels.const import (
-    CONF_API_KEY,
-    CONF_LANGUAGE_CODE,
-    CONF_UPDATE_INTERVAL,
-    DEFAULT_UPDATE_INTERVAL,
-    DOMAIN,
-)
-from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
     POLLEN_API_URL_RE,
     async_setup_config_entry,
-    location_subentry_data,
     mock_pollen_api,
 )
 
@@ -82,35 +73,13 @@ async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
     enable_custom_integrations: None,
     socket_enabled: None,
     fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
     """Diagnostics should summarize stale and failed locations from real runtime."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
     monkeypatch.setattr(
         hass.config_entries, "async_schedule_reload", lambda _entry_id: None
@@ -174,34 +143,12 @@ async def test_ha_diagnostics_registry_summary_uses_real_registries(
     enable_custom_integrations: None,
     socket_enabled: None,
     fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
     """Diagnostics should summarize real entity and device registry links."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -11,20 +11,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from custom_components.pollenlevels.const import (
-    CONF_API_KEY,
-    CONF_LANGUAGE_CODE,
-    CONF_UPDATE_INTERVAL,
-    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
 )
 from custom_components.pollenlevels.issue_helpers import (
     PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID,
 )
-from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
     async_setup_config_entry,
-    location_subentry_data,
     mock_pollen_api,
 )
 
@@ -33,35 +27,12 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
     """Sensor and button platforms should attach entities to each subentry."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -21,7 +21,6 @@ from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
     async_setup_config_entry,
-    location_subentry_data,
     mock_pollen_api,
 )
 
@@ -67,36 +66,13 @@ async def test_ha_force_update_skips_removed_subentry_without_reload(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
     """force_update should skip a removed subentry before runtime reloads."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:
@@ -143,36 +119,13 @@ async def test_ha_force_update_refreshes_multiple_location_subentries(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
     """force_update should refresh every active location subentry."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:
@@ -201,36 +154,13 @@ async def test_ha_force_update_continues_after_one_location_failure(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
     """force_update should continue refreshing locations after one failure."""
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:
@@ -293,38 +223,16 @@ async def test_ha_force_update_reports_absorbed_coordinator_failure_and_continue
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     caplog,
     monkeypatch,
 ) -> None:
     """force_update reports coordinator-absorbed UpdateFailed and continues."""
     from homeassistant.helpers.update_coordinator import UpdateFailed
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
 
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:

--- a/tests/test_ha_subentry_removal.py
+++ b/tests/test_ha_subentry_removal.py
@@ -12,22 +12,16 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     async_fire_time_changed,
 )
 
 from custom_components.pollenlevels.const import (
-    CONF_API_KEY,
-    CONF_LANGUAGE_CODE,
-    CONF_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
 )
-from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
     async_setup_config_entry,
-    location_subentry_data,
     mock_pollen_api,
 )
 
@@ -58,34 +52,13 @@ async def test_ha_real_subentry_removal_lifecycle(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    fake_api_key: str,
-    sample_location_subentry_data: dict[str, Any],
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
     """A real subentry removal should clean registries and stale runtime."""
     clear_integration_modules()
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        entry_id="pollenlevels-entry",
-        title="Pollen Levels",
-        data={CONF_API_KEY: fake_api_key},
-        options={
-            CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
-            CONF_LANGUAGE_CODE: "es",
-        },
-        unique_id=api_key_unique_id(fake_api_key),
-        subentries_data=[
-            sample_location_subentry_data,
-            location_subentry_data(
-                subentry_id="location-barcelona",
-                title="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        ],
-        version=6,
-    )
+    entry = ha_two_location_config_entry
     entry.add_to_hass(hass)
     captured_params: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary

- add a concrete two-location Home Assistant config-entry fixture;
- reuse it in the eight tests that share the standard Madrid/Barcelona topology;
- keep migration, reauthentication, stale, malformed, failure, and identity-specific scenarios explicit and local.

## Validation

- `uv lock --check`
- `ruff check .`
- `ruff format --check .`
- affected Home Assistant harness suites
- full test suite: 591 passed
- `compileall`
- `git diff --check`

## Scope

Tests only. No production, migration, dependency, lock-file, documentation, or version changes.

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Home Assistant test coverage for configurations containing multiple locations.
  * Verified entities are created for each location.
  * Continued validating diagnostics, force updates, failure handling, and location removal scenarios.
  * Consolidated test setup to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->