### PR TITLE
test: remove redundant test path mutations

### DIFF
--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -21,7 +21,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,5 @@
 """Tests for the Pollen Levels config flow language validation."""
 
-# ruff: noqa: E402
-
 from __future__ import annotations
 
 import ast
@@ -26,7 +24,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,7 +25,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 @dataclass(frozen=True)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -25,7 +25,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 @dataclass(frozen=True)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -26,7 +26,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 class SensorModules(NamedTuple):

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -22,7 +22,6 @@ from tests._ha_stubs import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 
 class SensorModules(NamedTuple):


### PR DESCRIPTION
Closes #246

## Summary

- Remove six redundant test-local repository-root `sys.path.insert(0, str(ROOT))` mutations.
- Remove the now-obsolete broad `# ruff: noqa: E402` suppression in `tests/test_config_flow.py`.
- No production, migration implementation, dependency, version, lockfile, or workflow changes.
- `sitecustomize.py` is untouched; #267 remains separate.

## Validation

- Pre/post collection: 584 tests; collected node lists are identical. The raw pytest summaries differ only in elapsed collection time.
- Supported full suite: `584 passed in 14.70s`.
- Individual affected files: 10, 98, 77, 8, 91, and 4 tests passed respectively.
- Combined forward and reverse orders: `288 passed` each.
- Import origins before and after resolve `tests._ha_stubs` and `custom_components.pollenlevels` from the checkout.
- `uv lock --check`, Ruff lint, Ruff format check, compileall, and `git diff --check` passed using Python 3.14.6 and uv 0.12.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified test setup by relying on the existing environment configuration for imports.
  - Removed redundant path adjustments and linting exceptions from test modules.
  - No changes to application behavior or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->