### PR TITLE
docs: document release lock synchronization

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -172,7 +172,7 @@ after publication do not necessarily require a new release.
 - [ ] `uv.lock` local `pollenlevels` package version matches the release version.
 - [ ] `uv lock --check` passes.
 - [ ] Release lock synchronization introduced no unrelated dependency, hash,
-      source, or resolution-marker changes.
+      source, resolution-marker, or other lock metadata changes.
 - [ ] Changelog is complete.
 - [ ] If a release PR was used, its checks are green.
 - [ ] If a release PR was used, it was squash merged.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,15 +39,27 @@ pins or `uv.lock`, and cannot replace the required locked validation lane.
 ## 1. Prepare a release pull request (recommended)
 
 For normal stable releases, a release-only pull request is recommended. It
-should normally modify only:
+should normally modify exactly:
 
+- `CHANGELOG.md`
 - `custom_components/pollenlevels/manifest.json`
 - `pyproject.toml`
-- `CHANGELOG.md`
+- `uv.lock`
 
-The manifest and project versions must match exactly. The release tag is
-derived automatically: version `3.0.1` maps to tag `v3.0.1`, and version
-`3.0.1rc1` maps to tag `v3.0.1rc1`.
+The manifest and project versions must match exactly, and the local
+`pollenlevels` package version recorded in `uv.lock` must match that same release
+version. Synchronize the lockfile with the repository-pinned uv version and the
+existing lock policy; do not use `uv lock --upgrade` as part of release
+preparation.
+
+For a release-only version synchronization, the expected `uv.lock` diff is only
+the local `pollenlevels` project version. Any unrelated dependency version,
+hash, source, resolution marker, or other lock metadata change is unexpected and
+must be investigated before merge. `uv lock --check` must pass before the
+release pull request is considered ready.
+
+The release tag is derived automatically: version `3.0.1` maps to tag `v3.0.1`,
+and version `3.0.1rc1` maps to tag `v3.0.1rc1`.
 
 Include backup, no-downgrade, migration, and prerelease notes where applicable.
 
@@ -156,7 +168,11 @@ after publication do not necessarily require a new release.
 ## Release checklist
 
 - [ ] Selected ref and resolved SHA were reviewed.
-- [ ] Manifest and project version files match.
+- [ ] Manifest version matches project version.
+- [ ] `uv.lock` local `pollenlevels` package version matches the release version.
+- [ ] `uv lock --check` passes.
+- [ ] Release lock synchronization introduced no unrelated dependency, hash,
+      source, or resolution-marker changes.
 - [ ] Changelog is complete.
 - [ ] If a release PR was used, its checks are green.
 - [ ] If a release PR was used, it was squash merged.


### PR DESCRIPTION
Closes #281

## Summary

- document the four-file scope of a normal release-only PR;
- require the local `pollenlevels` version in `uv.lock` to match the release version;
- document repository-pinned uv lock synchronization without `uv lock --upgrade`;
- treat unrelated dependency, hash, source, marker, or lock metadata changes as unexpected;
- extend the release checklist with lock synchronization and `uv lock --check` verification.

## Scope

Documentation-only. Only `RELEASING.md` is changed.

No release workflow, versioning policy, tag derivation, draft-first behavior, historical snapshot support, dependency version, Renovate policy, package content, or `uv.lock` changes are included.

## Validation

- branch is two commits ahead of `main` and zero commits behind;
- compare shows only `RELEASING.md` changed;
- existing draft-first and emergency published-fallback procedures are preserved;
- release-only lock guidance explicitly avoids dependency upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to include lockfile synchronization and version validation.
  * Added checks to ensure release metadata remains consistent and free of unrelated changes.
  * Clarified validation requirements and separated release tag instructions for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->