### PR TITLE
fix(translations): remove deprecated subentry titles

### DIFF
--- a/custom_components/pollenlevels/translations/ca.json
+++ b/custom_components/pollenlevels/translations/ca.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Ubicació",
       "entry_type": "Ubicació",
       "initiate_flow": {
         "user": "Afegeix ubicació"

--- a/custom_components/pollenlevels/translations/cs.json
+++ b/custom_components/pollenlevels/translations/cs.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Umístění",
       "entry_type": "Poloha",
       "initiate_flow": {
         "user": "Přidat polohu"

--- a/custom_components/pollenlevels/translations/da.json
+++ b/custom_components/pollenlevels/translations/da.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Placering",
       "entry_type": "Placering",
       "initiate_flow": {
         "user": "Tilføj placering"

--- a/custom_components/pollenlevels/translations/de.json
+++ b/custom_components/pollenlevels/translations/de.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Standort",
       "entry_type": "Standort",
       "initiate_flow": {
         "user": "Standort hinzufügen"

--- a/custom_components/pollenlevels/translations/en.json
+++ b/custom_components/pollenlevels/translations/en.json
@@ -50,7 +50,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Location",
       "entry_type": "Location",
       "initiate_flow": {
         "user": "Add location"

--- a/custom_components/pollenlevels/translations/es.json
+++ b/custom_components/pollenlevels/translations/es.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Ubicación",
       "entry_type": "Ubicación",
       "initiate_flow": {
         "user": "Añadir ubicación"

--- a/custom_components/pollenlevels/translations/fi.json
+++ b/custom_components/pollenlevels/translations/fi.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Sijainti",
       "entry_type": "Sijainti",
       "initiate_flow": {
         "user": "Lisää sijainti"

--- a/custom_components/pollenlevels/translations/fr.json
+++ b/custom_components/pollenlevels/translations/fr.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Emplacement",
       "entry_type": "Emplacement",
       "initiate_flow": {
         "user": "Ajouter un emplacement"

--- a/custom_components/pollenlevels/translations/hu.json
+++ b/custom_components/pollenlevels/translations/hu.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Hely",
       "entry_type": "Hely",
       "initiate_flow": {
         "user": "Hely hozzáadása"

--- a/custom_components/pollenlevels/translations/it.json
+++ b/custom_components/pollenlevels/translations/it.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Posizione",
       "entry_type": "Posizione",
       "initiate_flow": {
         "user": "Aggiungi posizione"

--- a/custom_components/pollenlevels/translations/nb.json
+++ b/custom_components/pollenlevels/translations/nb.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Plassering",
       "entry_type": "Plassering",
       "initiate_flow": {
         "user": "Legg til plassering"

--- a/custom_components/pollenlevels/translations/nl.json
+++ b/custom_components/pollenlevels/translations/nl.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Locatie",
       "entry_type": "Locatie",
       "initiate_flow": {
         "user": "Locatie toevoegen"

--- a/custom_components/pollenlevels/translations/pl.json
+++ b/custom_components/pollenlevels/translations/pl.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Lokalizacja",
       "entry_type": "Lokalizacja",
       "initiate_flow": {
         "user": "Dodaj lokalizację"

--- a/custom_components/pollenlevels/translations/pt-BR.json
+++ b/custom_components/pollenlevels/translations/pt-BR.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Local",
       "entry_type": "Local",
       "initiate_flow": {
         "user": "Adicionar local"

--- a/custom_components/pollenlevels/translations/pt-PT.json
+++ b/custom_components/pollenlevels/translations/pt-PT.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Localização",
       "entry_type": "Localização",
       "initiate_flow": {
         "user": "Adicionar localização"

--- a/custom_components/pollenlevels/translations/ro.json
+++ b/custom_components/pollenlevels/translations/ro.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Locație",
       "entry_type": "Locație",
       "initiate_flow": {
         "user": "Adaugă locație"

--- a/custom_components/pollenlevels/translations/ru.json
+++ b/custom_components/pollenlevels/translations/ru.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Местоположение",
       "entry_type": "Местоположение",
       "initiate_flow": {
         "user": "Добавить местоположение"

--- a/custom_components/pollenlevels/translations/sv.json
+++ b/custom_components/pollenlevels/translations/sv.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Plats",
       "entry_type": "Plats",
       "initiate_flow": {
         "user": "Lägg till plats"

--- a/custom_components/pollenlevels/translations/uk.json
+++ b/custom_components/pollenlevels/translations/uk.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "Місце",
       "entry_type": "Місце",
       "initiate_flow": {
         "user": "Додати місце"

--- a/custom_components/pollenlevels/translations/zh-Hans.json
+++ b/custom_components/pollenlevels/translations/zh-Hans.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "位置",
       "entry_type": "位置",
       "initiate_flow": {
         "user": "添加位置"

--- a/custom_components/pollenlevels/translations/zh-Hant.json
+++ b/custom_components/pollenlevels/translations/zh-Hant.json
@@ -116,7 +116,6 @@
   },
   "config_subentries": {
     "location": {
-      "title": "位置",
       "entry_type": "位置",
       "initiate_flow": {
         "user": "新增位置"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -336,6 +336,12 @@ def test_config_subentries_location_schema_shape() -> None:
         data = _load_translation(translation_path)
         location = data.get("config_subentries", {}).get("location", {})
 
+        if "title" in location:
+            problems.append(
+                f"{translation_path.name}: "
+                "config_subentries.location.title is deprecated and must be omitted"
+            )
+
         entry_type = location.get("entry_type")
         if not isinstance(entry_type, str) or not entry_type.strip():
             problems.append(
@@ -378,7 +384,6 @@ def test_v3_subentry_translation_strings_are_localized() -> None:
         "config.step.user.description",
         "options.step.init.description",
         "config.error.already_configured",
-        "config_subentries.location.title",
         "config_subentries.location.entry_type",
         "config_subentries.location.initiate_flow.user",
         "config_subentries.location.step.user.title",
@@ -497,7 +502,6 @@ def test_sensor_translation_keys_present() -> None:
 
 def test_services_translation_keys_present() -> None:
     """Ensure services declared in services.yaml have translations in en.json."""
-
     english = _flatten_keys(_load_translation(TRANSLATIONS_DIR / "en.json"))
     service_names = _extract_services_from_services_yaml()
     if not service_names:


### PR DESCRIPTION
## Summary

Remove the deprecated `config_subentries.location.title` translation key from all locales and update translation coverage to match the current Home Assistant config-subentry translation schema.

Closes #250.

## Changes

- remove `config_subentries.location.title` from all 21 translation files;
- keep `entry_type`, `initiate_flow`, and step titles unchanged;
- remove the obsolete title path from the localized-string coverage test;
- add a regression assertion that rejects deprecated subentry root titles.

## Why

Current hassfest emits a non-blocking `[TRANSLATIONS]` warning because Home Assistant removed config-subentry root `title` in favor of `entry_type` and `initiate_flow`.

No `strings.json` is added because Pollen Levels is a custom integration and continues to use `translations/en.json` as its translation source of truth.

## Scope / safety

No runtime, migration, registry, entity, device, service, diagnostics, forecast, or release metadata changes.

## Validation

CI should cover:

- Ruff checks and formatting;
- pytest, including `tests/test_translations.py`;
- hassfest;
- HACS validation;
- workflow security and CodeQL.

Manual smoke testing is only needed if CI exposes a translation/UI regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Localization**
  - Updated supported translations by removing the obsolete location title label.
  - Existing location labels, configuration text, and setup flows remain available across all supported languages.

- **Bug Fixes**
  - Improved translation validation to prevent the retired location title entry from reappearing.
  - Helps maintain consistent location configuration wording across locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->