### PR TITLE
test: remove redundant test path mutations

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -21,7 +21,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 @pytest.fixture

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -22,7 +22,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 class SensorModules(NamedTuple):


### PR DESCRIPTION
## Summary

Start the focused #246 cleanup by removing redundant module-local repository-root `sys.path` mutations from lightweight tests.

This PR is intentionally test-infrastructure-only. It must not change runtime behavior, v3 migration, package layout, pytest import mode, Home Assistant semantics, or `sitecustomize.py`.

## Scope

Targeted files from #246:

- `tests/test_button.py`
- `tests/test_config_flow.py`
- `tests/test_init.py`
- `tests/test_migration.py`
- `tests/test_sensor.py`
- `tests/test_sensor_plant_advice.py`

The broad `# ruff: noqa: E402` in `tests/test_config_flow.py` will also be removed if Ruff proves it unnecessary after the path cleanup. If a real E402 remains, imports will not be reordered merely to silence it.

## Environment contract

Required validation is Linux/GitHub Actions with the repository's documented `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q` invocation. Native Windows pytest is not a supported merge gate; Windows development remains available through WSL2. Native-Windows shims are tracked separately in #267.

## Validation

Before this draft is marked ready:

- all six affected files independently;
- affected files together in multiple orders;
- full locked pytest suite;
- Ruff check and format check;
- compileall;
- unchanged collected test count;
- stub/harness isolation review;
- required GitHub checks green.

Refs #246
Refs #267
