### PR TITLE
refactor(entities): require supported subentry callback

### DIFF
--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -22,7 +22,7 @@ from .util import (
 )
 
 if TYPE_CHECKING:
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
     from .coordinator import PollenDataUpdateCoordinator
 
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     _hass: HomeAssistant,
     config_entry: PollenLevelsConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Pollen Levels update buttons for all configured locations."""
     runtime = getattr(config_entry, "runtime_data", None)

--- a/custom_components/pollenlevels/entity_helpers.py
+++ b/custom_components/pollenlevels/entity_helpers.py
@@ -2,61 +2,25 @@
 
 from __future__ import annotations
 
-from annotationlib import Format
 from collections.abc import Sequence
-from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
     from .coordinator import PollenDataUpdateCoordinator
 
 
 def add_entities_for_subentry(
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
     entities: Sequence[Any],
     subentry_id: str,
 ) -> None:
-    """Add entities with subentry association when supported by Home Assistant."""
-    entity_list = list(entities)
-    supports_subentry_id = _supports_config_subentry_id(async_add_entities)
-    if supports_subentry_id is False:
-        async_add_entities(entity_list)
-        return
-
-    try:
-        async_add_entities(entity_list, config_subentry_id=subentry_id)
-    except TypeError as err:
-        if supports_subentry_id is not None or not (
-            _is_unsupported_config_subentry_id_type_error(err)
-        ):
-            raise
-        async_add_entities(entity_list)
-
-
-def _supports_config_subentry_id(callback: AddEntitiesCallback) -> bool | None:
-    """Return callback support for config_subentry_id, or None when ambiguous."""
-    try:
-        parameters = signature(
-            callback, annotation_format=Format.STRING
-        ).parameters.values()
-    except TypeError, ValueError:
-        return None
-
-    accepts_var_kwargs = False
-    for parameter in parameters:
-        if parameter.name == "config_subentry_id":
-            return True
-        if parameter.kind is Parameter.VAR_KEYWORD:
-            accepts_var_kwargs = True
-    return None if accepts_var_kwargs else False
-
-
-def _is_unsupported_config_subentry_id_type_error(err: TypeError) -> bool:
-    """Return whether ``err`` is from an unsupported config_subentry_id kwarg."""
-    message = str(err)
-    return "config_subentry_id" in message and "unexpected keyword argument" in message
+    """Add entities with their location subentry association."""
+    async_add_entities(
+        list(entities),
+        config_subentry_id=subentry_id,
+    )
 
 
 def device_translation_placeholders(

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -34,7 +34,7 @@ from homeassistant.helpers.update_coordinator import (
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
-    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
     ATTRIBUTION,
@@ -176,7 +176,7 @@ async def _remove_legacy_per_day_entities(
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: PollenLevelsConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create coordinator and build sensors."""
     runtime = cast(

--- a/tests/test_entity_helpers.py
+++ b/tests/test_entity_helpers.py
@@ -15,51 +15,25 @@ def test_add_entities_for_subentry_passes_config_subentry_id() -> None:
     """Modern callbacks receive the subentry association."""
     first = object()
     second = object()
-    calls: list[tuple[list[Any], dict[str, Any]]] = []
+    calls: list[tuple[list[Any], bool, str | None]] = []
 
-    def _add_entities(entities: list[Any], **kwargs: Any) -> None:
-        calls.append((entities, kwargs))
+    def _add_entities(
+        entities: list[Any],
+        update_before_add: bool = False,
+        *,
+        config_subentry_id: str | None = None,
+    ) -> None:
+        calls.append((entities, update_before_add, config_subentry_id))
 
     add_entities_for_subentry(_add_entities, (first, second), "location-home")
 
     assert calls == [
-        ([first, second], {"config_subentry_id": "location-home"}),
+        ([first, second], False, "location-home"),
     ]
 
 
-def test_add_entities_for_subentry_falls_back_for_legacy_callback() -> None:
-    """Callbacks without config_subentry_id support still receive entities."""
-    first = object()
-    second = object()
-    calls: list[list[Any]] = []
-
-    def _add_entities(entities: list[Any]) -> None:
-        calls.append(entities)
-
-    add_entities_for_subentry(_add_entities, (first, second), "location-home")
-
-    assert calls == [[first, second]]
-
-
-def test_add_entities_for_subentry_falls_back_for_wrapped_legacy_callback() -> None:
-    """Wrapped legacy callbacks still fall back when the inner callable rejects kwargs."""
-    first = object()
-    second = object()
-    calls: list[list[Any]] = []
-
-    def _add_entities(entities: list[Any]) -> None:
-        calls.append(entities)
-
-    def _wrapped_add_entities(*args: Any, **kwargs: Any) -> None:
-        _add_entities(*args, **kwargs)
-
-    add_entities_for_subentry(_wrapped_add_entities, (first, second), "location-home")
-
-    assert calls == [[first, second]]
-
-
 def test_add_entities_for_subentry_reraises_internal_type_error() -> None:
-    """Internal callback TypeError should not trigger legacy fallback."""
+    """Internal callback TypeError should propagate without retry."""
     calls: list[str | None] = []
 
     def _add_entities(
@@ -74,35 +48,6 @@ def test_add_entities_for_subentry_reraises_internal_type_error() -> None:
         add_entities_for_subentry(_add_entities, [object()], "location-home")
     except TypeError as err:
         assert str(err) == "internal config_subentry_id setup bug"
-    else:  # pragma: no cover - assertion guard
-        raise AssertionError("Expected internal TypeError to be reraised")
-
-    assert calls == ["location-home"]
-
-
-def test_add_entities_for_subentry_reraises_modern_internal_keyword_type_error() -> (
-    None
-):
-    """Explicit modern callbacks should not fall back on internal keyword errors."""
-    calls: list[str | None] = []
-
-    def _add_entities(
-        entities: list[Any],
-        *,
-        config_subentry_id: str | None = None,
-    ) -> None:
-        calls.append(config_subentry_id)
-        raise TypeError(
-            "internal helper got an unexpected keyword argument 'config_subentry_id'"
-        )
-
-    try:
-        add_entities_for_subentry(_add_entities, [object()], "location-home")
-    except TypeError as err:
-        assert (
-            str(err)
-            == "internal helper got an unexpected keyword argument 'config_subentry_id'"
-        )
     else:  # pragma: no cover - assertion guard
         raise AssertionError("Expected internal TypeError to be reraised")
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -147,10 +147,17 @@ def _install_sensor_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
 
     entity_platform_mod = types.ModuleType("homeassistant.helpers.entity_platform")
 
-    def _add_entities_callback_stub(entities, update_before_add: bool = False) -> None:
+    def _add_config_entry_entities_callback_stub(
+        entities,
+        update_before_add: bool = False,
+        *,
+        config_subentry_id: str | None = None,
+    ) -> None:
         return None
 
-    entity_platform_mod.AddEntitiesCallback = _add_entities_callback_stub  # type: ignore[assignment]
+    entity_platform_mod.AddConfigEntryEntitiesCallback = (
+        _add_config_entry_entities_callback_stub  # type: ignore[assignment]
+    )
     monkeypatch.setitem(
         sys.modules, "homeassistant.helpers.entity_platform", entity_platform_mod
     )
@@ -3006,7 +3013,12 @@ async def test_async_setup_entry_skips_legacy_d1_d2_data_keys(
 
     captured: list[Any] = []
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         captured.extend(entities)
 
     await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
@@ -3084,7 +3096,12 @@ async def test_async_setup_entry_creates_repair_when_legacy_removal_fails(
     )
     captured: list[Any] = []
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         captured.extend(entities)
 
     await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
@@ -3399,7 +3416,12 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
     captured: list[Any] = []
     update_before_add_value: bool | None = None
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         nonlocal update_before_add_value
         captured.extend(entities)
         update_before_add_value = _update_before_add
@@ -3463,7 +3485,12 @@ async def test_async_setup_entry_adds_daily_summary_sensors(
 
     captured: list[Any] = []
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         captured.extend(entities)
 
     await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
@@ -3520,7 +3547,12 @@ async def test_device_info_uses_default_title_when_blank(
 
     captured: list[Any] = []
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         captured.extend(entities)
 
     await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)
@@ -3574,7 +3606,12 @@ async def test_device_info_trims_custom_title(
 
     captured: list[Any] = []
 
-    def _capture_entities(entities, _update_before_add=False):
+    def _capture_entities(
+        entities,
+        _update_before_add=False,
+        *,
+        config_subentry_id: str | None = None,
+    ):
         captured.extend(entities)
 
     await sensor_modules.sensor.async_setup_entry(hass, config_entry, _capture_entities)


### PR DESCRIPTION
## Summary

Candidate 4 from #247: require Home Assistant's supported config-entry entity callback for location subentry association.

- use `AddConfigEntryEntitiesCallback` in the shared helper and both platforms;
- remove obsolete signature inspection and legacy/wrapped callback fallbacks;
- modernize only the six lightweight sensor doubles that reach the helper;
- retain the real Home Assistant registry/subentry harness unchanged.

## Validation

- `uv lock --check`
- `ruff check .`
- `ruff format --check .`
- focused entity/platform suites: 109 passed
- full suite: 588 passed
- `compileall`
- `git diff --check`

## Scope

- `custom_components/pollenlevels/entity_helpers.py`
- `custom_components/pollenlevels/sensor.py`
- `custom_components/pollenlevels/button.py`
- `tests/test_entity_helpers.py`
- `tests/test_sensor.py`

The `button.py` no-location `runtime.coordinator` branch remains intentionally out of scope for separate review.

Refs #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer Home Assistant entity setup callbacks.
  * Ensured entities created from configuration subentries are correctly associated with their subentry.
  * Improved reliability when adding pollen level buttons and sensors during integration setup.

* **Tests**
  * Updated coverage to verify subentry association and callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->