### PR TITLE
chore(renovate): owner-manage Home Assistant harness updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -167,23 +167,12 @@
       "groupName": "Generic pytest tooling"
     },
     {
-      "description": "Require approval for Home Assistant harness compatibility updates",
+      "description": "Keep Home Assistant harness compatibility pins owner-managed",
       "matchManagers": [
         "pep621"
       ],
       "matchPackageNames": [
-        "pytest-homeassistant-custom-component"
-      ],
-      "groupName": "Home Assistant test compatibility",
-      "separateMajorMinor": true,
-      "dependencyDashboardApproval": true
-    },
-    {
-      "description": "Keep harness-controlled compatibility pins owner-reviewed",
-      "matchManagers": [
-        "pep621"
-      ],
-      "matchPackageNames": [
+        "pytest-homeassistant-custom-component",
         "homeassistant",
         "pytest",
         "pytest-asyncio"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -439,6 +439,22 @@ def test_renovate_has_one_source_for_each_managed_validation_dependency() -> Non
     assert uv_managers[0]["managerFilePatterns"] == ["/^pyproject\\.toml$/"]
     assert renovate["automerge"] is False
     assert renovate["lockFileMaintenance"]["enabled"] is True
+    harness_packages = {
+        "pytest-homeassistant-custom-component",
+        "homeassistant",
+        "pytest",
+        "pytest-asyncio",
+    }
+    harness_rules = [
+        rule
+        for rule in renovate["packageRules"]
+        if harness_packages.intersection(rule.get("matchPackageNames", []))
+    ]
+    assert len(harness_rules) == 1
+    harness_rule = harness_rules[0]
+    assert harness_rule["matchManagers"] == ["pep621"]
+    assert set(harness_rule["matchPackageNames"]) == harness_packages
+    assert harness_rule["enabled"] is False
     policy = json.dumps(renovate)
     assert "minimumGroupSize" not in policy
     assert "groupSingleUpdates" not in policy


### PR DESCRIPTION
## Summary

- Make the Home Assistant test-harness pins explicitly owner-managed in Renovate.
- Add metadata coverage that requires exactly one disabled `pep621` rule for PHACC, Home Assistant, pytest, and pytest-asyncio.

## Why

Follow-up to #274: Renovate can independently update PHACC while the exact Home Assistant compatibility pin remains disabled, producing a dependency set that cannot generate a valid `uv.lock`.

Ordinary Renovate grouping was considered and rejected because it cannot guarantee dependency-aware PHACC-to-Home-Assistant version selection. The advisory Home Assistant compatibility canary remains the detection mechanism for newer coherent harness sets; maintainers update the coupled pins manually in one compatibility change.

## Scope

- No dependency declarations or `uv.lock` changes.
- No runtime, workflow, migration, or documentation changes.
- Existing metadata tests continue to enforce exact harness compatibility alignment.

## Validation

- `python -m json.tool renovate.json`
- `renovate-config-validator` 44.12.0
- `uv lock --check`
- Ruff check and format check
- `tests/test_metadata.py`: 17 passed
- Full suite: 584 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package update management to provide more controlled handling of compatibility-related updates.
  * Removed automatic update grouping and approval requirements for selected maintenance packages.

* **Tests**
  * Strengthened configuration checks to ensure update-management rules remain consistent and correctly scoped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->