### PR TITLE
refactor(config-flow): remove obsolete parent lookup fallback

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -465,17 +465,7 @@ def _entry_for_parent_unique_id(
     hass: Any, unique_id: str
 ) -> config_entries.ConfigEntry | None:
     """Return an existing parent entry with this API-key unique ID."""
-    config_entry_manager = getattr(hass, "config_entries", None)
-    lookup = getattr(config_entry_manager, "async_entry_for_domain_unique_id", None)
-    if callable(lookup):
-        return lookup(DOMAIN, unique_id)
-
-    async_entries = getattr(config_entry_manager, "async_entries", None)
-    if callable(async_entries):
-        for candidate in async_entries(DOMAIN):
-            if getattr(candidate, "unique_id", None) == unique_id:
-                return candidate
-    return None
+    return hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, unique_id)
 
 
 async def _async_reload_parent_after_subentry_create(hass: Any, entry_id: str) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1854,6 +1854,7 @@ def test_api_key_confirm_description_placeholders_round_coordinates(
     flow = config_flow_stubs.PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(
         config_entries=SimpleNamespace(
+            async_entry_for_domain_unique_id=lambda _domain, _unique_id: None,
             async_update_entry=lambda *args, **kwargs: None,
             async_reload=lambda *args, **kwargs: None,
         )
@@ -2035,6 +2036,9 @@ def test_reconfigure_api_key_validation_accepts_later_working_location(
         def __init__(self) -> None:
             self.updated = None
             self.reloaded = None
+
+        def async_entry_for_domain_unique_id(self, _domain, _unique_id):
+            return None
 
         def async_get_entry(self, entry_id: str):
             return entry if entry_id == entry.entry_id else None
@@ -2232,6 +2236,9 @@ def test_reauth_confirm_does_not_reintroduce_option_fields_in_data(
         def __init__(self) -> None:
             self.updated = None
 
+        def async_entry_for_domain_unique_id(self, _domain, _unique_id):
+            return None
+
         def async_get_entry(self, entry_id: str):
             return entry if entry_id == entry.entry_id else None
 
@@ -2299,6 +2306,9 @@ def test_reconfigure_does_not_reintroduce_option_fields_in_data(
         def __init__(self) -> None:
             self.updated = None
 
+        def async_entry_for_domain_unique_id(self, _domain, _unique_id):
+            return None
+
         def async_get_entry(self, entry_id: str):
             return entry if entry_id == entry.entry_id else None
 
@@ -2358,7 +2368,10 @@ def test_async_step_user_defaults_entry_name(
 
     flow = config_flow_stubs.PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace(
-        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en")
+        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
+        config_entries=SimpleNamespace(
+            async_entry_for_domain_unique_id=lambda _domain, _unique_id: None
+        ),
     )
 
     normalized = {
@@ -2396,10 +2409,10 @@ def test_async_step_user_defaults_entry_name(
     }
 
 
-def test_async_step_user_checks_api_key_unique_id_with_async_entries_fallback(
+def test_async_step_user_checks_api_key_unique_id(
     config_flow_stubs: ConfigFlowStubs,
 ) -> None:
-    """New setup should detect duplicate API-key parents via async_entries fallback."""
+    """New setup should detect duplicate API-key parents by unique ID."""
 
     class _TrackingFlow(config_flow_stubs.PollenLevelsConfigFlow):
         def __init__(self) -> None:
@@ -2411,14 +2424,21 @@ def test_async_step_user_checks_api_key_unique_id_with_async_entries_fallback(
             return None
 
     duplicate_unique_id = config_flow_stubs.config_flow._api_key_unique_id("shared-key")
+    lookup_calls: list[tuple[str, str]] = []
+
+    def _lookup_parent(domain: str, unique_id: str):
+        lookup_calls.append((domain, unique_id))
+        if (
+            domain == config_flow_stubs.config_flow.DOMAIN
+            and unique_id == duplicate_unique_id
+        ):
+            return SimpleNamespace(unique_id=duplicate_unique_id)
+        return None
+
     flow = _TrackingFlow()
     flow.hass = SimpleNamespace(
         config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
-        config_entries=SimpleNamespace(
-            async_entries=lambda _domain: [
-                SimpleNamespace(unique_id=duplicate_unique_id)
-            ]
-        ),
+        config_entries=SimpleNamespace(async_entry_for_domain_unique_id=_lookup_parent),
     )
 
     normalized = {
@@ -2443,6 +2463,7 @@ def test_async_step_user_checks_api_key_unique_id_with_async_entries_fallback(
 
     assert result == {"type": "abort", "reason": "api_key_already_configured"}
     assert flow.unique_ids == [duplicate_unique_id]
+    assert lookup_calls == [(config_flow_stubs.config_flow.DOMAIN, duplicate_unique_id)]
 
 
 class _SubentryRecorder:


### PR DESCRIPTION
## Summary

Use Home Assistant's supported `async_entry_for_domain_unique_id()` API directly for parent API-key identity lookup.

- remove the obsolete `async_entries()` fallback;
- update only the lightweight config-entry manager doubles that execute this path;
- retain the existing initial-setup duplicate-key test and verify its exact `(DOMAIN, api_key_unique_id)` lookup arguments.

## Scope

- `custom_components/pollenlevels/config_flow.py`
- `tests/test_config_flow.py`

No migration, registry, subentry, entity identity, reload, workflow, dependency, documentation, or release-metadata changes.

## Validation

- `uv lock --check`
- `ruff check .`
- `ruff format --check .`
- config-flow focused tests: 110 passed
- full test suite: 591 passed
- `compileall`
- `git diff --check`

GitHub Actions is currently affected by a platform incident; cancelled jobs before repository steps run are treated as infrastructure and will be reported separately.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate configuration detection during setup, reauthentication, and reconfiguration.
  * Configuration checks now use Home Assistant’s current entry lookup behavior for more consistent results.

* **Tests**
  * Updated coverage for unique-ID lookups and duplicate-entry scenarios.
  * Added validation that the expected configuration-entry lookup is performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->