### PR TITLE
refactor(ha): declare platform parallel update limits

### DIFF
--- a/custom_components/pollenlevels/button.py
+++ b/custom_components/pollenlevels/button.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from .coordinator import PollenDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -58,6 +58,7 @@ from .util import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 0
 
 _FORECAST_ATTRIBUTE_NAMES = (
     "forecast",

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 import types
@@ -198,6 +199,18 @@ async def test_button_press_raises_homeassistant_error_on_refresh_failure(
 
     assert err.value.translation_domain == "pollenlevels"
     assert err.value.translation_key == "refresh_failed"
+
+
+@pytest.mark.asyncio
+async def test_button_press_propagates_cancelled_error(
+    button_platform: SimpleNamespace,
+) -> None:
+    coordinator = _FakeCoordinator()
+    coordinator.async_request_refresh.side_effect = asyncio.CancelledError
+    entity = button_platform.module.PollenLevelsUpdateButton(coordinator)
+
+    with pytest.raises(asyncio.CancelledError):
+        await entity.async_press()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -10,6 +11,10 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
+from custom_components.pollenlevels import (
+    button as button_platform,
+    sensor as sensor_platform,
+)
 from custom_components.pollenlevels.const import (
     DOMAIN,
 )
@@ -21,6 +26,12 @@ from tests.ha_helpers import (
     async_setup_config_entry,
     mock_pollen_api,
 )
+
+
+def test_platform_parallel_update_limits() -> None:
+    """Entity platforms should declare their intended concurrency limits."""
+    assert sensor_platform.PARALLEL_UPDATES == 0
+    assert button_platform.PARALLEL_UPDATES == 1
 
 
 async def test_ha_platforms_create_entities_for_each_location_subentry(
@@ -61,36 +72,41 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
         )
 
 
-async def test_ha_button_press_refreshes_location_coordinator(
+async def test_ha_button_press_refreshes_only_location_coordinator(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
-    ha_config_entry,
+    ha_two_location_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
     monkeypatch,
 ) -> None:
-    """button.press should refresh the coordinator for its location subentry."""
+    """button.press should refresh only the selected location coordinator."""
     clear_integration_modules()
-    ha_config_entry.add_to_hass(hass)
+    entry = ha_two_location_config_entry
+    entry.add_to_hass(hass)
 
     async with aiointercept(mock_external_urls=True) as mocked:
         mock_pollen_api(mocked, google_pollen_5_day_payload)
-        await async_setup_config_entry(hass, ha_config_entry)
+        await async_setup_config_entry(hass, entry)
 
         registry = er.async_get(hass)
         button_entry = next(
             entity
-            for entity in er.async_entries_for_config_entry(
-                registry, ha_config_entry.entry_id
-            )
+            for entity in er.async_entries_for_config_entry(registry, entry.entry_id)
             if entity.domain == "button"
             and entity.config_subentry_id == "location-madrid"
         )
-        refresh = AsyncMock()
+        madrid_refresh = AsyncMock()
+        barcelona_refresh = AsyncMock()
         monkeypatch.setattr(
-            ha_config_entry.runtime_data.locations["location-madrid"].coordinator,
+            entry.runtime_data.locations["location-madrid"].coordinator,
             "async_request_refresh",
-            refresh,
+            madrid_refresh,
+        )
+        monkeypatch.setattr(
+            entry.runtime_data.locations["location-barcelona"].coordinator,
+            "async_request_refresh",
+            barcelona_refresh,
         )
 
         await hass.services.async_call(
@@ -101,7 +117,71 @@ async def test_ha_button_press_refreshes_location_coordinator(
         )
         await hass.async_block_till_done()
 
-    refresh.assert_awaited_once()
+    madrid_refresh.assert_awaited_once()
+    barcelona_refresh.assert_not_awaited()
+
+
+async def test_ha_same_parent_button_presses_are_serialized(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_two_location_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """Update buttons under one parent should not refresh concurrently."""
+    clear_integration_modules()
+    entry = ha_two_location_config_entry
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+        registry = er.async_get(hass)
+        button_entries = {
+            entity.config_subentry_id: entity
+            for entity in er.async_entries_for_config_entry(registry, entry.entry_id)
+            if entity.domain == "button" and entity.config_subentry_id is not None
+        }
+
+        active = 0
+        max_active = 0
+        calls = {"location-madrid": 0, "location-barcelona": 0}
+
+        def _tracked_refresh(subentry_id: str):
+            async def _refresh() -> None:
+                nonlocal active, max_active
+                calls[subentry_id] += 1
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0)
+                active -= 1
+
+            return _refresh
+
+        for subentry_id in calls:
+            monkeypatch.setattr(
+                entry.runtime_data.locations[subentry_id].coordinator,
+                "async_request_refresh",
+                _tracked_refresh(subentry_id),
+            )
+
+        await asyncio.gather(
+            *(
+                hass.services.async_call(
+                    "button",
+                    "press",
+                    {ATTR_ENTITY_ID: button_entries[subentry_id].entity_id},
+                    blocking=True,
+                )
+                for subentry_id in calls
+            )
+        )
+        await hass.async_block_till_done()
+
+    assert calls == {"location-madrid": 1, "location-barcelona": 1}
+    assert max_active == 1
 
 
 async def test_ha_platforms_clean_legacy_per_day_entities_and_create_repair(


### PR DESCRIPTION
## Summary

Explicitly declare Home Assistant entity-platform concurrency limits for Pollen Levels instead of relying on implicit defaults.

- `sensor.py`: `PARALLEL_UPDATES = 0` for the read-only `DataUpdateCoordinator` platform.
- `button.py`: `PARALLEL_UPDATES = 1` so concurrent `Update now` actions for locations under the same parent/API key are serialized by Home Assistant.

Home Assistant creates a separate `EntityPlatform` per config entry, so different parent entries/API keys keep independent button semaphores.

Closes #284.

## Why

Home Assistant's current Integration Quality Scale recommends declaring parallel-update behavior explicitly. Pollen Levels already centralizes sensor data through per-location coordinators, while the manual update button performs an outbound refresh action and benefits from a single-action platform limit.

This mechanism is supported across the integration's current Home Assistant compatibility range and does not require a minimum-version bump or compatibility fallback.

## `pollenlevels.force_update`

The global `pollenlevels.force_update` service is intentionally unchanged.

It is registered directly by the integration rather than through an entity platform and already owns explicit concurrency control through `_FORCE_UPDATE_CONCURRENCY_LIMIT = 1` and `_refresh_force_update_targets()`.

This PR does **not** change:

- `_FORCE_UPDATE_CONCURRENCY_LIMIT`;
- global service semantics;
- shared client/API-key concurrency tracked in #215;
- retry or `Retry-After` behavior.

## Tests

Coverage added/strengthened for:

- the selected platform constants (`sensor = 0`, `button = 1`);
- a `button.press` refresh affecting only the selected location coordinator;
- concurrent same-parent `button.press` calls remaining serialized through the public Home Assistant service path;
- `asyncio.CancelledError` propagation from the per-location update button.

Existing coverage continues to protect:

- entity/subentry association;
- `force_update` sequential behavior;
- stale runtime filtering;
- button failure translation;
- setup/unload/reload and coordinator behavior.

## Scope

No changes to migration, entity IDs, unique IDs, device identifiers, parent/subentry architecture, forecasts, config flow, translations, services, client retries, version metadata, or release documentation.

## Validation

Expected repository validation:

```bash
uv lock --check
uv sync --locked --only-group lint
uv run --locked --no-sync ruff check .
uv run --locked --no-sync ruff format --check .
uv sync --locked --only-group test
PYTHONPATH=. uv run --locked --no-sync python -m pytest -q
uv run --locked --no-sync python -m compileall -q custom_components tests
git diff --check
```

Normal hassfest, HACS validation, workflow-security and CodeQL checks should remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple pollen-level refresh actions occur simultaneously.
  * Refreshes now remain isolated to the selected location.
  * Cancelled refresh operations are handled without being reported as errors.

* **Tests**
  * Added coverage for concurrent actions, location-specific refreshes, and cancellation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->