### PR TITLE
fix(client): release retry responses before backoff

### DIFF
--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -141,6 +141,9 @@ class GooglePollenApiClient:
         max_retries = MAX_RETRIES
         for attempt in range(0, max_retries + 1):
             try:
+                retry_429_delay: float | None = None
+                retry_5xx_status: int | None = None
+
                 async with self._session.get(
                     url,
                     params=params,
@@ -172,44 +175,29 @@ class GooglePollenApiClient:
                             if retry_after_raw:
                                 delay = self._parse_retry_after(retry_after_raw)
                             delay = delay + random.uniform(0.0, 0.4)
-                            delay = max(0.0, min(delay, 5.0))
-                            _LOGGER.warning(
-                                "Pollen API 429 — retrying in %.2fs (attempt %d/%d)",
-                                delay,
-                                attempt + 1,
-                                max_retries,
+                            retry_429_delay = max(0.0, min(delay, 5.0))
+                        else:
+                            _, message = await self._async_redacted_http_message(
+                                resp,
+                                default="",
+                                latitude=latitude,
+                                longitude=longitude,
                             )
-                            await asyncio.sleep(delay)
-                            continue
-                        _, message = await self._async_redacted_http_message(
-                            resp,
-                            default="",
-                            latitude=latitude,
-                            longitude=longitude,
-                        )
-                        raise PollenQuotaExceededError(message)
+                            raise PollenQuotaExceededError(message)
 
-                    if 500 <= resp.status <= 599:
+                    elif 500 <= resp.status <= 599:
                         if attempt < max_retries:
-                            await self._async_backoff(
-                                attempt=attempt,
-                                max_retries=max_retries,
-                                message=(
-                                    "Pollen API HTTP %s — retrying in %.2fs "
-                                    "(attempt %d/%d)"
-                                ),
-                                base_args=(resp.status,),
+                            retry_5xx_status = resp.status
+                        else:
+                            _, message = await self._async_redacted_http_message(
+                                resp,
+                                default="",
+                                latitude=latitude,
+                                longitude=longitude,
                             )
-                            continue
-                        _, message = await self._async_redacted_http_message(
-                            resp,
-                            default="",
-                            latitude=latitude,
-                            longitude=longitude,
-                        )
-                        raise UpdateFailed(message)
+                            raise UpdateFailed(message)
 
-                    if 400 <= resp.status < 500 and resp.status not in (403, 429):
+                    elif 400 <= resp.status < 500 and resp.status not in (403, 429):
                         raw_message, message = await self._async_redacted_http_message(
                             resp,
                             default="",
@@ -219,7 +207,7 @@ class GooglePollenApiClient:
                         _raise_auth_failed_if_invalid_api_key(raw_message, message)
                         raise UpdateFailed(message)
 
-                    if resp.status != 200:
+                    elif resp.status != 200:
                         _, message = await self._async_redacted_http_message(
                             resp,
                             default="",
@@ -228,22 +216,44 @@ class GooglePollenApiClient:
                         )
                         raise UpdateFailed(message)
 
-                    try:
+                    else:
                         try:
-                            payload = await resp.json(content_type=None)
-                        except TypeError:
-                            payload = await resp.json()
-                    except (ContentTypeError, TypeError, ValueError) as err:
-                        raise UpdateFailed(
-                            "Unexpected API response: invalid JSON"
-                        ) from err
+                            try:
+                                payload = await resp.json(content_type=None)
+                            except TypeError:
+                                payload = await resp.json()
+                        except (ContentTypeError, TypeError, ValueError) as err:
+                            raise UpdateFailed(
+                                "Unexpected API response: invalid JSON"
+                            ) from err
 
-                    if not isinstance(payload, dict):
-                        raise UpdateFailed(
-                            "Unexpected API response: expected JSON object"
-                        )
+                        if not isinstance(payload, dict):
+                            raise UpdateFailed(
+                                "Unexpected API response: expected JSON object"
+                            )
 
-                    return payload
+                        return payload
+
+                if retry_429_delay is not None:
+                    _LOGGER.warning(
+                        "Pollen API 429 — retrying in %.2fs (attempt %d/%d)",
+                        retry_429_delay,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    await asyncio.sleep(retry_429_delay)
+                    continue
+
+                if retry_5xx_status is not None:
+                    await self._async_backoff(
+                        attempt=attempt,
+                        max_retries=max_retries,
+                        message=(
+                            "Pollen API HTTP %s — retrying in %.2fs (attempt %d/%d)"
+                        ),
+                        base_args=(retry_5xx_status,),
+                    )
+                    continue
 
             except ConfigEntryAuthFailed:
                 raise

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 from pathlib import Path
@@ -78,6 +79,8 @@ class FakeResponse:
         self.headers: dict[str, str] = {}
         self._json_results = list(json_results or [])
         self._text_body = text_body
+        self.in_context = False
+        self.exit_calls = 0
 
     async def json(self, *args: Any, **kwargs: Any) -> Any:
         """Return or raise the next configured JSON result."""
@@ -98,11 +101,14 @@ class FakeResponse:
     async def __aenter__(self) -> FakeResponse:
         """Support the async context manager protocol."""
 
+        self.in_context = True
         return self
 
     async def __aexit__(self, exc_type, exc: BaseException | None, tb) -> None:
         """Support the async context manager protocol."""
 
+        self.in_context = False
+        self.exit_calls += 1
         return None
 
 
@@ -370,3 +376,77 @@ async def test_client_treats_400_non_auth_error_as_update_failed(
 
     with pytest.raises(client_module.UpdateFailed, match="HTTP 400"):
         await _fetch_with_response(client_module, response)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected_error_name"),
+    [
+        (429, "PollenQuotaExceededError"),
+        (503, "UpdateFailed"),
+    ],
+)
+async def test_client_releases_retry_response_before_backoff(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    expected_error_name: str,
+) -> None:
+    """Retryable HTTP responses should exit their context before backoff."""
+
+    response = FakeResponse(status=status)
+    session = FakeSession(response)
+    client = client_module.GooglePollenApiClient(session, "test")
+    sleep_observations: list[tuple[bool, int, int]] = []
+
+    async def _sleep(_delay: float) -> None:
+        sleep_observations.append(
+            (response.in_context, response.exit_calls, session.calls)
+        )
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    expected_error = getattr(client_module, expected_error_name)
+    with pytest.raises(expected_error):
+        await client.async_fetch_pollen_data(
+            latitude=1.0,
+            longitude=2.0,
+            days=5,
+            language_code=None,
+        )
+
+    assert sleep_observations == [(False, 1, 1)]
+    assert session.calls == 2
+    assert response.exit_calls == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [429, 503])
+async def test_client_retry_backoff_propagates_cancelled_error(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+) -> None:
+    """Cancellation during HTTP retry backoff should propagate unchanged."""
+
+    response = FakeResponse(status=status)
+    session = FakeSession(response)
+    client = client_module.GooglePollenApiClient(session, "test")
+
+    async def _cancel_sleep(_delay: float) -> None:
+        assert response.in_context is False
+        assert response.exit_calls == 1
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await client.async_fetch_pollen_data(
+            latitude=1.0,
+            longitude=2.0,
+            days=5,
+            language_code=None,
+        )
+
+    assert session.calls == 1
+    assert response.exit_calls == 1


### PR DESCRIPTION
## Summary

Ensure retryable HTTP 429 and 5xx responses leave their aiohttp response context before Pollen Levels waits for retry backoff.

Closes #285.

## Why

`async_fetch_pollen_data()` previously awaited the retry sleep from inside:

```python
async with self._session.get(...) as resp:
```

For retryable 429/5xx responses, that kept the current response context active during the backoff delay.

The retry decision is now made while the response is available, but the actual warning/backoff sleep happens only after the `async with` has exited. aiohttp releases a `ClientResponse` when its async context manager exits, so this avoids holding the previous response context during the delay without reading arbitrary error bodies or manually calling `release()`.

## Behavior preserved

- `MAX_RETRIES` remains unchanged.
- 429 retry delay and the existing 5-second `Retry-After` cap remain unchanged.
- Final 429 still raises `PollenQuotaExceededError`.
- Final 5xx still raises `UpdateFailed`.
- 401/403 and generic 4xx classification remain unchanged.
- Timeout/network retry behavior remains unchanged.
- Invalid JSON handling remains unchanged.
- API key, URL and coordinate redaction remain unchanged.
- No shared client/API-key semaphore or other #215 behavior is introduced.

## Tests

Direct client tests now verify for both HTTP 429 and 503 that:

- the response context has exited before the backoff sleep starts;
- exactly one retry is still performed with the current retry policy;
- final error classification is unchanged;
- cancellation during HTTP backoff propagates as `asyncio.CancelledError`;
- both response contexts are exited across the retry/final-attempt path.

## Scope

Only these files change:

- `custom_components/pollenlevels/client.py`
- `tests/test_client.py`

No migration, entity, service, coordinator, forecast, version, documentation or `force_update` changes.

## Validation

Expected repository checks:

```bash
uv lock --check
uv sync --locked --only-group lint
uv run --locked --no-sync ruff check .
uv run --locked --no-sync ruff format --check .
uv sync --locked --only-group test
PYTHONPATH=. uv run --locked --no-sync python -m pytest -q
uv run --locked --no-sync python -m compileall -q custom_components tests
git diff --check
```

Normal hassfest, HACS validation, Package Test, Workflow Security and CodeQL should remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary service errors and rate limits during pollen data retrieval.
  * Ensured response resources are released before retry delays begin.
  * Prevented invalid response data from being processed after unsuccessful requests.
  * Preserved cancellation behavior during retry delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->