### PR TITLE
refactor(config-flow): remove unused legacy helper parameter

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -374,15 +374,12 @@ def _location_subentry_data(
     title: str,
     lat: float,
     lon: float,
-    legacy_entry_id: str | None = None,
 ) -> dict[str, Any]:
     """Return ConfigSubentryData for one pollen location."""
     data: dict[str, Any] = {
         CONF_LATITUDE: lat,
         CONF_LONGITUDE: lon,
     }
-    if legacy_entry_id:
-        data[CONF_LEGACY_ENTRY_ID] = legacy_entry_id
     return {
         "subentry_type": SUBENTRY_TYPE_LOCATION,
         "title": title,


### PR DESCRIPTION
## Summary

Remove the unused `legacy_entry_id` parameter and its unreachable conditional from `_location_subentry_data()`.

This is the first isolated cleanup investigated in #247.

## Evidence

- `_location_subentry_data()` has one production caller.
- That caller never supplies `legacy_entry_id`.
- Migration does not use this helper; it persists `CONF_LEGACY_ENTRY_ID` through its dedicated migration path.
- Location reconfiguration preserves an existing legacy entry ID directly from persisted subentry data.
- Supported calls to the helper produce identical output after this removal.

## Scope

- `custom_components/pollenlevels/config_flow.py` only.
- Three lines removed.
- No migration changes.
- No entity, device, registry, unique ID, or history changes.
- No documentation, translation, release, or version changes.

## Validation

- Branch is based directly on current `main` (`61d00aca`).
- One clean commit; no temporary workflow remains in the diff or branch history.
- Python 3.14.6 source compilation passed.
- 591 tests passed.
- Ruff lint and format checks passed.
- Package Test passed.
- hassfest passed.
- HACS validation passed.
- Workflow security checks passed.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New location configurations no longer store unnecessary legacy identifiers.
  * Existing legacy identifiers continue to be supported when reconfiguring locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->