### PR TITLE
test: rely on pytest-asyncio runtime

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
-"""Pytest configuration for lightweight async test support."""
+"""Shared pytest fixtures and configuration for Pollen Levels tests."""
 
 from __future__ import annotations
 
-import asyncio
-import inspect
 import json
 from pathlib import Path
 from typing import Any
@@ -26,85 +24,6 @@ from custom_components.pollenlevels.util import (
 )
 
 TESTS_DIR = Path(__file__).resolve().parent
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the asyncio marker used for lightweight async tests."""
-
-    config.addinivalue_line(
-        "markers", "asyncio: run test in an event loop without external plugins"
-    )
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
-    """Run @pytest.mark.asyncio tests locally when no other async plugin is active."""
-
-    marker = pyfuncitem.get_closest_marker("asyncio")
-    if marker is None or not inspect.iscoroutinefunction(pyfuncitem.obj):
-        return None
-
-    # If another asyncio-aware plugin is active, let it handle the test.
-    plugin_manager = pyfuncitem.config.pluginmanager
-    if plugin_manager.hasplugin("asyncio") or plugin_manager.hasplugin(
-        "pytest-asyncio"
-    ):
-        return None
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        running_loop = False
-    else:
-        running_loop = True
-
-    if running_loop:
-        raise RuntimeError(
-            "Detected a running event loop without an asyncio-aware pytest plugin. "
-            "Disable conflicting plugins or install/enable pytest-asyncio."
-        )
-
-    try:
-        previous_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        previous_loop = None
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        signature = inspect.signature(pyfuncitem.obj)
-        declared_funcargs = {
-            name: pyfuncitem.funcargs[name]
-            for name in signature.parameters
-            if name in pyfuncitem.funcargs
-        }
-        loop.run_until_complete(pyfuncitem.obj(**declared_funcargs))
-    finally:
-        # Ensure all tasks and async generators are properly cleaned up
-        try:
-            pending = asyncio.all_tasks(loop)
-            for task in pending:
-                task.cancel()
-            if pending:
-                loop.run_until_complete(
-                    asyncio.gather(*pending, return_exceptions=True)
-                )
-        except Exception:
-            # Continue teardown even if cleanup raises
-            pass
-        finally:
-            try:
-                loop.run_until_complete(loop.shutdown_asyncgens())
-            except Exception:
-                pass
-            finally:
-                loop.close()
-                try:
-                    asyncio.set_event_loop(previous_loop)
-                except Exception:
-                    asyncio.set_event_loop(None)
-
-    return True
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #244

## Summary

- Remove the redundant local async pytest runner and duplicate asyncio marker registration.
- Rely on the pinned `pytest-asyncio` runtime, which already owns coroutine test execution in `asyncio_mode = "auto"`.
- Keep all shared fixtures and every test body unchanged.

## Evidence

- Pre/post collection node IDs are identical: 584 tests.
- Full suite: 584 passed.
- Focused lightweight and Home Assistant harness test modules all pass.
- Ruff, format check, locked resolution, and `compileall` pass with no new async cleanup or marker warnings.

Manual `asyncio.run(...)` and explicit-loop modernization was investigated and intentionally deferred: it is not required to remove the inactive fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed custom asynchronous test support and related event-loop handling.
  * Updated the test configuration description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->