### PR TITLE
refactor(runtime): remove obsolete setup retry reload fallback

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -271,25 +271,9 @@ def _setup_failure_is_retryable(failure: PollenLocationSetupFailure) -> bool:
     return failure.error_type not in _NON_RETRYABLE_SETUP_FAILURE_TYPES
 
 
-def _schedule_parent_reload(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Schedule a parent config entry reload when supported by the runtime."""
-    schedule_reload = getattr(hass.config_entries, "async_schedule_reload", None)
-    if callable(schedule_reload):
-        schedule_reload(entry.entry_id)
-        return True
-
-    async_reload = getattr(hass.config_entries, "async_reload", None)
-    if not callable(async_reload):
-        return False
-
-    result = async_reload(entry.entry_id)
-    if asyncio.iscoroutine(result):
-        create_task = getattr(hass, "async_create_task", None)
-        if not callable(create_task):
-            result.close()
-            return False
-        create_task(result, name=f"pollenlevels setup retry {entry.entry_id}")
-    return True
+def _schedule_parent_reload(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Schedule a parent config entry reload."""
+    hass.config_entries.async_schedule_reload(entry.entry_id)
 
 
 # ---- Service -------------------------------------------------------------
@@ -652,13 +636,11 @@ async def async_setup_entry(
         raise ConfigEntryNotReady from err
 
     retry_reload_needed = False
-    first_retry_failures: list[PollenLocationSetupFailure] = []
     for failure in failed_locations.values():
         if not _setup_failure_is_retryable(failure):
             continue
         if not _setup_retry_failure_seen(hass, entry.entry_id, failure.subentry_id):
             _mark_setup_retry_failure(hass, entry.entry_id, failure.subentry_id)
-            first_retry_failures.append(failure)
             retry_reload_needed = True
             continue
         create_location_setup_failed_issue(
@@ -671,17 +653,8 @@ async def async_setup_entry(
             reason=failure.reason,
         )
 
-    if retry_reload_needed and not _schedule_parent_reload(hass, entry):
-        for failure in first_retry_failures:
-            create_location_setup_failed_issue(
-                hass,
-                entry_id=entry.entry_id,
-                entry_title=entry.title,
-                location_title=failure.title,
-                subentry_id=failure.subentry_id,
-                error_type=failure.error_type,
-                reason=failure.reason,
-            )
+    if retry_reload_needed:
+        _schedule_parent_reload(hass, entry)
 
     _LOGGER.info("PollenLevels integration loaded successfully")
     return True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -836,6 +836,7 @@ def test_setup_entry_skips_invalid_subentry_coordinates_when_others_load(
     failure = entry.runtime_data.failed_locations["bad-location"]
     assert failure.error_type == "InvalidStoredLocation"
     assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    assert hass.config_entries.reload_calls == []
     expected_issue_id = integration.invalid_stored_location_issue_id(
         entry.entry_id, subentry_id="bad-location"
     )


### PR DESCRIPTION
## Summary

Use Home Assistant's supported `async_schedule_reload()` API directly for the one-time parent reload after a retryable isolated location setup failure.

This is Candidate 3B from #247.

## Changes

- simplify `_schedule_parent_reload()` to the supported Home Assistant API;
- remove unreachable `async_reload()` / missing-task compatibility branches;
- remove the obsolete scheduling-failure Repair fallback;
- explicitly verify that non-retryable invalid stored locations do not schedule a parent reload.

## Behavior preserved

- first retryable location failure schedules one parent reload;
- repeated retryable failure creates the per-location Repair instead of looping;
- healthy sibling locations remain loaded;
- non-retryable failures do not schedule retries;
- retry bookkeeping and Repair cleanup remain unchanged.

## Scope

- `custom_components/pollenlevels/__init__.py`
- `tests/test_init.py`

No config-flow reload changes, migration changes, identity/registry changes, stale-runtime changes, service changes, diagnostics changes, documentation, workflow, dependency, or release-metadata changes.

## Validation

- `uv lock --check`
- `ruff check .`
- `ruff format --check .`
- modified non-retryable test: 1 passed
- remaining focused Candidate 3B scenarios: 10 passed
- `tests/test_init.py`: 79 passed
- `tests/test_ha_init.py`: 4 passed
- full test suite: 591 passed
- `compileall`
- `git diff --check`

Refs #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of retryable setup failures by scheduling configuration reloads more consistently.
  * Prevented unnecessary configuration reloads when subentry coordinates are invalid.
  * Removed fallback repair notifications when a reload cannot be scheduled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->