### PR TITLE
diagnostics: expose stale payload state

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -214,6 +214,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.data: dict[str, dict[str, Any]] = {}
         self.last_updated: datetime | None = None
+        self.using_stale_data: bool = False
+        self.last_payload_valid: bool | None = None
 
     def _utcnow(self) -> datetime:
         """Return the current UTC time."""
@@ -268,7 +270,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             daily = None
 
         if not daily:
+            self.last_payload_valid = False
             if self._has_fresh_cached_data():
+                self.using_stale_data = True
                 if not self._missing_dailyinfo_warned:
                     cache_age = self._utcnow() - self.last_updated
                     _LOGGER.warning(
@@ -280,6 +284,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     )
                     self._missing_dailyinfo_warned = True
                 return self.data
+            self.using_stale_data = False
             if self.data:
                 if not self._stale_dailyinfo_warned:
                     _LOGGER.warning(
@@ -290,6 +295,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     "API response missing or invalid dailyInfo; cached data expired"
                 )
             raise UpdateFailed("API response missing or invalid dailyInfo")
+        self.last_payload_valid = True
         self._missing_dailyinfo_warned = False
         self._stale_dailyinfo_warned = False
 
@@ -434,6 +440,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.data = new_data
         self.last_updated = self._utcnow()
+        self.using_stale_data = False
         if _LOGGER.isEnabledFor(logging.DEBUG):
             total = len(new_data)
             types = 0

--- a/custom_components/pollenlevels/diagnostics.py
+++ b/custom_components/pollenlevels/diagnostics.py
@@ -113,6 +113,8 @@ def _coordinator_diagnostics(coordinator: Any) -> dict[str, Any]:
         "forecast_days": FORECAST_DAYS,
         "language": getattr(coordinator, "language", None),
         "last_updated": _iso_or_none(getattr(coordinator, "last_updated", None)),
