### PR TITLE
fix(client): honor long Retry-After cooldowns

### DIFF
--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -4,6 +4,8 @@ import asyncio
 import logging
 import math
 import random
+from email.utils import parsedate_to_datetime
+from time import monotonic
 from typing import Any
 
 from aiohttp import ClientError, ClientSession, ClientTimeout, ContentTypeError
@@ -15,6 +17,8 @@ from .const import MAX_RETRIES, POLLEN_API_TIMEOUT, is_invalid_api_key_message
 from .util import extract_error_message, redact_sensitive_values
 
 _LOGGER = logging.getLogger(__name__)
+_DEFAULT_429_RETRY_DELAY = 2.0
+_MAX_INLINE_RETRY_AFTER = 5.0
 
 
 def _format_http_message(status: int, raw_message: str | None) -> str:
@@ -42,6 +46,16 @@ class PollenQuotaExceededError(UpdateFailed):
     error handling while still allowing explicit quota classification in config flow.
     """
 
+    def __init__(
+        self,
+        *args: object,
+        retry_after: float | None = None,
+    ) -> None:
+        """Initialize a quota error with an optional server-requested delay."""
+
+        super().__init__(*args)
+        self.retry_after = retry_after
+
 
 class GooglePollenApiClient:
     """Thin async client wrapper for the Google Pollen API."""
@@ -50,23 +64,53 @@ class GooglePollenApiClient:
         self._session = session
         self._api_key = api_key
         self._request_lock = asyncio.Lock()
+        self._quota_cooldown_until: float | None = None
 
-    def _parse_retry_after(self, retry_after_raw: str) -> float:
-        """Translate a Retry-After header into a delay in seconds."""
+    def _parse_retry_after(self, retry_after_raw: str) -> float | None:
+        """Translate a usable Retry-After header into a delay in seconds."""
 
         try:
             parsed = float(retry_after_raw)
             if math.isfinite(parsed) and parsed > 0:
                 return parsed
-            return 2.0
+            return None
         except TypeError, ValueError:
-            retry_at = dt_util.parse_http_date(retry_after_raw)
-            if retry_at is not None:
-                delay = (retry_at - dt_util.utcnow()).total_seconds()
-                if math.isfinite(delay) and delay > 0:
-                    return delay
+            try:
+                retry_at = parsedate_to_datetime(retry_after_raw)
+            except TypeError, ValueError, IndexError, OverflowError:
+                return None
 
-        return 2.0
+            if retry_at is None or retry_at.tzinfo is None:
+                return None
+
+            delay = (retry_at - dt_util.utcnow()).total_seconds()
+            if math.isfinite(delay) and delay > 0:
+                return delay
+
+        return None
+
+    def _set_quota_cooldown(self, retry_after: float) -> None:
+        """Record the longest active server-requested quota cooldown."""
+
+        if not math.isfinite(retry_after) or retry_after <= 0:
+            return
+
+        deadline = monotonic() + retry_after
+        if self._quota_cooldown_until is None or deadline > self._quota_cooldown_until:
+            self._quota_cooldown_until = deadline
+
+    def _quota_cooldown_remaining(self) -> float | None:
+        """Return the active quota cooldown delay, clearing expired state."""
+
+        if self._quota_cooldown_until is None:
+            return None
+
+        remaining = self._quota_cooldown_until - monotonic()
+        if not math.isfinite(remaining) or remaining <= 0:
+            self._quota_cooldown_until = None
+            return None
+
+        return remaining
 
     async def _async_backoff(
         self,
@@ -126,6 +170,16 @@ class GooglePollenApiClient:
         """Fetch pollen data while serializing requests through this client."""
 
         async with self._request_lock:
+            if (retry_after := self._quota_cooldown_remaining()) is not None:
+                _LOGGER.debug(
+                    "Pollen API quota cooldown active — skipping request for %.2fs",
+                    retry_after,
+                )
+                raise PollenQuotaExceededError(
+                    "HTTP 429",
+                    retry_after=retry_after,
+                )
+
             return await self._async_fetch_pollen_data(
                 latitude=latitude,
                 longitude=longitude,
@@ -162,6 +216,8 @@ class GooglePollenApiClient:
             try:
                 retry_429_delay: float | None = None
                 retry_5xx_status: int | None = None
+                quota_retry_after: float | None = None
+                quota_error_message: str | None = None
 
                 async with self._session.get(
                     url,
@@ -188,13 +244,38 @@ class GooglePollenApiClient:
                         raise UpdateFailed(message)
 
                     if resp.status == 429:
-                        if attempt < max_retries:
-                            retry_after_raw = resp.headers.get("Retry-After")
-                            delay = 2.0
-                            if retry_after_raw:
-                                delay = self._parse_retry_after(retry_after_raw)
-                            delay = delay + random.uniform(0.0, 0.4)
-                            retry_429_delay = max(0.0, min(delay, 5.0))
+                        retry_after_raw = resp.headers.get("Retry-After")
+                        retry_after = (
+                            self._parse_retry_after(retry_after_raw)
+                            if retry_after_raw is not None
+                            else None
+                        )
+
+                        if retry_after is not None and (
+                            retry_after > _MAX_INLINE_RETRY_AFTER
+                            or attempt >= max_retries
+                        ):
+                            (
+                                _,
+                                quota_error_message,
+                            ) = await self._async_redacted_http_message(
+                                resp,
+                                default="",
+                                latitude=latitude,
+                                longitude=longitude,
+                            )
+                            quota_retry_after = retry_after
+                        elif attempt < max_retries:
+                            delay = (
+                                retry_after
+                                if retry_after is not None
+                                else _DEFAULT_429_RETRY_DELAY
+                            )
+                            delay += random.uniform(0.0, 0.4)
+                            retry_429_delay = max(
+                                0.0,
+                                min(delay, _MAX_INLINE_RETRY_AFTER),
+                            )
                         else:
                             _, message = await self._async_redacted_http_message(
                                 resp,
@@ -252,6 +333,17 @@ class GooglePollenApiClient:
                             )
 
                         return payload
+
+                if quota_error_message is not None and quota_retry_after is not None:
+                    self._set_quota_cooldown(quota_retry_after)
+                    _LOGGER.warning(
+                        "Pollen API 429 — deferring requests for %.2fs",
+                        quota_retry_after,
+                    )
+                    raise PollenQuotaExceededError(
+                        quota_error_message,
+                        retry_after=quota_retry_after,
+                    )
 
                 if retry_429_delay is not None:
                     _LOGGER.warning(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -30,6 +32,14 @@ class _StubConfigEntryAuthFailed(Exception):
 
 class _StubUpdateFailed(Exception):
     """Minimal Home Assistant update failure stub."""
+
+    def __init__(
+        self,
+        *args: object,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(*args)
+        self.retry_after = retry_after
 
 
 @pytest.fixture
@@ -126,6 +136,23 @@ class FakeSession:
         return self.response
 
 
+class SequenceSession:
+    """Return a sequence of fake aiohttp-like responses."""
+
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self.responses = responses
+        self.calls = 0
+
+    def get(self, *_args: Any, **_kwargs: Any) -> FakeResponse:
+        """Return the next configured response."""
+
+        if self.calls >= len(self.responses):
+            raise AssertionError("Unexpected extra HTTP request")
+        response = self.responses[self.calls]
+        self.calls += 1
+        return response
+
+
 class RaisingSession:
     """Raise an aiohttp-like client error for each GET call."""
 
@@ -136,6 +163,17 @@ class RaisingSession:
         """Raise the configured error."""
 
         raise self.error
+
+
+async def _fetch_client(client: Any) -> dict[str, Any]:
+    """Execute a representative direct client fetch."""
+
+    return await client.async_fetch_pollen_data(
+        latitude=1.0,
+        longitude=2.0,
+        days=5,
+        language_code=None,
+    )
 
 
 async def _fetch_with_response(
@@ -376,6 +414,266 @@ async def test_client_treats_400_non_auth_error_as_update_failed(
 
     with pytest.raises(client_module.UpdateFailed, match="HTTP 400"):
         await _fetch_with_response(client_module, response)
+
+
+@pytest.mark.asyncio
+async def test_client_short_numeric_retry_after_retries_inline(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Short numeric Retry-After should wait at least that long and retry once."""
+
+    first = FakeResponse(status=429)
+    first.headers["Retry-After"] = "1.5"
+    second = FakeResponse(json_results=[{"ok": True}])
+    session = SequenceSession([first, second])
+    client = client_module.GooglePollenApiClient(session, "test")
+    sleep_delays: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(client_module.random, "uniform", lambda *_args: 0.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    assert await _fetch_client(client) == {"ok": True}
+    assert sleep_delays == pytest.approx([1.5])
+    assert session.calls == 2
+    assert first.exit_calls == 1
+    assert second.exit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_http_date_retry_after_retries_inline(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A short HTTP-date Retry-After should behave like a numeric delay."""
+
+    now = datetime(2026, 8, 11, 13, 0, tzinfo=UTC)
+    first = FakeResponse(status=429)
+    first.headers["Retry-After"] = format_datetime(
+        now + timedelta(seconds=3),
+        usegmt=True,
+    )
+    second = FakeResponse(json_results=[{"ok": True}])
+    session = SequenceSession([first, second])
+    client = client_module.GooglePollenApiClient(session, "test")
+    sleep_delays: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(client_module.dt_util, "utcnow", lambda: now)
+    monkeypatch.setattr(client_module.random, "uniform", lambda *_args: 0.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    assert await _fetch_client(client) == {"ok": True}
+    assert sleep_delays == pytest.approx([3.0])
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_client_long_retry_after_sets_cooldown_without_inline_sleep(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long Retry-After should fail fast with a coordinator-visible cooldown."""
+
+    api_key = "AIzaFAKEPLACEHOLDER1234567890"
+    response = FakeResponse(
+        status=429,
+        json_results=[{"error": {"message": f"Quota exceeded for {api_key}"}}],
+    )
+    response.headers["Retry-After"] = "60"
+    session = FakeSession(response)
+    client = client_module.GooglePollenApiClient(session, api_key)
+
+    async def _unexpected_sleep(_delay: float) -> None:
+        raise AssertionError("Long Retry-After must not sleep inline")
+
+    monkeypatch.setattr(client_module, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _unexpected_sleep)
+
+    with pytest.raises(client_module.PollenQuotaExceededError) as exc_info:
+        await _fetch_client(client)
+
+    assert exc_info.value.retry_after == pytest.approx(60.0)
+    assert api_key not in str(exc_info.value)
+    assert session.calls == 1
+    assert response.exit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_active_cooldown_blocks_sibling_without_http_request(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared client cooldown should block sibling calls without network I/O."""
+
+    response = FakeResponse(status=429)
+    response.headers["Retry-After"] = "60"
+    session = FakeSession(response)
+    client = client_module.GooglePollenApiClient(session, "test")
+    now = [100.0]
+
+    monkeypatch.setattr(client_module, "monotonic", lambda: now[0])
+
+    with pytest.raises(client_module.PollenQuotaExceededError) as first_error:
+        await _fetch_client(client)
+    assert first_error.value.retry_after == pytest.approx(60.0)
+    assert session.calls == 1
+
+    now[0] = 110.0
+    with pytest.raises(client_module.PollenQuotaExceededError) as sibling_error:
+        await _fetch_client(client)
+
+    assert sibling_error.value.retry_after == pytest.approx(50.0)
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_cooldown_expires_and_allows_next_request(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An expired cooldown should clear and permit the next HTTP request."""
+
+    limited = FakeResponse(status=429)
+    limited.headers["Retry-After"] = "60"
+    healthy = FakeResponse(json_results=[{"ok": True}])
+    session = SequenceSession([limited, healthy])
+    client = client_module.GooglePollenApiClient(session, "test")
+    now = [100.0]
+
+    monkeypatch.setattr(client_module, "monotonic", lambda: now[0])
+
+    with pytest.raises(client_module.PollenQuotaExceededError):
+        await _fetch_client(client)
+    assert session.calls == 1
+
+    now[0] = 161.0
+    assert await _fetch_client(client) == {"ok": True}
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_client_cooldown_does_not_block_different_client(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cooldown must remain scoped to one client/API-key runtime."""
+
+    limited_response = FakeResponse(status=429)
+    limited_response.headers["Retry-After"] = "60"
+    limited_session = FakeSession(limited_response)
+    limited_client = client_module.GooglePollenApiClient(limited_session, "key-a")
+
+    healthy_response = FakeResponse(json_results=[{"ok": True}])
+    healthy_session = FakeSession(healthy_response)
+    healthy_client = client_module.GooglePollenApiClient(healthy_session, "key-b")
+
+    monkeypatch.setattr(client_module, "monotonic", lambda: 100.0)
+
+    with pytest.raises(client_module.PollenQuotaExceededError):
+        await _fetch_client(limited_client)
+
+    assert await _fetch_client(healthy_client) == {"ok": True}
+    assert limited_session.calls == 1
+    assert healthy_session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_client_exhausted_short_retry_after_sets_cooldown(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exhausted short Retry-After should create a shared cooldown."""
+
+    first = FakeResponse(status=429)
+    first.headers["Retry-After"] = "2"
+    second = FakeResponse(status=429)
+    second.headers["Retry-After"] = "2"
+    session = SequenceSession([first, second])
+    client = client_module.GooglePollenApiClient(session, "test")
+    now = [100.0]
+    sleep_delays: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(client_module, "monotonic", lambda: now[0])
+    monkeypatch.setattr(client_module.random, "uniform", lambda *_args: 0.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    with pytest.raises(client_module.PollenQuotaExceededError) as exc_info:
+        await _fetch_client(client)
+
+    assert sleep_delays == pytest.approx([2.0])
+    assert exc_info.value.retry_after == pytest.approx(2.0)
+    assert session.calls == 2
+    assert first.exit_calls == 1
+    assert second.exit_calls == 1
+
+    now[0] = 101.0
+    with pytest.raises(client_module.PollenQuotaExceededError) as sibling_error:
+        await _fetch_client(client)
+
+    assert sibling_error.value.retry_after == pytest.approx(1.0)
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "retry_after_raw",
+    [None, "not-a-date", "-1", "0", "nan", "inf"],
+)
+async def test_client_invalid_retry_after_uses_short_fallback(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    retry_after_raw: str | None,
+) -> None:
+    """Missing or malformed Retry-After should keep the short fallback retry."""
+
+    first = FakeResponse(status=429)
+    if retry_after_raw is not None:
+        first.headers["Retry-After"] = retry_after_raw
+    second = FakeResponse(json_results=[{"ok": True}])
+    session = SequenceSession([first, second])
+    client = client_module.GooglePollenApiClient(session, "test")
+    sleep_delays: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(client_module.random, "uniform", lambda *_args: 0.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    assert await _fetch_client(client) == {"ok": True}
+    assert sleep_delays == pytest.approx([2.0])
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_client_final_invalid_retry_after_does_not_create_cooldown(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A final malformed Retry-After should not invent a cooldown."""
+
+    monkeypatch.setattr(client_module, "MAX_RETRIES", 0)
+    first = FakeResponse(status=429)
+    first.headers["Retry-After"] = "not-a-date"
+    second = FakeResponse(json_results=[{"ok": True}])
+    session = SequenceSession([first, second])
+    client = client_module.GooglePollenApiClient(session, "test")
+
+    with pytest.raises(client_module.PollenQuotaExceededError) as exc_info:
+        await _fetch_client(client)
+
+    assert exc_info.value.retry_after is None
+    assert await _fetch_client(client) == {"ok": True}
+    assert session.calls == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Honor server-provided HTTP 429 `Retry-After` values without keeping a Home Assistant refresh task asleep for long delays.

This is the Retry-After half of #215, building on the shared runtime-client serialization merged in #289.

## Behavior

- Missing or malformed `Retry-After` keeps the existing conservative short fallback and one-retry limit.
- Valid short `Retry-After` values up to the existing 5-second inline budget wait at least the requested delay, then use the existing single retry.
- Valid `Retry-After` values longer than 5 seconds do not get clamped and retried early. The response context is exited, a client-local monotonic cooldown is recorded, and `PollenQuotaExceededError(..., retry_after=N)` is raised.
- A final 429 with a valid `Retry-After` also records and propagates that delay.
- While the shared runtime client is in cooldown, sibling calls fail fast with zero HTTP requests and expose the remaining delay via `retry_after`.
- Separate client/API-key instances remain independent.

`PollenQuotaExceededError` already subclasses Home Assistant `UpdateFailed`, so normal `DataUpdateCoordinator` refreshes can use the standard `retry_after` scheduling support available across the project's declared HA compatibility range.

## Scope boundaries

This PR deliberately does **not** change:

- HTTP 503 retry policy;
- the existing one-retry limit;
- `pollenlevels.force_update` concurrency;
- `button.py` `PARALLEL_UPDATES`;
- coordinator scheduling code;
- config/subentry-flow client topology;
- migration, entities, forecast data, diagnostics or public IDs.

Cooldown state is intentionally in-memory and scoped to one `GooglePollenApiClient`; it is not persisted and there is no process-global API-key registry.

During `async_config_entry_first_refresh()`, Home Assistant deliberately ignores coordinator `retry_after` and retains its normal `ConfigEntryNotReady` setup retry behavior. Config/subentry validation also uses its own temporary client, so its cooldown remains local to that validation attempt. Quota classification remains unchanged.

## Tests

Focused coverage verifies:

- short numeric `Retry-After` waits and retries once;
- short HTTP-date `Retry-After` behaves equivalently;
- long delays do not sleep inline and propagate `retry_after`;
- active shared-client cooldowns block sibling HTTP calls and return the remaining delay;
- different clients are unaffected by another client's cooldown;
- a final 429 refreshes and propagates a valid cooldown;
- missing/malformed headers retain the short fallback;
- malformed final headers do not invent a cooldown;
- existing response-cleanup-before-backoff and cancellation tests remain in place;
- existing auth/error/privacy/config-flow tests remain part of the full suite.

Part of #215.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit responses, including numeric and date-based retry instructions.
  * Added automatic retries with fallback delays when retry information is missing or invalid.
  * Requests now fail immediately during enforced cooldown periods after prolonged rate limiting.
  * Rate-limit errors include the applicable retry duration for clearer recovery guidance.
  * Cooldown behavior is scoped appropriately and refreshed when new rate-limit responses are received.
  * Improved cleanup and reliability when requests are retried after temporary rate limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->