### PR TITLE
release: prepare 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [3.0.1] - 2026-08-09
+
+### Added
+
+- Added per-location `using_stale_data` and `last_payload_valid` diagnostics so
+  support data clearly identifies cached pollen payload reuse after an invalid
+  upstream response.
+
+### Changed
+
+- Aligned config-flow, runtime, and entity setup with the Home Assistant APIs
+  supported by the current minimum version, removing obsolete compatibility
+  fallbacks without changing the v3 migration or public entity and device
+  identities.
+
+### Fixed
+
+- Removed deprecated config-subentry root `title` translation metadata to match
+  current Home Assistant translation validation while retaining the localized
+  entry type and setup-flow labels.
+
 ## [3.0.0] - 2026-08-02
 
 ### Added

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.0"
+    "version": "3.0.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.0"
+version = "3.0.1"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "pollenlevels"
-version = "3.0.0"
+version = "3.0.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- bump Pollen Levels to 3.0.1;
- add the 3.0.1 changelog;
- synchronize only the local project version in uv.lock.

## Release scope
- stale-payload diagnostics from #279;
- Home Assistant supported-API maintenance since 3.0.0;
- translation schema cleanup from #266;
- no v3 migration changes;
- no entity/device/public contract changes.

## Validation
- uv 0.12.2: `uv lock --check` passed.
- `uv sync --locked --only-group lint` passed.
- `uv run --locked --no-sync ruff check .` passed.
- `uv run --locked --no-sync ruff format --check .` passed (57 files already formatted).
- `uv sync --locked --only-group test` passed.
- `PYTHONPATH=. uv run --locked --no-sync python -m pytest --collect-only -q` passed (588 collected).
- `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q` passed (588 passed in 14.61s).
- `uv sync --locked --only-group release` passed.
- `uv run --locked --no-sync python -m compileall -q custom_components tests scripts` passed.
- `git diff --check` passed.
- Lock audit: only the virtual `pollenlevels` package version changed from 3.0.0 to 3.0.1; no dependency version, source, or hash changed.