### PR TITLE
test: simplify isolated async test wrappers

### DIFF
--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib
 import sys
 from dataclasses import dataclass
@@ -221,20 +220,18 @@ def test_options_flow_uses_modern_reload_base_class(
     )
 
 
-def test_options_flow_invalid_language_sets_error(
+async def test_options_flow_invalid_language_sets_error(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
     """Invalid language in options should map to invalid_language_format."""
 
     flow = _flow(options_flow_env)
 
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: "bad code",
-                options_flow_env.CONF_UPDATE_INTERVAL: 6,
-            }
-        )
+    result = await flow.async_step_init(
+        {
+            options_flow_env.CONF_LANGUAGE_CODE: "bad code",
+            options_flow_env.CONF_UPDATE_INTERVAL: 6,
+        }
     )
 
     assert result["errors"] == {
@@ -242,20 +239,18 @@ def test_options_flow_invalid_language_sets_error(
     }
 
 
-def test_options_flow_invalid_language_code_not_logged_raw(
+async def test_options_flow_invalid_language_code_not_logged_raw(
     options_flow_env: OptionsFlowEnv, caplog
 ) -> None:
     """Invalid language in options should not log the raw user-provided value."""
     flow = _flow(options_flow_env)
 
     with caplog.at_level("WARNING", logger=options_flow_env.config_flow.__name__):
-        result = asyncio.run(
-            flow.async_step_init(
-                {
-                    options_flow_env.CONF_LANGUAGE_CODE: "bad code",
-                    options_flow_env.CONF_UPDATE_INTERVAL: 6,
-                }
-            )
+        result = await flow.async_step_init(
+            {
+                options_flow_env.CONF_LANGUAGE_CODE: "bad code",
+                options_flow_env.CONF_UPDATE_INTERVAL: 6,
+            }
         )
 
     assert "bad code" not in caplog.text
@@ -264,20 +259,18 @@ def test_options_flow_invalid_language_code_not_logged_raw(
     }
 
 
-def test_options_flow_update_interval_below_min_sets_error(
+async def test_options_flow_update_interval_below_min_sets_error(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
     """Sub-1 update intervals should raise a field error."""
 
     flow = _flow(options_flow_env)
 
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_UPDATE_INTERVAL: 0,
-            }
-        )
+    result = await flow.async_step_init(
+        {
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+            options_flow_env.CONF_UPDATE_INTERVAL: 0,
+        }
     )
 
     assert result["errors"] == {
@@ -285,20 +278,18 @@ def test_options_flow_update_interval_below_min_sets_error(
     }
 
 
-def test_options_flow_invalid_update_interval_short_circuits(
+async def test_options_flow_invalid_update_interval_short_circuits(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
     """Invalid update interval should short-circuit without extra errors."""
 
     flow = _flow(options_flow_env)
 
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_UPDATE_INTERVAL: "not-a-number",
-            }
-        )
+    result = await flow.async_step_init(
+        {
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+            options_flow_env.CONF_UPDATE_INTERVAL: "not-a-number",
+        }
     )
 
     assert result["errors"] == {
@@ -306,20 +297,18 @@ def test_options_flow_invalid_update_interval_short_circuits(
     }
 
 
-def test_options_flow_update_interval_above_max_sets_error(
+async def test_options_flow_update_interval_above_max_sets_error(
     options_flow_env: OptionsFlowEnv,
 ) -> None:
     """Over-max update intervals should raise a field error."""
 
     flow = _flow(options_flow_env)
 
-    result = asyncio.run(
-        flow.async_step_init(
-            {
-                options_flow_env.CONF_LANGUAGE_CODE: "en",
-                options_flow_env.CONF_UPDATE_INTERVAL: 999,
-            }
-        )
+    result = await flow.async_step_init(
+        {
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+            options_flow_env.CONF_UPDATE_INTERVAL: 999,
+        }
     )
 
     assert result["errors"] == {
@@ -335,7 +324,7 @@ def test_options_flow_update_interval_above_max_sets_error(
         (999, "MAX_UPDATE_INTERVAL_HOURS"),
     ],
 )
-def test_options_schema_update_interval_default_is_sanitized(
+async def test_options_schema_update_interval_default_is_sanitized(
     monkeypatch: pytest.MonkeyPatch,
     options_flow_env: OptionsFlowEnv,
     raw_value: object,
@@ -361,12 +350,12 @@ def test_options_schema_update_interval_default_is_sanitized(
         options_flow_env,
         options={options_flow_env.CONF_UPDATE_INTERVAL: raw_value},
     )
-    asyncio.run(flow.async_step_init(user_input=None))
+    await flow.async_step_init(user_input=None)
 
     assert captured_defaults == [expected]
 
 
-def test_options_schema_omits_removed_forecast_options(
+async def test_options_schema_omits_removed_forecast_options(
     monkeypatch: pytest.MonkeyPatch,
     options_flow_env: OptionsFlowEnv,
 ) -> None:
@@ -387,7 +376,7 @@ def test_options_schema_omits_removed_forecast_options(
             options_flow_env.CONF_CREATE_FORECAST_SENSORS: "bad",
         },
     )
-    asyncio.run(flow.async_step_init(user_input=None))
+    await flow.async_step_init(user_input=None)
 
     assert options_flow_env.CONF_FORECAST_DAYS not in captured_keys
     assert options_flow_env.CONF_CREATE_FORECAST_SENSORS not in captured_keys

--- a/tests/test_sensor_plant_advice.py
+++ b/tests/test_sensor_plant_advice.py
@@ -162,7 +162,7 @@ def _make_coordinator(
     )
 
 
-def test_plant_sensor_does_not_inherit_type_health_recommendations(
+async def test_plant_sensor_does_not_inherit_type_health_recommendations(
     sensor_modules: SensorModules,
 ) -> None:
     """Plant advice is not derived from same-family pollen type advice."""
@@ -202,19 +202,15 @@ def test_plant_sensor_does_not_inherit_type_health_recommendations(
     fake_session = FakeSession(payload)
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     coordinator = _make_coordinator(sensor_modules, loop, client)
-
-    try:
-        data = loop.run_until_complete(coordinator._async_update_data())
-    finally:
-        loop.close()
+    data = await coordinator._async_update_data()
 
     assert data["type_weed"]["advice"] == ["Keep windows closed"]
     assert data["plants_ragweed"]["advice"] is None
 
 
-def test_plant_without_index_info(
+async def test_plant_without_index_info(
     sensor_modules: SensorModules,
 ) -> None:
     """Plant without indexInfo is present in coordinator output with null index fields."""
@@ -257,13 +253,9 @@ def test_plant_without_index_info(
     fake_session = FakeSession(payload)
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     coordinator = _make_coordinator(sensor_modules, loop, client)
-
-    try:
-        data = loop.run_until_complete(coordinator._async_update_data())
-    finally:
-        loop.close()
+    data = await coordinator._async_update_data()
 
     assert "plants_hazel" in data
     hazel = data["plants_hazel"]
@@ -285,7 +277,7 @@ def test_plant_without_index_info(
     assert data["type_tree"]["advice"] == ["Avoid outdoor activity"]
 
 
-def test_plant_missing_optional_metadata(
+async def test_plant_missing_optional_metadata(
     sensor_modules: SensorModules,
 ) -> None:
     """Missing optional plant metadata fields fall back safely."""
@@ -333,13 +325,9 @@ def test_plant_missing_optional_metadata(
     fake_session = FakeSession(payload)
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     coordinator = _make_coordinator(sensor_modules, loop, client)
-
-    try:
-        data = loop.run_until_complete(coordinator._async_update_data())
-    finally:
-        loop.close()
+    data = await coordinator._async_update_data()
 
     alder = data["plants_alder"]
     assert alder["displayName"] == "alder"
@@ -372,7 +360,7 @@ def test_plant_missing_optional_metadata(
     assert oak["picture_closeup"] == "https://example.com/oak-close.jpg"
 
 
-def test_plant_missing_and_partial_colors(
+async def test_plant_missing_and_partial_colors(
     sensor_modules: SensorModules,
 ) -> None:
     """Missing, empty, partial, and zero-valued color structures produce correct output."""
@@ -425,13 +413,9 @@ def test_plant_missing_and_partial_colors(
     fake_session = FakeSession(payload)
     client = sensor_modules.client_mod.GooglePollenApiClient(fake_session, "test")
 
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     coordinator = _make_coordinator(sensor_modules, loop, client)
-
-    try:
-        data = loop.run_until_complete(coordinator._async_update_data())
-    finally:
-        loop.close()
+    data = await coordinator._async_update_data()
 
     assert data["plants_alder"]["color_hex"] is None
     assert data["plants_alder"]["color_rgb"] is None


### PR DESCRIPTION
Closes #278

## Summary

- Convert seven isolated options-flow `asyncio.run(...)` wrappers to direct awaits in auto-managed async tests.
- Convert four plant-advice tests from standalone loops to pytest-asyncio's running loop.
- Preserve all fixtures, payloads, parametrization, assertions, and helper signatures.

## Scope

Exactly two test files changed:

- `tests/test_options_flow.py`
- `tests/test_sensor_plant_advice.py`

Production code, v3 migration, dependencies, `uv.lock`, workflows, manifest/release metadata, translations, and documentation are unchanged.

## Validation

- Collection: **641 node IDs before and after; complete lists are identical.**
- Focused candidates: **14 passed**
- Async sentinel coverage (`tests/test_client_concurrency.py`, `tests/test_sensor.py`): **98 passed**
- Full suite: **641 passed**
- `ruff check .`: passed
- `ruff format --check .`: passed
- `python -m compileall -q custom_components tests scripts`: passed
- `git diff --check`: passed
- No skips, deselections, xfails, pytest-asyncio warnings, runtime warnings, task leaks, unclosed loops/sessions/connectors, async-generator cleanup errors, or fixture-teardown warnings observed.

## Async-pattern inventory

| Pattern | Before | After |
|---|---:|---:|
| `asyncio.run(` | 155 | 148 |
| `asyncio.new_event_loop(` | 46 | 42 |
| `run_until_complete(` | 53 | 49 |
| `asyncio.get_running_loop(` | 13 | 17 |
| async test functions | 97 | 108 |
| collected node IDs | 641 | 641 |

## Explicitly deferred

- `tests/test_sensor.py`
- `tests/test_config_flow.py`
- `tests/test_init.py`
- `tests/test_migration.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for configuration validation, including unsupported languages, update-interval boundaries, invalid values, and safe default handling.
  * Added regression coverage to ensure removed forecast settings are not presented.
  * Improved asynchronous test execution for configuration flows and plant advice updates, increasing reliability and consistency of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->