### PR TITLE
refactor(service): parallelize force update across parents

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -73,7 +73,6 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 6
-_FORCE_UPDATE_CONCURRENCY_LIMIT = 1
 _SETUP_FAILURE_REASON_MAX_LENGTH = 240
 _SETUP_RETRY_FAILURES_DATA_KEY = "setup_retry_failures"
 _NON_RETRYABLE_SETUP_FAILURE_TYPES = frozenset({"InvalidStoredLocation"})
@@ -354,14 +353,24 @@ async def _refresh_force_update_target(
 async def _refresh_force_update_targets(
     targets: list[tuple[ConfigEntry, str, Any]],
 ) -> None:
-    """Refresh force_update targets with an explicit concurrency limit."""
-    semaphore = asyncio.Semaphore(_FORCE_UPDATE_CONCURRENCY_LIMIT)
+    """Refresh force_update targets sequentially within each parent entry."""
+    targets_by_entry: dict[str, list[tuple[ConfigEntry, str, Any]]] = {}
+    for target in targets:
+        entry = target[0]
+        targets_by_entry.setdefault(entry.entry_id, []).append(target)
 
-    async def _refresh(target: tuple[ConfigEntry, str, Any]) -> None:
-        async with semaphore:
+    async def _refresh_parent(
+        parent_targets: list[tuple[ConfigEntry, str, Any]],
+    ) -> None:
+        for target in parent_targets:
             await _refresh_force_update_target(*target)
 
-    await asyncio.gather(*(_refresh(target) for target in targets))
+    await asyncio.gather(
+        *(
+            _refresh_parent(parent_targets)
+            for parent_targets in targets_by_entry.values()
+        )
+    )
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1536,7 +1536,7 @@ def test_force_update_logs_do_not_expose_secrets(
 def test_force_update_refreshes_location_subentries_sequentially(
     integration_modules: _InitModules,
 ) -> None:
-    """force_update should limit location refresh concurrency to one."""
+    """force_update should refresh locations under one parent sequentially."""
     integration = integration_modules.integration
 
     active = 0
@@ -1579,6 +1579,46 @@ def test_force_update_refreshes_location_subentries_sequentially(
 
     assert max_active == 1
     assert order == ["loc-1:start", "loc-1:end", "loc-2:start", "loc-2:end"]
+
+
+def test_force_update_refreshes_different_parents_concurrently(
+    integration_modules: _InitModules,
+) -> None:
+    """force_update should refresh locations under different parents concurrently."""
+    integration = integration_modules.integration
+
+    active = 0
+    max_active = 0
+
+    class _Coordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            nonlocal active, max_active
+            self.calls += 1
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+
+    coordinator1 = _Coordinator()
+    coordinator2 = _Coordinator()
+    entry1 = _FakeEntry(integration, entry_id="entry-1")
+    entry2 = _FakeEntry(integration, entry_id="entry-2")
+
+    asyncio.run(
+        integration._refresh_force_update_targets(
+            [
+                (entry1, "loc-1", coordinator1),
+                (entry2, "loc-2", coordinator2),
+            ]
+        )
+    )
+
+    assert max_active == 2
+    assert coordinator1.calls == 1
+    assert coordinator2.calls == 1
 
 
 def test_force_update_refreshes_fallback_location_without_subentries(
@@ -1713,6 +1753,45 @@ def test_force_update_continues_after_one_location_failure(
     assert "-98.765432" not in text
     assert "location.latitude=***" in text
     assert "location.longitude=***" in text
+
+
+def test_force_update_continues_after_different_parent_failure(
+    integration_modules: _InitModules,
+) -> None:
+    """One parent failure should not prevent another parent from refreshing."""
+    integration = integration_modules.integration
+
+    class _FailCoordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+            raise RuntimeError("refresh failed")
+
+    class _OkCoordinator:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_request_refresh(self):
+            self.calls += 1
+
+    failing = _FailCoordinator()
+    ok = _OkCoordinator()
+    entry1 = _FakeEntry(integration, entry_id="entry-failing")
+    entry2 = _FakeEntry(integration, entry_id="entry-ok")
+
+    asyncio.run(
+        integration._refresh_force_update_targets(
+            [
+                (entry1, "loc-failing", failing),
+                (entry2, "loc-ok", ok),
+            ]
+        )
+    )
+
+    assert failing.calls == 1
+    assert ok.calls == 1
 
 
 def test_force_update_propagates_location_cancelled_error(


### PR DESCRIPTION
## Summary

- Group `force_update` targets by parent config-entry ID.
- Refresh locations sequentially within each parent while allowing independent parents/API keys to progress concurrently.
- Add focused coverage for cross-parent concurrency and failure isolation while preserving existing same-parent sequencing and failure coverage.

Part of #215

## Concurrency and behavior

Same-parent locations remain intentionally sequential in the service layer. Independent parents/API keys may now refresh concurrently, with no arbitrary cross-parent concurrency cap.

PR #289 still serializes requests through each shared runtime `GooglePollenApiClient`, including overlaps with scheduler, button, service, or other coordinator paths. PR #290 still enforces parent-local HTTP 429 `Retry-After` cooldowns.

Unrelated update paths and public behavior are unchanged. The service continues to await all refresh work, propagate cancellation, isolate ordinary per-location failures, and preserve privacy-safe failure logging.

## Validation

Passed locally with the repository-pinned `uv==0.12.2`:

- `uv lock --check`
- locked test and lint dependency synchronization
- `python -m compileall -q custom_components tests`
- full pytest suite: 641 passed
- `ruff check .`
- `ruff format --check .`
- release ZIP creation
- `python scripts/validate_release_zip.py /tmp/pollenlevels-release-validation.zip`

Hassfest and HACS validation could not be run locally because this environment has neither their executables nor container support; those remain for the repository's GitHub Actions checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved force updates so locations under the same configuration refresh reliably in sequence.
  * Locations under separate configurations can refresh concurrently for faster updates.
  * A failed refresh no longer prevents locations under other configurations from updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->