### PR TITLE
refactor(config-flow): remove obsolete subentry reload fallback

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -472,16 +472,7 @@ async def _async_reload_parent_after_subentry_create(hass: Any, entry_id: str) -
     """Reload the parent after Home Assistant persists the created subentry."""
     # Let Home Assistant finish attaching the newly-created subentry before reload.
     await asyncio.sleep(0)
-    schedule_reload = getattr(hass.config_entries, "async_schedule_reload", None)
-    if callable(schedule_reload):
-        schedule_reload(entry_id)
-        return
-
-    async_reload = getattr(hass.config_entries, "async_reload", None)
-    if callable(async_reload):
-        result = async_reload(entry_id)
-        if asyncio.iscoroutine(result):
-            await result
+    hass.config_entries.async_schedule_reload(entry_id)
 
 
 def _parse_int_option(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2479,19 +2479,11 @@ class _SubentryRecorder:
         self.reload_calls.append(entry_id)
 
 
-class _ReloadOnlySubentryRecorder:
-    def __init__(self) -> None:
-        self.reload_calls: list[str] = []
-
-    async def async_reload(self, entry_id: str) -> None:
-        self.reload_calls.append(entry_id)
-
-
 def _build_location_subentry_flow(config_flow_stubs: ConfigFlowStubs, entry):
     recorder = _SubentryRecorder(entry)
 
     def _async_create_task(coro, *, name=None):
-        task = asyncio.create_task(coro, name=name)
+        task = asyncio.create_task(coro, name=name, eager_start=True)
         recorder.created_tasks.append(task)
         return task
 
@@ -2529,21 +2521,57 @@ def test_location_subentry_user_step_shows_form(
     assert result == {"type": "form", "step_id": "user", "errors": {}}
 
 
-def test_location_subentry_create_reload_helper_falls_back_to_async_reload(
+def test_location_subentry_user_step_creates_entry_without_premature_reload(
     config_flow_stubs: ConfigFlowStubs,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Subentry reload helper should use async_reload when schedule_reload is absent."""
+    """Adding a valid location should reload the parent after create is returned."""
 
-    recorder = _ReloadOnlySubentryRecorder()
-    hass = SimpleNamespace(config_entries=recorder)
-
-    asyncio.run(
-        config_flow_stubs.config_flow._async_reload_parent_after_subentry_create(
-            hass, "entry-id"
-        )
+    calls = _patch_client_fetch(config_flow_stubs, monkeypatch)
+    entry = config_flow_stubs.config_flow.config_entries.ConfigEntry(
+        data={config_flow_stubs.CONF_API_KEY: "key"},
+        options={config_flow_stubs.CONF_LANGUAGE_CODE: " es-ES "},
+        entry_id="entry-id",
     )
+    flow, recorder = _build_location_subentry_flow(config_flow_stubs, entry)
 
+    async def run_flow():
+        result = await flow.async_step_user(
+            {
+                config_flow_stubs.CONF_NAME: " Garden ",
+                config_flow_stubs.CONF_LOCATION: {
+                    config_flow_stubs.CONF_LATITUDE: 12.34567,
+                    config_flow_stubs.CONF_LONGITUDE: -98.76543,
+                },
+            }
+        )
+        assert recorder.reload_calls == []
+        assert len(recorder.created_tasks) == 1
+        assert recorder.created_tasks[0].get_name() == (
+            "reload Pollen Levels parent after location subentry create"
+        )
+        await recorder.created_tasks[0]
+        return result
+
+    result = asyncio.run(run_flow())
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Garden"
+    assert result["data"] == {
+        config_flow_stubs.CONF_LATITUDE: 12.34567,
+        config_flow_stubs.CONF_LONGITUDE: -98.76543,
+    }
+    assert result["unique_id"] == "12.3457_-98.7654"
+    assert len(recorder.created_tasks) == 1
     assert recorder.reload_calls == ["entry-id"]
+    assert calls == [
+        {
+            "latitude": 12.34567,
+            "longitude": -98.76543,
+            "days": config_flow_stubs.FORECAST_DAYS,
+            "language_code": "es-ES",
+        }
+    ]
 
 
 def test_location_subentry_user_step_rejects_invalid_api_payload(

--- a/tests/test_ha_config_flow.py
+++ b/tests/test_ha_config_flow.py
@@ -449,10 +449,22 @@ async def test_ha_location_subentry_flow_creates_subentry(
     clear_integration_modules()
     captured_params: list[dict[str, Any]] = []
     scheduled_reloads: list[str] = []
+    subentries_at_reload: list[list[tuple[str, str, str | None, dict[str, Any]]]] = []
     original_schedule_reload = hass.config_entries.async_schedule_reload
 
     def _capture_schedule_reload(entry_id: str) -> None:
         scheduled_reloads.append(entry_id)
+        subentries_at_reload.append(
+            [
+                (
+                    subentry.subentry_type,
+                    subentry.title,
+                    subentry.unique_id,
+                    dict(subentry.data),
+                )
+                for subentry in entry.subentries.values()
+            ]
+        )
         original_schedule_reload(entry_id)
 
     monkeypatch.setattr(
@@ -488,6 +500,16 @@ async def test_ha_location_subentry_flow_creates_subentry(
     assert_fixed_forecast_days(captured_params)
     assert captured_params[0]["languageCode"] == "es"
     assert scheduled_reloads == [entry.entry_id]
+    assert subentries_at_reload == [
+        [
+            (
+                SUBENTRY_TYPE_LOCATION,
+                "Garden",
+                "41.3874_2.1686",
+                {CONF_LATITUDE: 41.3874, CONF_LONGITUDE: 2.1686},
+            )
+        ]
+    ]
     assert len(entry.subentries) == 1
 
     subentry = next(iter(entry.subentries.values()))


### PR DESCRIPTION
## Summary

Implement Candidate 3A from #247 by using Home Assistant's supported `async_schedule_reload()` API directly after creating a location subentry.

## Changes

- remove the obsolete `async_reload()` compatibility fallback and its incomplete test double;
- deliberately preserve `await asyncio.sleep(0)` so Home Assistant attaches the new subentry before reload scheduling;
- restore deterministic lightweight coverage for eager task creation, the exact task name, no premature reload, and the correct parent entry;
- strengthen the real Home Assistant harness to verify the new subentry is attached in memory when the scheduler is invoked.

## Behavior preserved

- valid location subentries are created before the parent reload;
- exactly one reload is requested for the correct parent;
- validation failures do not create reload tasks;
- duplicate locations and location reconfiguration remain unchanged;
- task ownership, task name, and the persistence-timing yield remain unchanged.

## Validation

- `uv lock --check`
- `uv sync --locked --only-group lint`
- `ruff check .`
- `ruff format --check .`
- `uv sync --locked --only-group test`
- focused Candidate 3A tests: 8 passed
- config-flow unit and HA harness suites: 110 passed
- full test suite: 591 passed
- `compileall`
- `git diff --check`

## Scope

- `custom_components/pollenlevels/config_flow.py`
- `tests/test_config_flow.py`
- `tests/test_ha_config_flow.py`

No Candidate 3B, retry/Repair, task API, migration, identity, registry/history, stale-runtime, service, diagnostics, documentation, workflow, dependency, lock-file, or release-metadata changes.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating new pollen location entries by ensuring the parent integration reload is scheduled correctly.
  * Location details, including language, coordinates, title, and unique ID, are now consistently retained during creation.

* **Tests**
  * Expanded coverage for location creation, reload scheduling, normalized values, and pollen forecast requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->