+        "using_stale_data": getattr(coordinator, "using_stale_data", False),
+        "last_payload_valid": getattr(coordinator, "last_payload_valid", None),
         "data_keys_total": 0,
         "data_keys": [],
     }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -205,6 +205,8 @@ async def test_diagnostics_includes_all_locations_without_top_level_duplicates(
         entity_identity_id="legacy-entry",
         language="en",
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        using_stale_data=True,
+        last_payload_valid=False,
         lat=12.3456,
         lon=78.9876,
         entry_title="Home",
@@ -217,6 +219,8 @@ async def test_diagnostics_includes_all_locations_without_top_level_duplicates(
         entity_identity_id="entry_subentry-2",
         language="en",
         last_updated=dt.datetime(2025, 1, 1, tzinfo=dt.UTC),
+        using_stale_data=False,
+        last_payload_valid=True,
         lat=40.7128,
         lon=-74.0060,
         entry_title="Office",
@@ -272,6 +276,10 @@ async def test_diagnostics_includes_all_locations_without_top_level_duplicates(
     assert "legacy_entry_id" not in first_payload["coordinator"]
     assert "entity_identity_id" not in first_payload["coordinator"]
     assert second_payload["coordinator"]["subentry_id"] == "subentry-2"
+    assert first_payload["coordinator"]["using_stale_data"] is True
+    assert first_payload["coordinator"]["last_payload_valid"] is False
+    assert second_payload["coordinator"]["using_stale_data"] is False
+    assert second_payload["coordinator"]["last_payload_valid"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_ha_diagnostics.py
+++ b/tests/test_ha_diagnostics.py
@@ -138,6 +138,68 @@ async def test_ha_diagnostics_summarizes_stale_and_failed_locations(
     assert "-98.765432" not in serialized
 
 
+async def test_ha_diagnostics_reports_stale_payload_per_active_location(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    ha_two_location_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """A stale payload for one active location must not affect another location."""
+
+    clear_integration_modules()
+    entry = ha_two_location_config_entry
+    entry.add_to_hass(hass)
+    serve_invalid_barcelona = False
+
+    def _callback(url, **_kwargs):
+        params = dict(parse_qsl(url.query_string))
+        if serve_invalid_barcelona and float(params["location.latitude"]) == 41.3874:
+            return CallbackResult(status=200, payload={"dailyInfo": []})
+        return CallbackResult(status=200, payload=google_pollen_5_day_payload)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mocked.get(POLLEN_API_URL_RE, callback=_callback, repeat=True)
+        await async_setup_config_entry(hass, entry)
+
+        serve_invalid_barcelona = True
+        barcelona = entry.runtime_data.locations["location-barcelona"].coordinator
+        madrid = entry.runtime_data.locations["location-madrid"].coordinator
+        await barcelona.async_refresh()
+
+        diagnostics_module = importlib.import_module(
+            "custom_components.pollenlevels.diagnostics"
+        )
+        diagnostics = await diagnostics_module.async_get_config_entry_diagnostics(
+            hass, entry
+        )
+
+    assert barcelona.last_update_success is True
+    assert barcelona.using_stale_data is True
+    assert barcelona.last_payload_valid is False
+    assert madrid.using_stale_data is False
+    assert madrid.last_payload_valid is True
+    barcelona_diagnostics = diagnostics["locations"]["location-barcelona"][
+        "coordinator"
+    ]
+    madrid_diagnostics = diagnostics["locations"]["location-madrid"]["coordinator"]
+    assert barcelona_diagnostics["using_stale_data"] is True
+    assert barcelona_diagnostics["last_payload_valid"] is False
+    assert madrid_diagnostics["using_stale_data"] is False
+    assert madrid_diagnostics["last_payload_valid"] is True
+    assert diagnostics["runtime_summary"] == {
+        "stale_location_count": 0,
+        "stale_location_ids": [],
+        "failed_location_count": 0,
+        "failed_location_ids": [],
+    }
+    serialized = json.dumps(diagnostics, sort_keys=True)
+    assert fake_api_key not in serialized
+    assert "41.3874" not in serialized
+    assert "2.1686" not in serialized
+
+
 async def test_ha_diagnostics_registry_summary_uses_real_registries(
     hass: HomeAssistant,
     enable_custom_integrations: None,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1141,7 +1141,12 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing(
     coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
+        assert coordinator.using_stale_data is False
+        assert coordinator.last_payload_valid is None
         first_data = loop.run_until_complete(coordinator._async_update_data())
+        first_updated = coordinator.last_updated
+        assert coordinator.using_stale_data is False
+        assert coordinator.last_payload_valid is True
         coordinator.data = first_data
         second_data = loop.run_until_complete(coordinator._async_update_data())
     finally:
@@ -1150,6 +1155,9 @@ def test_coordinator_preserves_last_data_when_dailyinfo_missing(
     assert first_data["type_grass"]["value"] == 2
     assert second_data == first_data
     assert second_data == coordinator.data
+    assert coordinator.last_updated == first_updated
+    assert coordinator.using_stale_data is True
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_handles_real_partial_google_pollen_fixture(
@@ -1265,12 +1273,16 @@ def test_coordinator_first_refresh_missing_dailyinfo_raises(
     coordinator = _make_coordinator(sensor_modules, loop, client)
 
     try:
+        assert coordinator.using_stale_data is False
+        assert coordinator.last_payload_valid is None
         with pytest.raises(sensor_modules.client_mod.UpdateFailed, match="dailyInfo"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
     assert coordinator.data == {}
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_first_refresh_invalid_dailyinfo_type_raises(
@@ -1316,6 +1328,7 @@ def test_coordinator_invalid_dailyinfo_items_keep_last_data(
                 },
             ),
             ResponseSpec(status=200, payload={"dailyInfo": ["bad-item"]}),
+            ResponseSpec(status=200, payload={"dailyInfo": ["bad-item"]}),
         ]
     )
     client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
@@ -1327,11 +1340,15 @@ def test_coordinator_invalid_dailyinfo_items_keep_last_data(
         first_data = loop.run_until_complete(coordinator._async_update_data())
         coordinator.data = first_data
         second_data = loop.run_until_complete(coordinator._async_update_data())
+        third_data = loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
     assert first_data["type_grass"]["value"] == 2
     assert second_data == first_data
+    assert third_data == first_data
+    assert coordinator.using_stale_data is True
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_mixed_dailyinfo_items_keep_last_data(
@@ -1418,6 +1435,8 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
         loop.close()
 
     assert coordinator.data == first_data
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_stale_cached_data_accepted_at_exactly_24_hours(
@@ -1448,6 +1467,8 @@ def test_coordinator_stale_cached_data_accepted_at_exactly_24_hours(
         loop.close()
 
     assert second_data == first_data
+    assert coordinator.using_stale_data is True
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_stale_data_ttl_is_fixed_24_hours(
@@ -1513,11 +1534,15 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
         assert coordinator.last_updated == first_refresh
+        assert coordinator.using_stale_data is False
+        assert coordinator.last_payload_valid is True
 
         now = malformed_refresh
         cached_data = loop.run_until_complete(coordinator._async_update_data())
         assert cached_data == first_data
         assert coordinator.last_updated == first_refresh
+        assert coordinator.using_stale_data is True
+        assert coordinator.last_payload_valid is False
 
         now = second_refresh
         second_data = loop.run_until_complete(coordinator._async_update_data())
@@ -1526,6 +1551,83 @@ def test_coordinator_success_after_malformed_response_updates_last_updated(
 
     assert second_data["type_grass"]["value"] == 4
     assert coordinator.last_updated == second_refresh
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is True
+
+
+def test_coordinator_preserves_stale_provenance_after_later_processing_failure(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A structurally valid payload must not clear stale provenance before success."""
+
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload(value=2)),
+            ResponseSpec(status=200, payload={}),
+            ResponseSpec(status=200, payload=_minimal_valid_payload(value=4)),
+        ]
+    )
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        loop.run_until_complete(coordinator._async_update_data())
+
+        def _raise_during_processing(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("forecast processing failed")
+
+        monkeypatch.setattr(
+            sensor_modules.coordinator_mod,
+            "attach_forecast_attributes",
+            _raise_during_processing,
+        )
+        with pytest.raises(RuntimeError, match="forecast processing failed"):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert coordinator.data == first_data
+    assert coordinator.using_stale_data is True
+    assert coordinator.last_payload_valid is True
+
+
+@pytest.mark.parametrize("exception_name", ["update_failed", "auth_failed"])
+def test_coordinator_transport_failures_leave_payload_state_unchanged(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_name: str,
+) -> None:
+    """Failures before dailyInfo validation must keep the retained-data state."""
+
+    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    coordinator.using_stale_data = True
+    coordinator.last_payload_valid = False
+
+    exception_type = (
+        sensor_modules.client_mod.UpdateFailed
+        if exception_name == "update_failed"
+        else sensor_modules.client_mod.ConfigEntryAuthFailed
+    )
+
+    async def _raise_before_validation(**_kwargs: Any) -> dict[str, Any]:
+        raise exception_type("request failed")
+
+    monkeypatch.setattr(client, "async_fetch_pollen_data", _raise_before_validation)
+
+    try:
+        with pytest.raises(exception_type, match="request failed"):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert coordinator.using_stale_data is True
+    assert coordinator.last_payload_valid is False
 
 
 def test_coordinator_rejects_removed_forecast_day_arguments(


### PR DESCRIPTION
Closes #216

## Summary

- Track per-coordinator stale-payload provenance in memory with `using_stale_data` and `last_payload_valid`.
- Expose those values under each active location's existing diagnostics coordinator snapshot.
- Keep cached-payload fallback, the fixed 24-hour TTL, availability, HTTP behavior, entities, and Last Updated sensor unchanged.

## Behavior

- Invalid `dailyInfo` with a fresh cache reports `using_stale_data: true` and `last_payload_valid: false`.
- A fully successful fresh payload clears stale provenance only when it replaces the retained data.
- Transport, HTTP, timeout, quota, invalid-JSON, and authentication failures leave the payload-state fields unchanged because they do not reach `dailyInfo` validation.
- Existing `runtime_summary.stale_location_*` continues to mean stale deleted/unconfigured runtime locations, not API payload freshness.

## Validation

- Full node-ID baseline retained; four focused coverage nodes added.
- `588 passed` (full suite).
- Focused coordinator/diagnostics/HA diagnostics: `117 passed`.
- `uv lock --check`, Ruff check/format, compileall, and `git diff --check` passed.
- Diagnostics tests retain API-key redaction and one-decimal coordinate rounding; no raw payload or full request URL is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into whether pollen data is valid or being served from a previous cached result.
  * Diagnostics now report data validity and stale-data status independently for each location.

* **Bug Fixes**
  * Improved handling of malformed, incomplete, processing, and connection failures while preserving reliable cached data and timestamps.
  * Successful refreshes correctly restore current-data status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->