### PR TITLE
fix: normalize pollen index values defensively

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -21,6 +21,7 @@ from .const import (
 from .forecast import attach_forecast_attributes
 from .util import (
     normalize_language_code,
+    normalize_pollen_index_value,
     redact_sensitive_values,
     safe_parse_int,
 )
@@ -116,7 +117,7 @@ def _build_forecast_entry(
         "offset": offset,
         "date": date,
         "has_index": has_index,
-        "value": idx.get("value") if has_index else None,
+        "value": normalize_pollen_index_value(idx.get("value")) if has_index else None,
         "category": idx.get("category") if has_index else None,
         "description": idx.get("indexDescription") if has_index else None,
         "color_hex": _rgb_to_hex_triplet(rgb) if has_index else None,
@@ -337,7 +338,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             key = f"type_{tcode.lower()}"
             new_data[key] = {
                 "source": "type",
-                "value": idx.get("value"),
+                "value": normalize_pollen_index_value(idx.get("value")),
                 "category": idx.get("category"),
                 "displayName": titem.get("displayName", tcode),
                 "inSeason": titem.get("inSeason"),
@@ -365,7 +366,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             key = f"plants_{code.lower()}"
             new_data[key] = {
                 "source": "plant",
-                "value": idx.get("value"),
+                "value": normalize_pollen_index_value(idx.get("value")),
                 "category": idx.get("category"),
                 "displayName": pitem.get("displayName", code),
                 "code": code,

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -393,6 +393,8 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                 and existing.get("value") is None
                 and existing.get("category") is None
                 and existing.get("description") is None
+                and existing.get("color_hex") is None
+                and existing.get("color_rgb") is None
             )
             base = existing or {}
             if needs_skeleton:

--- a/custom_components/pollenlevels/forecast.py
+++ b/custom_components/pollenlevels/forecast.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .util import normalize_pollen_index_value
+
 
 def attach_forecast_attributes(
     base: dict[str, Any],
@@ -33,7 +35,11 @@ def attach_forecast_attributes(
     def _set_convenience(prefix: str, off: int) -> None:
         f = forecast_by_offset.get(off)
         base[f"{prefix}_has_index"] = f.get("has_index") if f else False
-        base[f"{prefix}_value"] = f.get("value") if f and f.get("has_index") else None
+        base[f"{prefix}_value"] = (
+            normalize_pollen_index_value(f.get("value"))
+            if f and f.get("has_index")
+            else None
+        )
         base[f"{prefix}_category"] = (
             f.get("category") if f and f.get("has_index") else None
         )
@@ -48,9 +54,10 @@ def attach_forecast_attributes(
     _set_convenience("d2", 2)
 
     # Trend (today vs tomorrow)
-    now_val = current_value if current_value is not None else base.get("value")
+    selected_current = current_value if current_value is not None else base.get("value")
+    now_val = normalize_pollen_index_value(selected_current)
     tomorrow_val = base.get("tomorrow_value")
-    if isinstance(now_val, (int, float)) and isinstance(tomorrow_val, (int, float)):
+    if now_val is not None and tomorrow_val is not None:
         if tomorrow_val > now_val:
             base["trend"] = "up"
         elif tomorrow_val < now_val:
@@ -62,15 +69,19 @@ def attach_forecast_attributes(
 
     # Expected peak (excluding today)
     peak = None
+    peak_value = None
     for f in forecast_list:
-        if f.get("has_index") and isinstance(f.get("value"), (int, float)):
-            if peak is None or f["value"] > peak["value"]:
-                peak = f
+        value = (
+            normalize_pollen_index_value(f.get("value")) if f.get("has_index") else None
+        )
+        if value is not None and (peak_value is None or value > peak_value):
+            peak = f
+            peak_value = value
     base["expected_peak"] = (
         {
             "offset": peak["offset"],
             "date": peak["date"],
-            "value": peak["value"],
+            "value": peak_value,
             "category": peak["category"],
         }
         if peak

--- a/custom_components/pollenlevels/summary.py
+++ b/custom_components/pollenlevels/summary.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import math
 from typing import Any, NamedTuple
 
 from .forecast import attach_forecast_attributes
+from .util import normalize_pollen_index_value
 
 
 class SummaryEntry(NamedTuple):
@@ -15,15 +15,6 @@ class SummaryEntry(NamedTuple):
     name: str
     key: str
     info: dict[str, Any]
-
-
-def is_finite_number(value: Any) -> bool:
-    """Return whether value is a finite non-boolean number."""
-    return (
-        isinstance(value, int | float)
-        and not isinstance(value, bool)
-        and math.isfinite(value)
-    )
 
 
 def normalize_entry_code(key: str, info: dict[str, Any], prefix: str) -> str:
@@ -59,7 +50,7 @@ def current_day_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
             continue
         if not isinstance(info, dict) or info.get("source") != "type":
             continue
-        if not is_finite_number(info.get("value")):
+        if normalize_pollen_index_value(info.get("value")) is None:
             continue
         code = normalize_entry_code(key, info, "type_")
         name = info.get("displayName") or code
@@ -87,7 +78,7 @@ def forecast_type_entries(data_map: dict[str, Any]) -> list[SummaryEntry]:
 
 def top_type_entries(
     data_map: dict[str, Any],
-) -> tuple[float | int | None, list[SummaryEntry]]:
+) -> tuple[int | None, list[SummaryEntry]]:
     """Return the maximum current-day type value and all entries tied for it."""
     entries = current_day_type_entries(data_map)
     if not entries:
@@ -134,7 +125,8 @@ def _overall_forecast_from_type_forecasts(
         valid = [
             (entry, f)
             for entry, f in pairs
-            if f.get("has_index") is True and is_finite_number(f.get("value"))
+            if f.get("has_index") is True
+            and normalize_pollen_index_value(f.get("value")) is not None
         ]
 
         if not valid:

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -377,6 +377,14 @@ def validate_location_pair(latitude: Any, longitude: Any) -> tuple[float, float]
     return parsed_latitude, parsed_longitude
 
 
+def normalize_pollen_index_value(value: Any) -> int | None:
+    """Return a valid Google pollen index value or None."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+
+    return value if 0 <= value <= 5 else None
+
+
 def safe_parse_int(value: Any) -> int | None:
     """Parse an integer-like value, rejecting non-finite and decimal numbers."""
     if value is None or isinstance(value, bool):
@@ -407,6 +415,7 @@ __all__ = [
     "has_legacy_per_day_option",
     "LEGACY_FORECAST_OPTION_KEYS",
     "normalize_language_code",
+    "normalize_pollen_index_value",
     "normalize_subentry_ids",
     "parse_finite_float",
     "redact_api_key",

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -3,31 +3,76 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import Any
 
-FORECAST_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "custom_components"
-    / "pollenlevels"
-    / "forecast.py"
+PKG_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pollenlevels"
+FORECAST_PATH = PKG_PATH / "forecast.py"
+
+_PKG_NAME = "custom_components.pollenlevels"
+_STUB_MODULE_NAMES = (
+    "custom_components",
+    _PKG_NAME,
+    f"{_PKG_NAME}.const",
+    f"{_PKG_NAME}.util",
+    f"{_PKG_NAME}.forecast",
 )
 
 
 def _load_forecast_module() -> ModuleType:
-    """Load forecast.py directly (pure module, no HA imports)."""
-    spec = importlib.util.spec_from_file_location(
-        "pollenlevels_forecast", FORECAST_PATH
-    )
-    assert spec is not None
-    assert spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    """Load forecast.py with package context and without Home Assistant."""
+    previous_modules = {
+        name: sys.modules[name] for name in _STUB_MODULE_NAMES if name in sys.modules
+    }
+    try:
+        parent_name = "custom_components"
+        if parent_name not in sys.modules:
+            parent = ModuleType(parent_name)
+            parent.__path__ = [str(PKG_PATH.parent)]
+            parent.__package__ = parent_name
+            sys.modules[parent_name] = parent
+
+        if _PKG_NAME not in sys.modules:
+            pkg = ModuleType(_PKG_NAME)
+            pkg.__path__ = [str(PKG_PATH)]
+            pkg.__package__ = _PKG_NAME
+            sys.modules[_PKG_NAME] = pkg
+
+        spec = importlib.util.spec_from_file_location(
+            f"{_PKG_NAME}.forecast", FORECAST_PATH
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"{_PKG_NAME}.forecast"] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name in _STUB_MODULE_NAMES:
+            if name in previous_modules:
+                sys.modules[name] = previous_modules[name]
+            else:
+                sys.modules.pop(name, None)
 
 
 attach_forecast_attributes = _load_forecast_module().attach_forecast_attributes
+
+
+def test_forecast_module_loader_restores_sys_modules() -> None:
+    """The standalone loader should not leak its package dependencies."""
+    previous_modules = {
+        name: sys.modules[name] for name in _STUB_MODULE_NAMES if name in sys.modules
+    }
+
+    _load_forecast_module()
+
+    for name in _STUB_MODULE_NAMES:
+        if name in previous_modules:
+            assert sys.modules[name] is previous_modules[name]
+        else:
+            assert name not in sys.modules
 
 
 def test_attach_empty_forecast() -> None:
@@ -99,7 +144,7 @@ def test_attach_two_offsets() -> None:
             "offset": 2,
             "date": "2026-06-11",
             "has_index": True,
-            "value": 6,
+            "value": 5,
             "category": "Very High",
             "description": "Very High",
             "color_hex": "#FF0000",
@@ -110,13 +155,13 @@ def test_attach_two_offsets() -> None:
     result = attach_forecast_attributes(base, forecast)
 
     assert result["tomorrow_value"] == 4
-    assert result["d2_value"] == 6
+    assert result["d2_value"] == 5
     assert result["d2_has_index"] is True
     assert result["d2_category"] == "Very High"
     assert result["expected_peak"] == {
         "offset": 2,
         "date": "2026-06-11",
-        "value": 6,
+        "value": 5,
         "category": "Very High",
     }
 
@@ -198,7 +243,7 @@ def test_expected_peak_picks_highest() -> None:
             "offset": 2,
             "date": "2026-06-11",
             "has_index": True,
-            "value": 7,
+            "value": 5,
             "category": "Very High",
             "description": "Very High",
             "color_hex": None,
@@ -209,7 +254,113 @@ def test_expected_peak_picks_highest() -> None:
     result = attach_forecast_attributes(base, forecast)
 
     assert result["expected_peak"]["offset"] == 2
-    assert result["expected_peak"]["value"] == 7
+    assert result["expected_peak"]["value"] == 5
+
+
+def test_zero_is_valid_for_convenience_trend_and_expected_peak() -> None:
+    """A zero index remains a real value in every forecast calculation."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 0,
+            "category": "None",
+            "description": "No pollen",
+            "color_hex": "#00FF00",
+            "color_rgb": [0, 255, 0],
+        }
+    ]
+
+    result = attach_forecast_attributes({"value": 1}, forecast)
+
+    assert result["tomorrow_value"] == 0
+    assert result["trend"] == "down"
+    assert result["expected_peak"] == {
+        "offset": 1,
+        "date": "2026-06-10",
+        "value": 0,
+        "category": "None",
+    }
+
+
+def test_malformed_forecast_values_do_not_affect_derived_attributes() -> None:
+    """Malformed future values preserve metadata but not numeric derivatives."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": float("nan"),
+            "category": "Tomorrow category",
+            "description": "Tomorrow description",
+            "color_hex": "#112233",
+            "color_rgb": [17, 34, 51],
+        },
+        {
+            "offset": 2,
+            "date": "2026-06-11",
+            "has_index": True,
+            "value": "3",
+            "category": "D2 category",
+            "description": "D2 description",
+            "color_hex": "#445566",
+            "color_rgb": [68, 85, 102],
+        },
+        {
+            "offset": 3,
+            "date": "2026-06-12",
+            "has_index": True,
+            "value": 4,
+            "category": "Valid category",
+            "description": "Valid description",
+            "color_hex": "#778899",
+            "color_rgb": [119, 136, 153],
+        },
+    ]
+
+    result = attach_forecast_attributes({"value": 2}, forecast)
+
+    assert result["forecast"] is forecast
+    assert result["tomorrow_has_index"] is True
+    assert result["tomorrow_value"] is None
+    assert result["tomorrow_category"] == "Tomorrow category"
+    assert result["tomorrow_description"] == "Tomorrow description"
+    assert result["tomorrow_color_hex"] == "#112233"
+    assert result["d2_has_index"] is True
+    assert result["d2_value"] is None
+    assert result["d2_category"] == "D2 category"
+    assert result["d2_description"] == "D2 description"
+    assert result["d2_color_hex"] == "#445566"
+    assert result["trend"] is None
+    assert result["expected_peak"] == {
+        "offset": 3,
+        "date": "2026-06-12",
+        "value": 4,
+        "category": "Valid category",
+    }
+
+
+def test_invalid_current_value_override_does_not_fall_back_to_base() -> None:
+    """An explicit malformed current value disables trend calculation."""
+    forecast = [
+        {
+            "offset": 1,
+            "date": "2026-06-10",
+            "has_index": True,
+            "value": 2,
+            "category": "Low",
+            "description": "Low",
+            "color_hex": None,
+            "color_rgb": None,
+        }
+    ]
+
+    result = attach_forecast_attributes({"value": 1}, forecast, current_value=6)
+
+    assert result["tomorrow_value"] == 2
+    assert result["trend"] is None
+    assert result["expected_peak"]["value"] == 2
 
 
 def test_attach_current_value_overrides_base_value() -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2148,6 +2148,14 @@ def test_coordinator_normalizes_mixed_pollen_index_values(
                             "color": {"red": 255, "green": 0, "blue": 0},
                         },
                     },
+                    {
+                        "code": "MOLD",
+                        "displayName": "Mold",
+                        "indexInfo": {
+                            "value": 6,
+                            "color": {"red": 1},
+                        },
+                    },
                 ],
                 "plantInfo": [
                     {
@@ -2227,6 +2235,7 @@ def test_coordinator_normalizes_mixed_pollen_index_values(
         "region",
         "date",
         "type_grass",
+        "type_mold",
         "type_tree",
         "plants_hazel",
         "plants_oak",
@@ -2251,6 +2260,14 @@ def test_coordinator_normalizes_mixed_pollen_index_values(
     assert type_entry["tomorrow_value"] is None
     assert type_entry["trend"] is None
     assert type_entry["expected_peak"] is None
+
+    color_only_type_entry = data["type_mold"]
+    assert color_only_type_entry["value"] is None
+    assert color_only_type_entry["category"] is None
+    assert color_only_type_entry["description"] is None
+    assert color_only_type_entry["color_hex"] == "#FF0000"
+    assert color_only_type_entry["color_rgb"] == [255, 0, 0]
+    assert color_only_type_entry["forecast"][0]["offset"] == 1
 
     plant_entry = data["plants_hazel"]
     assert plant_entry["value"] is None

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -887,7 +887,7 @@ def test_type_summary_sensors_ignore_per_day_d1_d2_values(
             "type_grass_d2": {
                 "source": "type",
                 "displayName": "Grass D+2",
-                "value": 6,
+                "value": 4,
             },
         }
     )
@@ -1882,7 +1882,7 @@ def test_coordinator_requests_five_days_and_exposes_four_future_offsets(
                         "code": "ragweed",
                         "displayName": "Ragweed",
                         "indexInfo": {
-                            "value": day + 10,
+                            "value": (day + 1) % 6,
                             "category": f"PLANT-{day}",
                             "indexDescription": f"Plant day {day}",
                         },
@@ -1924,7 +1924,7 @@ def test_coordinator_requests_five_days_and_exposes_four_future_offsets(
         4,
     ]
     assert data["type_grass"]["forecast"][3]["value"] == 5
-    assert data["plants_ragweed"]["forecast"][3]["value"] == 15
+    assert data["plants_ragweed"]["forecast"][3]["value"] == 0
     assert "type_grass_d1" not in data
     assert "type_grass_d2" not in data
 
@@ -2116,6 +2116,164 @@ def test_forecast_extraction_preserves_missing_index_and_date_behavior(
     }
     assert plant_entry["forecast"][1]["date"] is None
     assert plant_entry["forecast"][1]["color_hex"] == "#00FF00"
+
+
+def test_coordinator_normalizes_mixed_pollen_index_values(
+    sensor_modules: SensorModules,
+) -> None:
+    """Malformed indexes become None without discarding usable payload data."""
+    payload = {
+        "regionCode": "us_test_region",
+        "dailyInfo": [
+            {
+                "date": {"year": 2026, "month": 8, "day": 9},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {
+                            "value": 0,
+                            "category": "NONE",
+                            "indexDescription": "No grass pollen",
+                            "color": {"red": 0, "green": 255, "blue": 0},
+                        },
+                    },
+                    {
+                        "code": "TREE",
+                        "displayName": "Tree",
+                        "indexInfo": {
+                            "value": 6,
+                            "category": "INVALID TYPE",
+                            "indexDescription": "Type metadata survives",
+                            "color": {"red": 255, "green": 0, "blue": 0},
+                        },
+                    },
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {
+                            "value": 5,
+                            "category": "VERY HIGH",
+                            "indexDescription": "Valid oak value",
+                            "color": {"red": 255, "green": 0, "blue": 0},
+                        },
+                        "plantDescription": {"type": "TREE", "family": "Fagaceae"},
+                    },
+                    {
+                        "code": "hazel",
+                        "displayName": "Hazel",
+                        "indexInfo": {
+                            "value": "3",
+                            "category": "INVALID PLANT",
+                            "indexDescription": "Plant metadata survives",
+                            "color": {"red": 0, "green": 255, "blue": 0},
+                        },
+                        "plantDescription": {
+                            "type": "TREE",
+                            "family": "Betulaceae",
+                            "season": "Winter",
+                        },
+                    },
+                ],
+            },
+            {
+                "date": {"year": 2026, "month": 8, "day": 10},
+                "pollenTypeInfo": [
+                    {
+                        "code": "GRASS",
+                        "displayName": "Grass",
+                        "indexInfo": {"value": 4, "category": "HIGH"},
+                    },
+                    {
+                        "code": "TREE",
+                        "displayName": "Tree",
+                        "indexInfo": {
+                            "value": 2.0,
+                            "category": "INVALID FORECAST TYPE",
+                            "indexDescription": "Forecast metadata survives",
+                            "color": {"red": 255, "green": 0, "blue": 0},
+                        },
+                    },
+                ],
+                "plantInfo": [
+                    {
+                        "code": "oak",
+                        "displayName": "Oak",
+                        "indexInfo": {"value": True, "category": "INVALID OAK"},
+                    },
+                    {
+                        "code": "hazel",
+                        "displayName": "Hazel",
+                        "indexInfo": {"value": 1, "category": "VERY LOW"},
+                    },
+                ],
+            },
+        ],
+    }
+
+    client = sensor_modules.client_mod.GooglePollenApiClient(
+        FakeSession(payload), "test"
+    )
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert set(data) == {
+        "region",
+        "date",
+        "type_grass",
+        "type_tree",
+        "plants_hazel",
+        "plants_oak",
+    }
+
+    assert data["type_grass"]["value"] == 0
+    assert data["type_grass"]["forecast"][0]["value"] == 4
+    assert data["plants_oak"]["value"] == 5
+
+    type_entry = data["type_tree"]
+    assert type_entry["value"] is None
+    assert type_entry["category"] == "INVALID TYPE"
+    assert type_entry["description"] == "Type metadata survives"
+    assert type_entry["color_hex"] == "#FF0000"
+    assert type_entry["forecast"][0]["offset"] == 1
+    assert type_entry["forecast"][0]["has_index"] is True
+    assert type_entry["forecast"][0]["value"] is None
+    assert type_entry["forecast"][0]["category"] == "INVALID FORECAST TYPE"
+    assert type_entry["forecast"][0]["description"] == "Forecast metadata survives"
+    assert type_entry["forecast"][0]["color_hex"] == "#FF0000"
+    assert type_entry["tomorrow_has_index"] is True
+    assert type_entry["tomorrow_value"] is None
+    assert type_entry["trend"] is None
+    assert type_entry["expected_peak"] is None
+
+    plant_entry = data["plants_hazel"]
+    assert plant_entry["value"] is None
+    assert plant_entry["category"] == "INVALID PLANT"
+    assert plant_entry["description"] == "Plant metadata survives"
+    assert plant_entry["color_hex"] == "#00FF00"
+    assert plant_entry["type"] == "TREE"
+    assert plant_entry["family"] == "Betulaceae"
+    assert plant_entry["season"] == "Winter"
+    assert plant_entry["forecast"][0]["offset"] == 1
+    assert plant_entry["forecast"][0]["value"] == 1
+
+    assert data["plants_oak"]["forecast"][0]["has_index"] is True
+    assert data["plants_oak"]["forecast"][0]["value"] is None
+
+    assert (
+        sensor_modules.sensor.PollenSensor(coordinator, "type_tree").native_value
+        is None
+    )
+    assert (
+        sensor_modules.sensor.PollenSensor(coordinator, "plants_hazel").native_value
+        is None
+    )
 
 
 def test_plant_forecast_matches_codes_case_insensitively(

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -16,6 +16,8 @@ _PKG_NAME = "custom_components.pollenlevels"
 _STUB_MODULE_NAMES = (
     "custom_components",
     _PKG_NAME,
+    f"{_PKG_NAME}.const",
+    f"{_PKG_NAME}.util",
     f"{_PKG_NAME}.forecast",
     f"{_PKG_NAME}.summary",
 )
@@ -78,7 +80,6 @@ _module = _load_summary_module()
 daily_summary = _module.daily_summary
 current_day_type_entries = _module.current_day_type_entries
 forecast_type_entries = _module.forecast_type_entries
-is_finite_number = _module.is_finite_number
 
 
 # ── existing tests (unchanged) ─────────────────────────────────────────────
@@ -141,13 +142,13 @@ def test_daily_summary_preserves_ties_and_ignores_future_and_nonfinite_values() 
             "type_grass_d1": {
                 "source": "type",
                 "displayName": "Grass tomorrow",
-                "value": 6,
+                "value": 5,
                 "category": "Very High",
             },
             "type_weed_d2": {
                 "source": "type",
                 "displayName": "Weed D+2",
-                "value": 7,
+                "value": 3,
                 "category": "Very High",
             },
         }
@@ -319,7 +320,7 @@ def test_overall_forecast_three_days() -> None:
                         "offset": 2,
                         "date": "2026-06-11",
                         "has_index": True,
-                        "value": 7,
+                        "value": 5,
                         "category": "Very High",
                         "description": "Very High",
                         "color_hex": "#FF0000",
@@ -336,10 +337,102 @@ def test_overall_forecast_three_days() -> None:
     assert overall["forecast"][0]["offset"] == 1
     assert overall["forecast"][1]["offset"] == 2
     assert overall["tomorrow_value"] == 3
-    assert overall["d2_value"] == 7
+    assert overall["d2_value"] == 5
     assert overall["d2_has_index"] is True
     assert overall["expected_peak"]["offset"] == 2
-    assert overall["expected_peak"]["value"] == 7
+    assert overall["expected_peak"]["value"] == 5
+
+
+def test_summary_ignores_malformed_current_and_forecast_values() -> None:
+    """Only valid indexes contribute to current and forecast summaries."""
+    summary = daily_summary(
+        {
+            "type_tree": {
+                "source": "type",
+                "code": "TREE",
+                "displayName": "Tree",
+                "value": 0,
+                "category": "None",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 0,
+                        "category": "None",
+                        "description": "No pollen",
+                        "color_hex": "#00FF00",
+                        "color_rgb": [0, 255, 0],
+                    },
+                    {
+                        "offset": 2,
+                        "date": "2026-06-11",
+                        "has_index": True,
+                        "value": 4,
+                        "category": "High",
+                        "description": "High",
+                        "color_hex": "#FF0000",
+                        "color_rgb": [255, 0, 0],
+                    },
+                ],
+            },
+            "type_grass": {
+                "source": "type",
+                "code": "GRASS",
+                "displayName": "Grass",
+                "value": 6,
+                "category": "Invalid current",
+                "forecast": [
+                    {
+                        "offset": 1,
+                        "date": "2026-06-10",
+                        "has_index": True,
+                        "value": 6,
+                        "category": "Invalid forecast",
+                        "description": "Invalid forecast",
+                        "color_hex": "#FFFFFF",
+                        "color_rgb": [255, 255, 255],
+                    },
+                    {
+                        "offset": 2,
+                        "date": "2026-06-11",
+                        "has_index": True,
+                        "value": float("nan"),
+                        "category": "Invalid forecast",
+                        "description": "Invalid forecast",
+                        "color_hex": "#FFFFFF",
+                        "color_rgb": [255, 255, 255],
+                    },
+                ],
+            },
+        }
+    )
+
+    overall = summary["overall_pollen_risk_today"]
+    assert overall["state"] == 0
+    assert overall["category"] == "None"
+    assert overall["top_pollen_codes"] == ["TREE"]
+    assert overall["top_pollen_names"] == ["Tree"]
+    assert overall["tie_count"] == 1
+    assert [item["offset"] for item in overall["forecast"]] == [1, 2]
+    assert overall["forecast"][0]["value"] == 0
+    assert overall["forecast"][0]["top_pollen_codes"] == ["TREE"]
+    assert overall["forecast"][0]["tie_count"] == 1
+    assert overall["forecast"][1]["value"] == 4
+    assert overall["tomorrow_value"] == 0
+    assert overall["trend"] == "flat"
+    assert overall["expected_peak"] == {
+        "offset": 2,
+        "date": "2026-06-11",
+        "value": 4,
+        "category": "High",
+    }
+
+    top = summary["top_pollen_types_today"]
+    assert top["state"] == "Tree"
+    assert top["top_value"] == 0
+    assert top["top_pollen_codes"] == ["TREE"]
+    assert top["tie_count"] == 1
 
 
 def test_overall_forecast_five_day_offsets() -> None:
@@ -505,14 +598,14 @@ def test_overall_forecast_ignores_per_day_d1_d2_keys() -> None:
             "type_grass_d1": {
                 "source": "type",
                 "displayName": "Grass D+1",
-                "value": 9,
+                "value": 5,
                 "category": "Extreme",
                 "forecast": [
                     {
                         "offset": 1,
                         "date": "2026-06-10",
                         "has_index": True,
-                        "value": 9,
+                        "value": 5,
                         "category": "Extreme",
                         "description": "Extreme",
                         "color_hex": "#FF0000",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -329,6 +329,46 @@ def test_safe_parse_int(util_module, value, expected):
     assert util_module.safe_parse_int(value) == expected
 
 
+@pytest.mark.parametrize("value", range(6))
+def test_normalize_pollen_index_value_accepts_valid_integers(
+    util_module, value
+) -> None:
+    """Valid Google pollen index integers are returned unchanged."""
+
+    result = util_module.normalize_pollen_index_value(value)
+
+    assert result is value
+    assert type(result) is int
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        True,
+        False,
+        -1,
+        6,
+        2.0,
+        2.5,
+        "3",
+        "5",
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        None,
+        [],
+        {},
+        object(),
+    ],
+)
+def test_normalize_pollen_index_value_rejects_contract_violations(
+    util_module, value
+) -> None:
+    """Non-integer and out-of-range pollen index values normalize to None."""
+
+    assert util_module.normalize_pollen_index_value(value) is None
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [


### PR DESCRIPTION
## Summary

- add strict validation for Google pollen index values
- normalize malformed current and forecast values to `None`
- prevent malformed values from affecting summaries, trend, and expected peak
- preserve partial index metadata and existing `has_index` semantics
- add focused regression coverage for valid and malformed values

Closes #214

## Validation

- `uv lock --check` — passed with required uv 0.12.2
- `ruff check .` — passed
- `ruff format --check .` — passed (57 files already formatted)
- focused tests — 264 passed
- full test suite — 615 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and normalization of pollen index values across current conditions and forecasts.
  - Invalid, malformed, or out-of-range values are excluded from trends, summaries, convenience fields, and expected-peak calculations.
  - Zero-valued pollen indexes are now handled correctly.
  - Forecast type detection remains reliable when color information is missing.

- **Tests**
  - Added coverage for valid, invalid, missing, and mixed pollen index values.
  - Updated forecast and summary scenarios to reflect normalized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->