### PR TITLE
chore(deps): align Renovate with HA test harness

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -152,13 +152,11 @@
       "separateMajorMinor": true
     },
     {
-      "description": "Group compatible generic pytest tooling updates",
+      "description": "Group independent generic test tooling updates",
       "matchManagers": [
         "pep621"
       ],
       "matchPackageNames": [
-        "pytest",
-        "pytest-asyncio",
         "aiointercept",
         "packaging"
       ],
@@ -169,7 +167,7 @@
       "groupName": "Generic pytest tooling"
     },
     {
-      "description": "Keep Home Assistant harness compatibility updates separate",
+      "description": "Require approval for Home Assistant harness compatibility updates",
       "matchManagers": [
         "pep621"
       ],
@@ -177,15 +175,18 @@
         "pytest-homeassistant-custom-component"
       ],
       "groupName": "Home Assistant test compatibility",
-      "separateMajorMinor": true
+      "separateMajorMinor": true,
+      "dependencyDashboardApproval": true
     },
     {
-      "description": "Only the harness compatibility lane updates Home Assistant pins",
+      "description": "Keep harness-controlled compatibility pins owner-reviewed",
       "matchManagers": [
         "pep621"
       ],
       "matchPackageNames": [
-        "homeassistant"
+        "homeassistant",
+        "pytest",
+        "pytest-asyncio"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

Align Renovate with the dependency constraints imposed by `pytest-homeassistant-custom-component` (PHACC).

## Changes

- keep `aiointercept` and `packaging` in the independently updateable generic test-tooling group;
- stop Renovate from updating `pytest`, `pytest-asyncio`, and `homeassistant` independently because PHACC pins compatible versions of that stack;
- require Dependency Dashboard approval before Renovate creates a PHACC update PR, so harness compatibility changes are explicitly owner-reviewed.

## Why

The current Renovate lanes can create unsatisfiable dependency sets:

- PHACC updates require an exact Home Assistant version;
- PHACC also constrains pytest/test-stack versions;
- independently updating those pins causes `uv lock --check` and Renovate artifact generation to fail, as seen in #258 and #259.

This PR changes Renovate policy only. It does not modify dependency versions, runtime code, migration logic, workflows, or `uv.lock`.

## Validation

- `renovate.json` parses as valid JSON;
- configuration options are supported by current Renovate documentation (`dependencyDashboardApproval`, `enabled`, package rules);
- final diff is limited to `renovate.json`.

After merge, #258/#259 can be closed/re-evaluated under the corrected lanes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update management.
  * Independent tooling updates are now handled separately for clearer review.
  * Home Assistant harness updates require explicit approval and distinguish major from minor changes.
  * Related compatibility updates are grouped for coordinated, owner-reviewed maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->