### PR TITLE
refactor(runtime): remove legacy coordinator compatibility

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -382,10 +382,6 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
             runtime = getattr(entry, "runtime_data", None)
             locations = getattr(runtime, "locations", None) or {}
             if not locations:
-                coordinator = getattr(runtime, "coordinator", None)
-                if coordinator:
-                    targets.append((entry, entry.entry_id, coordinator))
-                    continue
                 _LOGGER.debug(
                     "Skipping force_update for entry %s (no location coordinators)",
                     entry.entry_id,

--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -40,10 +40,6 @@ async def async_setup_entry(
         raise ConfigEntryNotReady("Runtime data not ready")
     locations = getattr(runtime, "locations", None) or {}
     if not locations:
-        coordinator = getattr(runtime, "coordinator", None)
-        if coordinator is not None:
-            async_add_entities([PollenLevelsUpdateButton(coordinator)])
-            return
         _LOGGER.debug("No location subentries configured; no update buttons to add")
         return
 

--- a/custom_components/pollenlevels/runtime.py
+++ b/custom_components/pollenlevels/runtime.py
@@ -43,31 +43,11 @@ class PollenLevelsRuntimeData:
         client: GooglePollenApiClient,
         locations: dict[str, PollenLocationRuntime] | None = None,
         failed_locations: dict[str, PollenLocationSetupFailure] | None = None,
-        coordinator: PollenDataUpdateCoordinator | None = None,
     ) -> None:
-        """Initialize runtime data with v3 locations or a legacy coordinator."""
+        """Initialize runtime data for configured pollen locations."""
         self.client = client
         self.failed_locations = failed_locations or {}
-        if locations is not None:
-            self.locations = locations
-            return
-        self.locations = {}
-        if coordinator is not None:
-            subentry_id = getattr(coordinator, "subentry_id", None) or getattr(
-                coordinator, "entry_id", "legacy"
-            )
-            self.locations[subentry_id] = PollenLocationRuntime(
-                subentry_id=subentry_id,
-                coordinator=coordinator,
-                legacy_entry_id=getattr(coordinator, "legacy_entry_id", None),
-            )
-
-    @property
-    def coordinator(self) -> PollenDataUpdateCoordinator | None:
-        """Return the first location coordinator for legacy callers/tests."""
-        if not self.locations:
-            return None
-        return next(iter(self.locations.values())).coordinator
+        self.locations = locations if locations is not None else {}
 
 
 if TYPE_CHECKING:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -234,37 +234,6 @@ async def test_setup_entry_raises_if_runtime_data_missing(
 
 
 @pytest.mark.asyncio
-async def test_setup_entry_raises_if_runtime_data_attribute_missing(
-    button_platform: SimpleNamespace,
-) -> None:
-    entry = types.SimpleNamespace()
-
-    with pytest.raises(button_platform.exceptions.ConfigEntryNotReady):
-        await button_platform.module.async_setup_entry(
-            button_platform.hass_class(), entry, lambda entities: None
-        )
-
-
-@pytest.mark.asyncio
-async def test_setup_entry_adds_one_button_entity(
-    button_platform: SimpleNamespace,
-) -> None:
-    coordinator = _FakeCoordinator()
-    runtime = types.SimpleNamespace(coordinator=coordinator)
-    entry = types.SimpleNamespace(runtime_data=runtime)
-    added = []
-
-    def _add_entities(entities):
-        added.extend(entities)
-
-    await button_platform.module.async_setup_entry(
-        button_platform.hass_class(), entry, _add_entities
-    )
-    assert len(added) == 1
-    assert isinstance(added[0], button_platform.module.PollenLevelsUpdateButton)
-
-
-@pytest.mark.asyncio
 async def test_setup_entry_without_locations_adds_no_button(
     button_platform: SimpleNamespace,
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -146,7 +146,12 @@ async def test_diagnostics_rounds_coordinates_and_truncates_keys(
         data={f"type_{idx}": {} for idx in range(60)},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -772,7 +777,12 @@ async def test_diagnostics_request_days_are_fixed(
         data={"type_grass": {"source": "type"}},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -818,7 +828,12 @@ async def test_diagnostics_normalizes_request_example_language_code(
         data={"type_grass": {"source": "type"}},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -858,7 +873,12 @@ async def test_diagnostics_nonfinite_coordinates_are_omitted_in_examples(
         data={"type_grass": {"source": "type"}},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -939,7 +959,12 @@ async def test_diagnostics_includes_daily_summary_sensor_snapshot(
         },
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -995,7 +1020,12 @@ async def test_diagnostics_daily_summary_uses_empty_states_without_data(
         data={},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(
@@ -1074,7 +1104,12 @@ async def test_diagnostics_includes_registry_summary_without_sensitive_values(
         data={},
     )
     entry.runtime_data = diagnostics_modules.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": diagnostics_modules.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     diagnostics = await diagnostics_modules.diag.async_get_config_entry_diagnostics(

--- a/tests/test_ha_services.py
+++ b/tests/test_ha_services.py
@@ -213,7 +213,6 @@ async def test_ha_force_update_parent_without_locations_is_noop(
 
     await async_setup_config_entry(hass, entry)
     assert entry.runtime_data.locations == {}
-    assert entry.runtime_data.coordinator is None
 
     await hass.services.async_call(DOMAIN, "force_update", {}, blocking=True)
     await hass.async_block_till_done()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -558,7 +558,6 @@ def test_setup_entry_without_location_subentries_loads_empty_runtime(
 
     assert entry.runtime_data is not None
     assert entry.runtime_data.locations == {}
-    assert entry.runtime_data.coordinator is None
     assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
 
 
@@ -696,8 +695,9 @@ def test_setup_entry_numeric_string_coordinates_are_allowed(
 
     assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
     assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator.lat == pytest.approx(1.5)
-    assert entry.runtime_data.coordinator.lon == pytest.approx(2.5)
+    coordinator = entry.runtime_data.locations[entry.entry_id].coordinator
+    assert coordinator.lat == pytest.approx(1.5)
+    assert coordinator.lon == pytest.approx(2.5)
 
 
 def test_setup_entry_boundary_coordinates_are_allowed(
@@ -1242,7 +1242,10 @@ def test_setup_entry_success_and_unload(
     assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
 
     assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator.entry_id == entry.entry_id
+    assert (
+        entry.runtime_data.locations[entry.entry_id].coordinator.entry_id
+        == entry.entry_id
+    )
 
     assert asyncio.run(integration.async_unload_entry(hass, entry)) is True
     assert hass.config_entries.unload_calls == [(entry, ["sensor", "button"])]
@@ -1410,10 +1413,36 @@ def test_force_update_requests_refresh_per_entry(
         async def async_request_refresh(self):
             await self._mark()
 
-    entry1 = _FakeEntry(integration, entry_id="entry-1")
-    entry1.runtime_data = types.SimpleNamespace(coordinator=_StubCoordinator())
-    entry2 = _FakeEntry(integration, entry_id="entry-2")
-    entry2.runtime_data = types.SimpleNamespace(coordinator=_StubCoordinator())
+    coordinator1 = _StubCoordinator()
+    entry1 = _FakeEntry(
+        integration,
+        entry_id="entry-1",
+        data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "location-1"),
+    )
+    entry1.runtime_data = integration.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "location-1": integration.PollenLocationRuntime(
+                subentry_id="location-1", coordinator=coordinator1
+            )
+        },
+    )
+    coordinator2 = _StubCoordinator()
+    entry2 = _FakeEntry(
+        integration,
+        entry_id="entry-2",
+        data={integration.CONF_API_KEY: "key"},
+        subentries=_location_subentries(integration, "location-2"),
+    )
+    entry2.runtime_data = integration.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            "location-2": integration.PollenLocationRuntime(
+                subentry_id="location-2", coordinator=coordinator2
+            )
+        },
+    )
     entry3 = _FakeEntry(integration, entry_id="entry-3")
     entry3.runtime_data = None
     entry4 = _FakeEntry(integration, entry_id="entry-4")
@@ -1426,63 +1455,10 @@ def test_force_update_requests_refresh_per_entry(
 
     asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
 
-    assert entry1.runtime_data.coordinator.calls == ["refresh"]
-    assert entry2.runtime_data.coordinator.calls == ["refresh"]
-    assert entry1.runtime_data.coordinator.done.is_set()
-    assert entry2.runtime_data.coordinator.done.is_set()
-
-
-def test_force_update_continues_after_single_coordinator_failure(
-    integration_modules: _InitModules,
-) -> None:
-    """One coordinator failure should not block refreshes for other entries."""
-    integration = integration_modules.integration
-
-    class _OkCoordinator:
-        def __init__(self):
-            self.calls = 0
-
-        async def async_request_refresh(self):
-            self.calls += 1
-
-    class _FailCoordinator:
-        async def async_request_refresh(self):
-            raise RuntimeError("boom")
-
-    good_entry = _FakeEntry(integration, entry_id="entry-good")
-    good_entry.runtime_data = types.SimpleNamespace(coordinator=_OkCoordinator())
-    bad_entry = _FakeEntry(integration, entry_id="entry-bad")
-    bad_entry.runtime_data = types.SimpleNamespace(coordinator=_FailCoordinator())
-
-    hass = _FakeHass(entries=[bad_entry, good_entry])
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-    asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
-
-    assert good_entry.runtime_data.coordinator.calls == 1
-
-
-def test_force_update_propagates_per_entry_cancelled_error(
-    integration_modules: _InitModules, caplog
-) -> None:
-    """Per-entry cancellation must propagate through the global service."""
-    integration = integration_modules.integration
-
-    class _CancelledCoordinator:
-        async def async_request_refresh(self):
-            raise asyncio.CancelledError
-
-    entry = _FakeEntry(integration, entry_id="entry-cancel")
-    entry.runtime_data = types.SimpleNamespace(coordinator=_CancelledCoordinator())
-
-    hass = _FakeHass(entries=[entry])
-
-    assert asyncio.run(integration.async_setup(hass, {})) is True
-    with caplog.at_level("DEBUG"):
-        with pytest.raises(asyncio.CancelledError):
-            asyncio.run(hass.services.async_call(integration.DOMAIN, "force_update"))
-
-    assert "Manual refresh cancelled for entry entry-cancel" in caplog.text
+    assert coordinator1.calls == ["refresh"]
+    assert coordinator2.calls == ["refresh"]
+    assert coordinator1.done.is_set()
+    assert coordinator2.done.is_set()
 
 
 def test_force_update_no_coordinators_is_noop(
@@ -1515,6 +1491,7 @@ def test_force_update_logs_do_not_expose_secrets(
                 "location.longitude=-98.765432"
             )
 
+    subentry_id = "location-secrets"
     entry = _FakeEntry(
         integration,
         entry_id="entry-secrets",
@@ -1523,8 +1500,16 @@ def test_force_update_logs_do_not_expose_secrets(
             integration.CONF_LATITUDE: 12.345678,
             integration.CONF_LONGITUDE: -98.765432,
         },
+        subentries=_location_subentries(integration, subentry_id),
     )
-    entry.runtime_data = types.SimpleNamespace(coordinator=_FailCoordinator())
+    entry.runtime_data = integration.PollenLevelsRuntimeData(
+        client=object(),
+        locations={
+            subentry_id: integration.PollenLocationRuntime(
+                subentry_id=subentry_id, coordinator=_FailCoordinator()
+            )
+        },
+    )
 
     hass = _FakeHass(entries=[entry])
 
@@ -1543,7 +1528,10 @@ def test_force_update_logs_do_not_expose_secrets(
     assert "token=***" in text
     assert "location.latitude=***" in text
     assert "location.longitude=***" in text
-    assert "Manual refresh failed for entry entry-secrets (RuntimeError):" in text
+    assert (
+        "Manual refresh failed for entry entry-secrets subentry location-secrets "
+        "(RuntimeError):"
+    ) in text
 
 
 def test_force_update_refreshes_location_subentries_sequentially(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -35,6 +35,7 @@ class SensorModules(NamedTuple):
     const: types.ModuleType
     client_mod: types.ModuleType
     coordinator_mod: types.ModuleType
+    runtime_mod: types.ModuleType
     sensor: types.ModuleType
 
 
@@ -246,6 +247,7 @@ def sensor_modules(monkeypatch: pytest.MonkeyPatch) -> SensorModules:
         sensor=_load_module(
             "custom_components.pollenlevels.sensor", "sensor.py", monkeypatch
         ),
+        runtime_mod=sys.modules["custom_components.pollenlevels.runtime"],
     )
     yield modules
     # Remove imported integration modules directly so pytest does not restore
@@ -3008,7 +3010,14 @@ async def test_async_setup_entry_skips_legacy_d1_d2_data_keys(
         "type_grass_d2": {"source": "type", "name": "Grass D+2"},
     }
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=client
+        client=client,
+        locations={
+            coordinator.subentry_id: sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id=coordinator.subentry_id,
+                coordinator=coordinator,
+                legacy_entry_id=coordinator.legacy_entry_id,
+            )
+        },
     )
 
     captured: list[Any] = []
@@ -3092,7 +3101,14 @@ async def test_async_setup_entry_creates_repair_when_legacy_removal_fails(
         "type_grass": {"source": "type", "name": "Grass"},
     }
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=client
+        client=client,
+        locations={
+            coordinator.subentry_id: sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id=coordinator.subentry_id,
+                coordinator=coordinator,
+                legacy_entry_id=coordinator.legacy_entry_id,
+            )
+        },
     )
     captured: list[Any] = []
 
@@ -3410,7 +3426,12 @@ async def test_async_setup_entry_uses_refreshed_coordinator_data_without_forced_
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            "entry": sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id="entry", coordinator=coordinator
+            )
+        },
     )
 
     captured: list[Any] = []
@@ -3480,7 +3501,12 @@ async def test_async_setup_entry_adds_daily_summary_sensors(
         last_updated=None,
     )
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=object()
+        client=object(),
+        locations={
+            entry_id: sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id=entry_id, coordinator=coordinator
+            )
+        },
     )
 
     captured: list[Any] = []
@@ -3542,7 +3568,14 @@ async def test_device_info_uses_default_title_when_blank(
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=client
+        client=client,
+        locations={
+            coordinator.subentry_id: sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id=coordinator.subentry_id,
+                coordinator=coordinator,
+                legacy_entry_id=coordinator.legacy_entry_id,
+            )
+        },
     )
 
     captured: list[Any] = []
@@ -3601,7 +3634,14 @@ async def test_device_info_trims_custom_title(
     )
     coordinator.data = {"date": {"source": "meta"}, "region": {"source": "meta"}}
     config_entry.runtime_data = sensor_modules.sensor.PollenLevelsRuntimeData(
-        coordinator=coordinator, client=client
+        client=client,
+        locations={
+            coordinator.subentry_id: sensor_modules.runtime_mod.PollenLocationRuntime(
+                subentry_id=coordinator.subentry_id,
+                coordinator=coordinator,
+                legacy_entry_id=coordinator.legacy_entry_id,
+            )
+        },
     )
 
     captured: list[Any] = []


### PR DESCRIPTION
Candidate 5 from #247.

- remove unreachable coordinator-only button setup;
- remove unreachable coordinator-only force_update path;
- remove legacy PollenLevelsRuntimeData(coordinator=...) support;
- remove the legacy .coordinator projection;
- modernize affected lightweight fixtures to runtime.locations;
- retain real HA service/platform coverage unchanged apart from the obsolete property assertion;
- preserve parent-data fallback, stale filtering, migration, IDs, registries, history, diagnostics behavior and public services.

Validation:

```text
Focused: 204 passed in 5.18s
Full: 584 passed in 14.36s
Ruff: pass
Format: pass (58 files already formatted)
compileall: pass
diff-check: pass
```

Refs #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed support for standalone, location-less update buttons and refresh actions.
  * Refresh operations now skip entries without configured locations instead of using a fallback coordinator.
  * Improved logging when no location-specific configuration is available.

* **Refactor**
  * Standardized runtime handling around location-specific configurations.
  * Updated diagnostics, sensors, and service behavior to use the per-location model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->