### PR TITLE
docs: refresh README introduction and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@
 
 # 🌼 Pollen Levels Integration for Home Assistant
 
-**Monitor real-time pollen levels** from the Google Maps Pollen API directly in Home Assistant.  
-Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants like **OAK**, **PINE**, **OLIVE**, and many more!
+**Monitor current and forecast pollen levels** from the Google Maps Pollen API directly in Home Assistant.  
+Track **grass**, **tree**, and **weed** pollen, regional plant species, daily summaries, and up to **5 days of forecast data** across multiple locations.
 
 [![GitHub Release](https://img.shields.io/github/v/release/eXPerience83/pollenlevels)](https://github.com/eXPerience83/pollenlevels/releases)
-![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)
-[![Lint](https://github.com/eXPerience83/pollenlevels/actions/workflows/lint.yml/badge.svg)](https://github.com/eXPerience83/pollenlevels/actions/workflows/lint.yml)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.3%2B-41BDF5?logo=home-assistant&logoColor=white)](https://www.home-assistant.io/)
+[![Latest Home Assistant Compatibility](https://github.com/eXPerience83/pollenlevels/actions/workflows/ha-compatibility-canary.yml/badge.svg?branch=main)](https://github.com/eXPerience83/pollenlevels/actions/workflows/ha-compatibility-canary.yml)
 [![hassfest validation](https://github.com/eXPerience83/pollenlevels/actions/workflows/hassfest.yml/badge.svg)](https://github.com/eXPerience83/pollenlevels/actions/workflows/hassfest.yml)
 [![HACS validation](https://github.com/eXPerience83/pollenlevels/actions/workflows/validate.yml/badge.svg)](https://github.com/eXPerience83/pollenlevels/actions/workflows/validate.yml)
-[![CodeQL enabled](https://img.shields.io/badge/CodeQL-enabled-brightgreen.svg)](https://github.com/eXPerience83/pollenlevels/security/code-scanning)
-[![License](https://img.shields.io/github/license/eXPerience83/pollenlevels?logo=github)](https://github.com/eXPerience83/pollenlevels/blob/main/LICENSE)
-[![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
-[![FAQ](https://img.shields.io/badge/FAQ-Read%20Here-blue?logo=readthedocs&logoColor=white)](https://github.com/eXPerience83/pollenlevels/blob/main/FAQ.md)
-[![Terms](https://img.shields.io/badge/Terms-Read-blue)](TERMS.md)
-[![Privacy](https://img.shields.io/badge/Privacy-Read-blue)](PRIVACY.md)
-[![Ko-fi](https://img.shields.io/badge/Ko%E2%80%91fi-Support%20this%20project-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/experience83)
-[![PayPal](https://img.shields.io/badge/PayPal-Donate-blue?logo=paypal)](https://paypal.me/eXPerience83)
+[![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/default/blob/master/integration)
+[![License](https://img.shields.io/github/license/eXPerience83/pollenlevels?logo=github)](LICENSE)
+
+[FAQ](FAQ.md) · [Terms](TERMS.md) · [Privacy](PRIVACY.md)
 
 [![Open your Home Assistant instance and add this repository inside HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=eXPerience83&repository=pollenlevels&category=integration)
 
@@ -27,8 +23,9 @@ Get sensors for **grass**, **tree**, **weed** pollen, plus individual plants lik
 
 ## Requirements
 
-- Requires Home Assistant 2026.3.0 or newer.
-- This release line targets Python 3.14+, matching the Home Assistant runtime baseline.
+- Home Assistant 2026.3.0 or newer.
+- HACS 2.0.0 or newer when installing through HACS.
+- A Google Cloud API key with the Maps Pollen API enabled.
 
 ## 🌟 Features
 
@@ -424,7 +421,7 @@ curl -X GET "https://pollen.googleapis.com/v1/forecast:lookup?key=YOUR_KEY&locat
 
 If this integration helps you, consider supporting development:
 
-[![Ko-fi](https://img.shields.io/badge/Ko%E2%80%91fi-Support%20this%20project-ff5e5b?logo=ko-fi\&logoColor=white)](https://ko-fi.com/experience83)
+[![Ko-fi](https://img.shields.io/badge/Ko%E2%80%91fi-Support%20this%20project-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/experience83)
 [![PayPal](https://img.shields.io/badge/PayPal-Donate-blue?logo=paypal)](https://paypal.me/eXPerience83)
 
 ---


### PR DESCRIPTION
## Summary

- replace the ambiguous `real-time` wording with current and forecast pollen data terminology aligned with the Google Maps Pollen API
- make the introduction highlight regional plant species, daily summaries, five-day forecasts, and multiple locations
- reduce header badge clutter and add user-relevant Home Assistant compatibility signals
- show the scheduled `Latest Home Assistant Compatibility Canary` badge instead of the generic project test badge; the canary runs the full suite against the latest stable Home Assistant harness while the locked `tests.yml` workflow remains the required PR/release test gate
- keep the HACS Default badge but point it to the actual HACS default integration catalogue
- move FAQ, Terms, and Privacy to a compact navigation row instead of status-style badges
- remove duplicated donation badges from the header while keeping the existing support section
- align the Requirements section with `hacs.json`: Home Assistant 2026.3+, HACS 2.0+ for HACS installs, and a Google Maps Pollen API key
- fix the unnecessary escaped ampersand in the existing Ko-fi badge URL

## Why

The previous header mixed project status, navigation, development runtime details, security signalling, and donations in one large badge block. It also described the Google Pollen API data as `real-time`, while Google documents the forecast endpoint as daily pollen information with an up-to-five-day forecast horizon.

For users evaluating compatibility, the latest-Home-Assistant canary provides a more meaningful README signal than the generic test badge: it shows whether the full integration test suite still passes against the latest stable Home Assistant environment. The normal locked test workflow remains authoritative for pull requests and releases.

This keeps the first screen focused on what the integration does, whether it is compatible and healthy, and how to install it, without changing the rest of the documentation structure.

## Impact

Documentation only. No runtime, migration, entity identity, translations, services, release metadata, CI behavior, or changelog changes.

## Validation

- reviewed the final diff against `main`
- confirmed `tests.yml`, `hassfest.yml`, and `validate.yml` exist
- confirmed `ha-compatibility-canary.yml` runs daily against the latest stable Home Assistant harness and executes the full test suite
- confirmed the repository is listed in the `hacs/default` integration catalogue
- confirmed `hacs.json` declares Home Assistant `2026.3.0` and HACS `2.0.0`
- verified Google documents the Pollen API forecast as daily information with up to five days

Local project checks were not run because this change was prepared through the GitHub connector without a local repository/toolchain; repository CI provides the authoritative validation for this documentation-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect current and forecast pollen monitoring capabilities.
  * Expanded details on forecast and location coverage.
  * Refreshed compatibility badges and added links for installation, licensing, and documentation.
  * Clarified requirements and corrected the Ko-fi badge link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->