### PR TITLE
release: prepare 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [3.0.2] - 2026-08-12
+
+### Changed
+
+- Declared Home Assistant platform concurrency explicitly so Update now button
+  actions under the same parent are serialized while sensor polling remains
+  coordinator-managed.
+- Serialized Google Pollen API requests through each shared runtime client so
+  sibling locations using the same API key cannot issue overlapping requests,
+  while independent API-key clients remain independent.
+- Updated the global `pollenlevels.force_update` action to keep locations under
+  the same parent/API key sequential while allowing independent parents to
+  refresh concurrently.
+
+### Fixed
+
+- Normalized Google pollen index values defensively across current state,
+  forecast, summary, trend, and peak calculations, accepting only integer
+  values from 0 through 5 while preserving valid non-index metadata.
+- Released retryable HTTP 429 and 5xx responses before backoff so connections
+  can be reused without changing retry classification or cancellation
+  behavior.
+- Honored valid long HTTP 429 `Retry-After` delays with shared client-local
+  cooldowns instead of retrying too early, while retaining short inline retries
+  and the safe fallback for missing, malformed, or non-positive values.
+
 ## [3.0.1] - 2026-08-09
 
 ### Added

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.0.1"
+    "version": "3.0.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pollenlevels"
-version = "3.0.1"
+version = "3.0.2"
 # Enforce the runtime floor aligned with Home Assistant Python 3.14 images.
 requires-python = ">=3.14"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "pollenlevels"
-version = "3.0.1"
+version = "3.0.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- bump Pollen Levels to 3.0.2;
- add the 3.0.2 changelog;
- synchronize only the local project version in uv.lock.

## Release scope
- defensive Google pollen index normalization from #283;
- Home Assistant platform concurrency declarations from #287;
- retry-response connection reuse hardening from #288;
- shared runtime-client serialization from #289;
- long HTTP 429 Retry-After cooldown handling from #290;
- parent-scoped force_update concurrency from #291;
- no v3 migration changes;
- no entity/device/public contract changes;
- no minimum Home Assistant version change.

## Validation
The host had uv 0.12.3, so the repository-pinned uv 0.12.2 was provisioned and every uv command below was invoked explicitly through `uvx --from uv==0.12.2 uv`.

- `uvx --from uv==0.12.2 uv --version` — passed; `uv 0.12.2`.
- `uvx --from uv==0.12.2 uv lock --check` — passed; resolved 155 packages.
- `uvx --from uv==0.12.2 uv sync --locked --only-group lint` — passed.
- `uvx --from uv==0.12.2 uv run --locked --no-sync ruff check .` — passed; all checks passed.
- `uvx --from uv==0.12.2 uv run --locked --no-sync ruff format --check .` — passed; 58 files already formatted.
- `uvx --from uv==0.12.2 uv sync --locked --only-group test` — passed.
- `PYTHONPATH=. uvx --from uv==0.12.2 uv run --locked --no-sync python -m pytest --collect-only -q` — passed; 641 tests collected.
- `PYTHONPATH=. uvx --from uv==0.12.2 uv run --locked --no-sync python -m pytest -q` — passed; 641 passed in 15.84s.
- `uvx --from uv==0.12.2 uv sync --locked --only-group release` — passed.
- `uvx --from uv==0.12.2 uv run --locked --no-sync python -m compileall -q custom_components tests scripts` — passed.
- `git diff --check` — passed.
- `git diff main...HEAD` — inspected; exactly the four release files changed.
- `git status --short` — clean after commit.
- `git archive --format=zip ... HEAD:custom_components/pollenlevels` followed by `EXPECTED_RELEASE_TAG=v3.0.2 uvx --from uv==0.12.2 uv run --locked --no-sync python scripts/validate_release_zip.py ...` — passed; ZIP structure, manifest, and release tag validated.

### Lock audit
Only the virtual `pollenlevels` package version changed in `uv.lock`, from 3.0.1 to 3.0.2. No dependency version, hash, source, resolution marker, package metadata, or other lock content changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved request scheduling for more reliable platform updates.
  - Added support for longer server-requested retry delays while preserving shorter retries.
  - Improved handling of shared API connections and location refreshes.

- **Bug Fixes**
  - Normalized pollen index values to valid integers from 0–5.
  - Safely releases temporarily unavailable responses before retrying.

- **Chores**
  - Updated the integration version to 3.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->