### PR TITLE
chore(deps): enforce lockfile release age with uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ release = [
 # renovate: datasource=github-releases depName=astral-sh/uv
 required-version = "==0.12.1"
 default-groups = []
+# Keep transitive packages behind the same supply-chain cooldown as Renovate.
+exclude-newer = "3 days"
 # Home Assistant 2026.8.0b3 requires Python 3.14.2+, while CI itself uses the
 # exact patch from .python-version. Keep the lock within the supported 3.14 line.
 environments = ["python_full_version >= '3.14.2' and python_full_version < '3.15'"]

--- a/renovate.json
+++ b/renovate.json
@@ -97,6 +97,16 @@
       "internalChecksFilter": "strict"
     },
     {
+      "description": "Delegate uv.lock release age enforcement to uv",
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Keep CI Python on the approved 3.14 patch line",
       "matchManagers": [
         "pyenv"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ supported-markers = [
     "python_full_version >= '3.14.2' and python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "acme"
 version = "5.4.0"


### PR DESCRIPTION
## Summary

Move the 3-day lockfile release-age enforcement to the layer that can actually evaluate transitive package upload times.

- Keep Renovate's existing `minimumReleaseAge: "3 days"` policy unchanged for direct dependency updates.
- Exempt `pep621` `lockFileMaintenance` updates from Renovate's unsupported `minimumReleaseAge` check.
- Add `exclude-newer = "3 days"` to `[tool.uv]` so uv enforces the same cooldown during lockfile resolution.
- Regenerate `uv.lock` with the repository-pinned uv `0.12.1` using plain `uv lock` (no `--upgrade`).

## Lockfile result

The lockfile regeneration changed metadata only; no dependency versions or artifact hashes changed:

```toml
[options]
exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
exclude-newer-span = "P3D"
```

## Validation performed before opening this PR

- `uv lock` completed successfully with the project-pinned uv `0.12.1` on a GitHub-hosted runner.
- `renovate-config-validator --strict renovate.json` completed successfully.
- Final branch diff contains exactly three files: `renovate.json`, `pyproject.toml`, and `uv.lock`.
- The branch was cleaned to one commit; temporary validation workflows are not part of the PR.

## Scope

This is a tooling-only change. It does not modify integration runtime, migration, workflows, documentation, versions, or the pytest / PHACC / Home Assistant compatibility policy. The separate compatibility failures in Renovate PRs #258 and #259 are intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a three-day cooldown for newly released packages during dependency resolution.
  * Updated automated dependency maintenance to handle lockfile updates without enforcing a minimum release-age requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->