### PR TITLE
docs: strengthen AGENTS.md for v3 architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,10 @@ Migration and registry identity are high-risk compatibility surfaces.
 
 Privacy and support diagnostics are part of the public maintenance contract.
 
-- API keys must always be redacted from diagnostics, logs, exceptions, Repairs,
-  test fixtures, and PR/issue text.
+- Real API keys and other secrets must never appear in diagnostics, logs,
+  exceptions, Repairs, test fixtures, or PR/issue text. Use clearly synthetic
+  credentials in tests and redact sensitive runtime values before surfacing
+  them.
 - Never log complete credential-bearing request URLs or precise coordinates.
 - Diagnostics may expose only deliberately reduced location information; current
   coordinate examples are rounded to one decimal place.
@@ -231,9 +233,8 @@ This section is the repository source of truth for changelog style.
   automatically. If such a section already exists, leave it unless the task
   explicitly changes it.
 - Version headings use `## [version] - YYYY-MM-DD` with an ASCII hyphen and stay
-  in reverse chronological order. Use SemVer identifiers such as `3.0.2`,
-  `3.0.0-rc1`, or `3.0.0-alpha1` according to the repository's established
-  release naming.
+  in reverse chronological order. Match the version notation used by the
+  current release metadata and changelog, for example `3.0.2` or `3.0.0rc4`.
 - Inside each version use only: `### Added`, `### Changed`, `### Deprecated`,
   `### Removed`, `### Fixed`, and `### Security`.
 - For breaking changes, keep one of those headings and prefix the bullet with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,9 @@ into the legacy one-entry-per-location design.
 
 Migration and registry identity are high-risk compatibility surfaces.
 
-- Do not modify v2-to-v3 migration logic unless the task fixes a demonstrated
-  migration bug or explicitly requires a migration change.
+- Do not modify v2-to-v3 migration logic unless fixing a demonstrated migration
+  bug. If a broader task appears to require it, report that discrepancy before
+  changing migration behavior.
 - Preserve existing `entity_id`, `unique_id`, device associations, dashboards,
   automations, and Recorder history across migration and reloads.
 - Do not change legacy entry IDs, location identity semantics, device

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,72 +1,247 @@
 # Repository Guidelines
 
-## Tooling
-- Tooling (CI, lint, and format) runs on the exact Python 3.14 patch in `.python-version`. Keep `requires-python = ">=3.14"` and Ruff `target-version = "py314"` until a dedicated Home Assistant compatibility change approves a new minor.
-- Ruff is the single tool for linting, import sorting, and formatting. Its exact validation version is declared in the PEP 735 `lint` dependency group; do not add a rolling Ruff requirement.
-- `[tool.uv].required-version` is the sole exact uv executable declaration. Use `uv lock --check` and `uv sync --locked --only-group <group>` for validation; commit generated `uv.lock` changes with reviewed dependency updates.
-- Required Lint, Tests, and modern Release validation are locked. The scheduled latest-Home-Assistant canary is intentionally fresh-resolving and advisory: it must not update pins or `uv.lock`, become required, or be used for Release decisions.
-- Ruff targets `py314`, line length 88, and stable formatting with preview disabled. Python 3.14 syntax must not be reported as invalid merely because it is unsupported by older Python versions.
-- Future stable Ruff versions may require mechanical formatting updates; this is intentional under the rolling tooling policy.
-- Tests use the exact pytest version declared in the PEP 735 `test`
-  dependency group on Python 3.14.
-- Home Assistant integration-surface tests should use
-  `pytest-homeassistant-custom-component` when practical, especially for config
-  flows, subentry flows, setup/unload, platform entity registration, services,
-  diagnostics, Repairs, registries, and migration behavior. Keep lightweight
-  unit/stub tests for pure parsing, API client behavior, redaction helpers,
-  malformed payload edge cases, and failure injection that is hard to express
-  through the real Home Assistant harness.
+These instructions apply to the entire repository unless a more specific nested
+`AGENTS.md` is added later.
 
-## Release & API boundaries
-- Do not change the integration version or changelog entries unless explicitly requested.
-- Do not rename entities, alter `unique_id` patterns, or modify translation keys unless explicitly requested.
-- Prefer minimal, focused diffs; avoid cosmetic refactors or large code moves.
+## Sources of truth and scope
 
-## Test and Defensive Coding Policy
-- Do not add defensive code or tests only because an arbitrary JSON shape could theoretically exist.
-- Add defensive handling or regression tests when they:
-  - protect public behavior or user-facing outputs,
-  - cover a real bug or previously observed failure,
-  - cover a new branch introduced by the change,
-  - prevent a likely exception from partially malformed upstream data,
-  - or document an intentional compatibility or migration behavior.
-- Prefer small, focused tests over large synthetic fixtures.
-- Avoid duplicating malformed-payload test cases when the same behavior is already covered by a smaller helper-level test.
-- Keep defensive parsing proportional to the upstream API contract; do not add broad schema validators unless the integration has observed real instability in that payload area.
-- When a review suggests hardening for a highly unlikely upstream shape, first decide whether the scenario is realistic enough to justify code and test complexity. If not, document the reasoning in the PR instead of expanding the code.
+- Treat the current repository code, tests, configuration, and workflows as the
+  source of truth. Old PR descriptions, release notes, prompts, and historical
+  architecture notes can be stale.
+- Before changing runtime architecture, migration, entity identity, diagnostics,
+  translations, or release behavior, inspect the current implementation and the
+  focused regression tests that protect it.
+- If a requested change conflicts with current code or tests, report the
+  discrepancy before expanding the scope.
+- Keep one focused objective per PR. Do not mix runtime, migration, release,
+  documentation, dependency/tooling, and cosmetic refactors unless they are
+  inseparable for correctness.
+- Prefer minimal diffs. Do not rename, reorder, move, or reformat unrelated code.
+
+## Project structure
+
+Pollen Levels is a Home Assistant custom integration distributed through HACS.
+
+- Integration code lives in `custom_components/pollenlevels/`.
+- Home Assistant integration-surface tests and focused unit tests live in
+  `tests/`; reusable API payloads belong in `tests/fixtures/`.
+- Release/validation helpers live in `scripts/`.
+- GitHub Actions workflows live in `.github/workflows/`.
+- The translation source of truth is
+  `custom_components/pollenlevels/translations/en.json`.
+
+Keep platform-specific behavior in its existing modules and preserve the
+coordinator-driven async design.
+
+## v3 architecture invariants
+
+The current storage/runtime model is deliberate and must not be flattened back
+into the legacy one-entry-per-location design.
+
+- One parent config entry represents one Google Pollen API key.
+- Each configured location is a Home Assistant config subentry of type
+  `location` under that parent.
+- The API key remains parent-scoped. Shared options such as update interval and
+  language remain parent-scoped.
+- Location title/name, latitude, longitude, and any migration-only legacy
+  identity belong to the location subentry.
+- Runtime state is per location: each loaded location has its own coordinator.
+- Sensors and the `Update now` button are location-scoped and must be registered
+  against the correct `config_subentry_id`.
+- Setup, unload, and reload behavior must keep both the `sensor` and `button`
+  platforms consistent with the configured subentries.
+- A local setup failure must not unnecessarily prevent healthy sibling locations
+  under the same parent from operating.
+- Use supported public Home Assistant APIs. Do not invent private hooks to work
+  around config-subentry lifecycle behavior.
+
+## Migration and identity safety
+
+Migration and registry identity are high-risk compatibility surfaces.
+
+- Do not modify v2-to-v3 migration logic unless the task fixes a demonstrated
+  migration bug or explicitly requires a migration change.
+- Preserve existing `entity_id`, `unique_id`, device associations, dashboards,
+  automations, and Recorder history across migration and reloads.
+- Do not change legacy entry IDs, location identity semantics, device
+  identifiers, `coordinator_identity_id()` / `coordinator_device_id()` behavior,
+  or registry reassociation logic without focused regression coverage.
+- Never delete or recreate registry objects merely to make a migration simpler
+  when they can be safely preserved or reassociated.
+- Migration changes require Home Assistant harness coverage for the affected
+  scenarios. At minimum consider: one legacy location; multiple locations
+  sharing one API key; locations using different API keys; merging a residual
+  legacy entry into an existing clean v3 parent; registry reassociation; and
+  retry/idempotency behavior.
+- Treat migration failures conservatively. If identity cannot be moved safely,
+  preserving the legacy state and allowing a retry is preferable to silent
+  history or registry loss.
+- User-facing migration/release documentation must continue to make backup and
+  downgrade implications explicit when relevant.
+
+## Runtime lifecycle and manual refresh
+
+- `pollenlevels.force_update` is a global service. It may refresh loaded active
+  locations, but it must not refresh runtime coordinators whose location
+  subentry has already been removed.
+- The per-location `Update now` button refreshes only its own coordinator.
+- Home Assistant may clean registry associations before in-memory runtime state
+  has been reloaded after a subentry deletion. Treat that temporary stale state
+  as an expected lifecycle condition rather than forcing unsupported hooks.
+- Sensor and button setup must skip stale runtime locations consistently.
+- Keep parent-level API requests serialized through the existing
+  `GooglePollenApiClient`; do not bypass its request lock, quota cooldown, retry,
+  or redaction behavior with ad-hoc HTTP calls.
+- Use Home Assistant's shared aiohttp session when creating the client. Keep
+  network I/O asynchronous, bounded by timeouts, and off the event-loop blocking
+  path.
+- Preserve cancellation semantics. Do not swallow `asyncio.CancelledError`.
+
+## Forecast and entity contracts
+
+- The Google Pollen forecast horizon is currently fixed to five days. Do not
+  reintroduce obsolete configurable forecast-day or legacy per-day `_d1` / `_d2`
+  entity modes as an unrelated change.
+- Forecast information stays on the base entities. Preserve the public forecast
+  attributes and semantics, including `forecast`, `tomorrow_*`, `d2_*`, `trend`,
+  and `expected_peak`, unless the task explicitly changes that contract.
+- Do not add/remove forecast entities, alter offsets, change state types, or
+  change stable unique-ID patterns as collateral cleanup.
+- Do not impose a hardcoded universal plant catalogue or a strict plant-code
+  whitelist. The API can expose region-specific plant codes, and the current
+  runtime must remain tolerant of supported upstream codes.
+- Keep defensive parsing proportional to the upstream API contract and observed
+  behavior. Do not add broad schema machinery for purely hypothetical payloads.
+
+## Diagnostics, privacy, and logging
+
+Privacy and support diagnostics are part of the public maintenance contract.
+
+- API keys must always be redacted from diagnostics, logs, exceptions, Repairs,
+  test fixtures, and PR/issue text.
+- Never log complete credential-bearing request URLs or precise coordinates.
+- Diagnostics may expose only deliberately reduced location information; current
+  coordinate examples are rounded to one decimal place.
+- Preserve `registry_summary` and `runtime_summary` unless an explicit diagnostic
+  contract change is requested.
+- `runtime_summary.stale_location_count` and stale location IDs exist to explain
+  temporary runtime state after subentry deletion; do not remove or repurpose
+  them casually.
+- Preserve failed-location diagnostics and their redaction semantics.
+- `async_get_config_entry_diagnostics()` must not perform network I/O.
+
+## Tooling and coding style
+
+Use the repository's current locked toolchain rather than remembered versions
+from older releases.
+
+- Use the exact Python patch from `.python-version` for local/CI tooling. The
+  project runtime floor remains `requires-python = ">=3.14"` unless a dedicated
+  compatibility change updates it.
+- Use the exact uv version declared in `[tool.uv].required-version`.
+- Ruff is the single linter, import sorter, and formatter. Do not add Black back
+  unless a dedicated tooling change explicitly reverses that decision.
+- Ruff targets Python 3.14, line length 88, double quotes, and stable formatting
+  with preview disabled; `pyproject.toml` is authoritative.
+- Use modern Python typing: PEP 604 unions and built-in generics where
+  applicable. Prefer `collections.abc` for runtime collection protocols.
+- Keep imports Ruff/isort-clean. `custom_components.pollenlevels` is first-party.
+- All code comments and docstrings must be in English.
+- Repository-facing technical documentation, README text, FAQ text, PR text, and
+  CHANGELOG entries should be in English unless a task explicitly requests
+  another language.
+- Do not use `print()`. Use `_LOGGER` without exposing secrets or precise
+  location data.
+
+## Translation and public API stability
+
+- `custom_components/pollenlevels/translations/en.json` is the translation source
+  of truth. Keep every bundled locale synchronized with its keyset.
+- Do not add or rely on `strings.json` in this custom integration.
+- Do not introduce `%key:` translation references.
+- Do not rename existing translation keys, services/actions, entity IDs, unique
+  IDs, device identifiers, or other public keys without an explicit requirement
+  and appropriate compatibility tests.
+- Keep `services.yaml` and translation/service behavior synchronized when the
+  public service contract changes.
+
+## Testing and defensive coding policy
+
+- Write pytest tests named `test_<behavior>` in the matching `tests/test_*.py`
+  module.
+- Prefer `pytest-homeassistant-custom-component` for Home Assistant integration
+  surfaces such as config/subentry flows, setup/unload/reload, platform entity
+  registration, services, diagnostics, Repairs, registries, and migration.
+- Keep lightweight unit tests for pure parsing, API-client behavior, redaction
+  helpers, malformed payload edges, and targeted failure injection.
+- Add defensive handling or regression tests when they protect public behavior,
+  cover a real or observed failure, cover a new branch, prevent a likely
+  exception from partially malformed upstream data, or document intentional
+  compatibility/migration behavior.
+- Do not add defensive code or tests solely because an arbitrary JSON shape can
+  be imagined. Prefer the smallest fixture that demonstrates the contract.
+- When touching subentry lifecycle or manual refresh behavior, cover active vs
+  stale locations, correct subentry association, sibling isolation, and
+  unload/reload behavior.
+- When touching diagnostics, cover redaction and registry/runtime summaries.
+- When touching identity or migration, use focused Home Assistant harness tests
+  and verify registry associations explicitly.
+
+## Build, test, and validation commands
+
+Use the locked commands reflected by the current repository configuration:
+
+- `uv lock --check`
+- `uv sync --locked --only-group lint`
+- `uv run --locked --no-sync ruff check .`
+- `uv run --locked --no-sync ruff format --check .`
+- `uv sync --locked --only-group test`
+- `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q`
+
+Run the narrowest relevant tests while developing, then the complete required
+suite before merge. Use `python -m compileall` as required by the current CI or
+release workflow for the files in scope.
+
+Hosted validation currently includes the locked Lint, Tests, Package Test,
+Workflow Security, hassfest, HACS validation, and CodeQL gates where configured.
+The scheduled latest-Home-Assistant compatibility canary is intentionally
+fresh-resolving and advisory; do not treat it as a replacement for locked merge
+or Release validation.
+
+## Commit, PR, and release discipline
+
+- Use focused Conventional Commit subjects, for example
+  `fix(client): honor quota cooldown` or `test: cover subentry removal`.
+- PRs should explain the behavior change, scope, risks, and validation performed;
+  link the owning issue when one exists.
+- Do not create tags or GitHub releases from a normal implementation PR.
+- Do not change `custom_components/pollenlevels/manifest.json`, the project
+  version in `pyproject.toml`, or add a release CHANGELOG entry unless the task is
+  explicitly a release/version PR.
+- Keep release-only PRs limited to release metadata and the exact release notes
+  unless a separate fix is required first.
+- Do not combine an unrelated runtime fix with migration, tooling, broad docs,
+  dependency upgrades, or release preparation.
 
 ## Changelog / `CHANGELOG.md`
-- This section is the single source of truth for the changelog style. Ignore external style guides when they conflict with these rules.
-- Do NOT add any new boilerplate, intro text or `## [Unreleased]` section automatically. If such sections already exist, leave them and only edit their content when explicitly requested.
-- Version headings must use the pattern `## [version] - YYYY-MM-DD` (ASCII hyphen) and releases must stay in reverse chronological order. Use SemVer identifiers such as `1.8.2`, `1.8.2-rc1`, `1.8.1-alpha1`.
-- Inside each version, use only these headings: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`. Prefer `Changed` for documentation-only updates.
-- For breaking changes, keep one of the allowed section headings above and
-  prefix the bullet with `**Breaking change:**`; do not add a separate
-  `### Breaking Changes` heading.
-- Each change must be a `- ` bullet. Wrap long bullets around 80–100 characters with indented continuation lines; do NOT insert blank lines inside a bullet and avoid `<br>` or trailing double spaces.
-- Keep diffs minimal: never reflow or rewrap unrelated text, and never rename existing headings unless they clearly violate these rules.
-- If comparison links exist at the bottom of the changelog, keep the existing style and only extend it for new versions of this repository.
 
-## Style and Documentation
-- All code comments, README entries, and changelog notes **must be written in English**.
-- Keep imports tidy—remove unused symbols and respect the Ruff isort grouping so the Home Assistant package stays first-party under `custom_components/pollenlevels`.
-- The translation source of truth is `custom_components/pollenlevels/translations/en.json`.
-- Keep all other locale files synchronized with that keyset.
-- Do not add or rely on a `strings.json` file.
-- Do not introduce `%key:` translation references in this custom repository.
+This section is the repository source of truth for changelog style.
 
-
-## Integration Architecture
-- This repository hosts the custom integration **Pollen Levels for Home Assistant**, distributed through **HACS**.
-- Preserve the current coordinator-driven architecture under `custom_components/pollenlevels` when extending functionality. Study the existing setup (`__init__.py`, platform files, and helpers) and mirror their async patterns, error handling, and notification logic.
-- When implementing features, align with Home Assistant best practices (ConfigEntry setup, `DataUpdateCoordinator`, platform separation) and avoid introducing blocking I/O in the event loop.
-
-## Verification
-- Ensure the integration still loads within Home Assistant with the existing config flows and maintains parity with the current logic paths for entity updates and notifications.
-- Before submitting changes, run the following checks:
-  - `uv lock --check`
-  - `uv sync --locked --only-group lint`
-  - `uv run --locked --no-sync ruff check .`
-  - `uv run --locked --no-sync ruff format --check .`
-  - `uv sync --locked --only-group test`
-  - `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q`
+- Do not add boilerplate, intro text, or an `## [Unreleased]` section
+  automatically. If such a section already exists, leave it unless the task
+  explicitly changes it.
+- Version headings use `## [version] - YYYY-MM-DD` with an ASCII hyphen and stay
+  in reverse chronological order. Use SemVer identifiers such as `3.0.2`,
+  `3.0.0-rc1`, or `3.0.0-alpha1` according to the repository's established
+  release naming.
+- Inside each version use only: `### Added`, `### Changed`, `### Deprecated`,
+  `### Removed`, `### Fixed`, and `### Security`.
+- For breaking changes, keep one of those headings and prefix the bullet with
+  `**Breaking change:**`; do not add a separate `### Breaking Changes` heading.
+- Each change is a `- ` bullet. Wrap long bullets around 80-100 characters with
+  indented continuation lines; do not insert blank lines inside a bullet or use
+  `<br>`/trailing double spaces.
+- Keep diffs minimal: never reflow unrelated historical entries or rename
+  existing headings unless they clearly violate these rules.
+- If comparison links exist at the bottom of the changelog, preserve the
+  existing style and extend it only when required by a release task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ into the legacy one-entry-per-location design.
   `location` under that parent.
 - The API key remains parent-scoped. Shared options such as update interval and
   language remain parent-scoped.
+- Legacy `forecast_days` and `create_forecast_sensors` keys are cleanup-only
+  compatibility data from older releases; do not restore them as active options.
 - Location title/name, latitude, longitude, and any migration-only legacy
   identity belong to the location subentry.
 - Runtime state is per location: each loaded location has its own coordinator.
@@ -70,8 +72,9 @@ Migration and registry identity are high-risk compatibility surfaces.
   when they can be safely preserved or reassociated.
 - Migration changes require Home Assistant harness coverage for the affected
   scenarios. At minimum consider: one legacy location; multiple locations
-  sharing one API key; locations using different API keys; merging a residual
-  legacy entry into an existing clean v3 parent; registry reassociation; and
+  sharing one API key; locations using different API keys; mixed same-key and
+  different-key entries; a parent without locations; merging a residual legacy
+  entry into an existing clean v3 parent; registry reassociation; and
   retry/idempotency behavior.
 - Treat migration failures conservatively. If identity cannot be moved safely,
   preserving the legacy state and allowing a retry is preferable to silent
@@ -105,8 +108,8 @@ Migration and registry identity are high-risk compatibility surfaces.
 - Forecast information stays on the base entities. Preserve the public forecast
   attributes and semantics, including `forecast`, `tomorrow_*`, `d2_*`, `trend`,
   and `expected_peak`, unless the task explicitly changes that contract.
-- Do not add/remove forecast entities, alter offsets, change state types, or
-  change stable unique-ID patterns as collateral cleanup.
+- Do not introduce separate forecast entities, alter forecast offsets or state
+  types, or change stable unique-ID patterns as collateral cleanup.
 - Do not impose a hardcoded universal plant catalogue or a strict plant-code
   whitelist. The API can expose region-specific plant codes, and the current
   runtime must remain tolerant of supported upstream codes.
@@ -137,9 +140,10 @@ Privacy and support diagnostics are part of the public maintenance contract.
 Use the repository's current locked toolchain rather than remembered versions
 from older releases.
 
-- Use the exact Python patch from `.python-version` for local/CI tooling. The
-  project runtime floor remains `requires-python = ">=3.14"` unless a dedicated
-  compatibility change updates it.
+- Use the exact Python patch from `.python-version` for local development and
+  modern CI parity. The package metadata floor remains `requires-python =
+  ">=3.14"`; do not infer support for every 3.14 patch when the pinned Home
+  Assistant harness requires a newer patch.
 - Use the exact uv version declared in `[tool.uv].required-version`.
 - Ruff is the single linter, import sorter, and formatter. Do not add Black back
   unless a dedicated tooling change explicitly reverses that decision.
@@ -198,17 +202,24 @@ Use the locked commands reflected by the current repository configuration:
 - `uv run --locked --no-sync ruff check .`
 - `uv run --locked --no-sync ruff format --check .`
 - `uv sync --locked --only-group test`
+- `uv run --locked --no-sync python -m compileall -q custom_components tests`
 - `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q`
 
 Run the narrowest relevant tests while developing, then the complete required
-suite before merge. Use `python -m compileall` as required by the current CI or
-release workflow for the files in scope.
+suite before merge.
 
 Hosted validation currently includes the locked Lint, Tests, Package Test,
 Workflow Security, hassfest, HACS validation, and CodeQL gates where configured.
 The scheduled latest-Home-Assistant compatibility canary is intentionally
 fresh-resolving and advisory; do not treat it as a replacement for locked merge
 or Release validation.
+
+When editing GitHub Actions, preserve the repository's supply-chain and workflow
+safety conventions: minimal `permissions`, appropriate `concurrency`, external
+actions pinned to reviewed full commit SHAs with readable version comments,
+`.python-version` via `python-version-file`, uv from `pyproject.toml`, and
+`shell: bash` for steps using `set -euo pipefail`. Keep actionlint and zizmor
+blocking and do not add broad security ignores to make a workflow pass.
 
 ## Commit, PR, and release discipline
 
@@ -218,10 +229,18 @@ or Release validation.
   link the owning issue when one exists.
 - Do not create tags or GitHub releases from a normal implementation PR.
 - Do not change `custom_components/pollenlevels/manifest.json`, the project
-  version in `pyproject.toml`, or add a release CHANGELOG entry unless the task is
-  explicitly a release/version PR.
+  version in `pyproject.toml`, or the local project version in `uv.lock` unless
+  the task is explicitly a release/version PR.
+- Preserve manifest identity fields such as `domain`, `integration_type`, and
+  `iot_class` unless a dedicated compatibility change explicitly requires them.
+- A normal stable release-only PR should normally modify exactly
+  `CHANGELOG.md`, `custom_components/pollenlevels/manifest.json`,
+  `pyproject.toml`, and `uv.lock`, following `RELEASING.md`. The manifest,
+  project, and local lockfile versions must stay synchronized.
 - Keep release-only PRs limited to release metadata and the exact release notes
   unless a separate fix is required first.
+- Let the Release workflow derive and create the release tag after validation;
+  do not manually create or move tags to bypass the documented release path.
 - Do not combine an unrelated runtime fix with migration, tooling, broad docs,
   dependency upgrades, or release preparation.
 
@@ -239,9 +258,9 @@ This section is the repository source of truth for changelog style.
   `### Removed`, `### Fixed`, and `### Security`.
 - For breaking changes, keep one of those headings and prefix the bullet with
   `**Breaking change:**`; do not add a separate `### Breaking Changes` heading.
-- Each change uses a bullet line that starts with a hyphen. Wrap long bullets
-  around 80-100 characters with indented continuation lines; do not insert blank
-  lines inside a bullet or use `<br>`/trailing double spaces.
+- Each change uses a hyphen followed by one space as the Markdown bullet marker.
+  Wrap long bullets around 80-100 characters with indented continuation lines;
+  do not insert blank lines inside a bullet or use `<br>`/trailing double spaces.
 - Keep diffs minimal: never reflow unrelated historical entries or rename
   existing headings unless they clearly violate these rules.
 - If comparison links exist at the bottom of the changelog, preserve the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ from older releases.
   with preview disabled; `pyproject.toml` is authoritative.
 - Use modern Python typing: PEP 604 unions and built-in generics where
   applicable. Prefer `collections.abc` for runtime collection protocols.
-- Keep imports Ruff/isort-clean. `custom_components/pollenlevels` is first-party.
+- Keep imports Ruff/isort-clean. `custom_components.pollenlevels` is first-party.
 - All code comments and docstrings must be in English.
 - Repository-facing technical documentation, README text, FAQ text, PR text, and
   CHANGELOG entries should be in English unless a task explicitly requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,9 +239,9 @@ This section is the repository source of truth for changelog style.
   `### Removed`, `### Fixed`, and `### Security`.
 - For breaking changes, keep one of those headings and prefix the bullet with
   `**Breaking change:**`; do not add a separate `### Breaking Changes` heading.
-- Each change is a `- ` bullet. Wrap long bullets around 80-100 characters with
-  indented continuation lines; do not insert blank lines inside a bullet or use
-  `<br>`/trailing double spaces.
+- Each change uses a bullet line that starts with a hyphen. Wrap long bullets
+  around 80-100 characters with indented continuation lines; do not insert blank
+  lines inside a bullet or use `<br>`/trailing double spaces.
 - Keep diffs minimal: never reflow unrelated historical entries or rename
   existing headings unless they clearly violate these rules.
 - If comparison links exist at the bottom of the changelog, preserve the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,20 +73,21 @@ Migration and registry identity are high-risk compatibility surfaces.
 - Migration changes require Home Assistant harness coverage for the affected
   scenarios. At minimum consider: one legacy location; multiple locations
   sharing one API key; locations using different API keys; mixed same-key and
-  different-key entries; a parent without locations; merging a residual legacy
-  entry into an existing clean v3 parent; registry reassociation; and
-  retry/idempotency behavior.
+  different-key entries; invalid or corrupt stored location data; a parent
+  without locations; merging a residual legacy entry into an existing clean v3
+  parent; registry reassociation; retry/idempotency behavior; and prerelease
+  upgrade paths when applicable.
 - Treat migration failures conservatively. If identity cannot be moved safely,
   preserving the legacy state and allowing a retry is preferable to silent
   history or registry loss.
-- User-facing migration/release documentation must continue to make backup and
-  downgrade implications explicit when relevant.
+- For v2-to-v3 user-facing migration guidance, keep the mandatory backup warning
+  and state that downgrade to 2.x is unsupported without restoring that backup.
 
 ## Runtime lifecycle and manual refresh
 
-- `pollenlevels.force_update` is a global service. It may refresh loaded active
-  locations, but it must not refresh runtime coordinators whose location
-  subentry has already been removed.
+- `pollenlevels.force_update` is a global service with an empty payload contract.
+  It may refresh loaded active locations, but it must not refresh runtime
+  coordinators whose location subentry has already been removed.
 - The per-location `Update now` button refreshes only its own coordinator.
 - Home Assistant may clean registry associations before in-memory runtime state
   has been reloaded after a subentry deletion. Treat that temporary stale state
@@ -141,10 +142,16 @@ Use the repository's current locked toolchain rather than remembered versions
 from older releases.
 
 - Use the exact Python patch from `.python-version` for local development and
-  modern CI parity. The package metadata floor remains `requires-python =
-  ">=3.14"`; do not infer support for every 3.14 patch when the pinned Home
-  Assistant harness requires a newer patch.
+  modern CI parity. The package metadata keeps `requires-python` at `>=3.14`;
+  do not infer support for every 3.14 patch when the pinned Home Assistant
+  harness requires a newer patch.
+- Repository development and test validation use Linux or Linux containers. On
+  Windows, use WSL2; native Windows Python/pytest is outside the validation
+  contract.
 - Use the exact uv version declared in `[tool.uv].required-version`.
+- Keep direct validation dependencies exact and the committed `uv.lock`
+  authoritative. Do not loosen pins or fresh-resolve dependencies as collateral
+  work.
 - Ruff is the single linter, import sorter, and formatter. Do not add Black back
   unless a dedicated tooling change explicitly reverses that decision.
 - Ruff targets Python 3.14, line length 88, double quotes, and stable formatting
@@ -180,6 +187,7 @@ from older releases.
   registration, services, diagnostics, Repairs, registries, and migration.
 - Keep lightweight unit tests for pure parsing, API-client behavior, redaction
   helpers, malformed payload edges, and targeted failure injection.
+- Tests must not depend on real network calls or real API keys.
 - Add defensive handling or regression tests when they protect public behavior,
   cover a real or observed failure, cover a new branch, prevent a likely
   exception from partially malformed upstream data, or document intentional

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ from older releases.
   with preview disabled; `pyproject.toml` is authoritative.
 - Use modern Python typing: PEP 604 unions and built-in generics where
   applicable. Prefer `collections.abc` for runtime collection protocols.
-- Keep imports Ruff/isort-clean. `custom_components.pollenlevels` is first-party.
+- Keep imports Ruff/isort-clean. `custom_components/pollenlevels` is first-party.
 - All code comments and docstrings must be in English.
 - Repository-facing technical documentation, README text, FAQ text, PR text, and
   CHANGELOG entries should be in English unless a task explicitly requests


### PR DESCRIPTION
## Summary

- update the existing root `AGENTS.md` rather than creating a second agent-instructions file
- make the current v3 parent/subentry architecture and per-location runtime model explicit
- add migration and registry-identity guardrails to protect entity IDs, unique IDs, devices, automations, and Recorder history
- document stale-subentry behavior for sensors, buttons, diagnostics, and the global `pollenlevels.force_update` service
- preserve the fixed five-day forecast/base-entity contract and prevent accidental resurrection of legacy `_d1` / `_d2` entity modes
- strengthen diagnostics/privacy requirements, including API-key redaction, one-decimal approximate coordinates, `registry_summary`, and `runtime_summary`
- align tooling guidance with the current locked uv/Python/Ruff-only setup and current hosted validation lanes
- retain and integrate the existing translation, defensive-testing, PR/release, and CHANGELOG guidance

## Why

The repository already had a long-lived root `AGENTS.md`, but its guidance had not fully caught up with the current v3 storage/runtime architecture and the compatibility invariants now protected by the Home Assistant harness tests.

This PR makes those constraints explicit so Codex and other repository agents do not infer legacy behavior from older PRs or prompts, especially around migration, config subentries, entity identity, stale runtime locations, forecast entities, and release boundaries.

## Scope

Documentation/instructions only. The only changed file is `AGENTS.md`.

No runtime, migration, entity identity, services, translations, diagnostics payload, workflow behavior, dependency, version, or CHANGELOG changes are included.

## Validation

- verified that current `main` contains exactly one `AGENTS.md`, at the repository root
- reviewed the guidance against current `__init__.py`, `runtime.py`, `sensor.py`, `button.py`, `client.py`, `diagnostics.py`, migration harness coverage, `pyproject.toml`, and current workflow inventory
- confirmed Ruff is the current formatter/linter/import sorter and Black is no longer part of the repository toolchain
- confirmed the current runtime uses one parent per API key, location subentries, per-location coordinators/entities, stale-runtime filtering, and fixed five-day forecast attributes
- no local executable checks were run because this PR changes Markdown instructions only; repository CI remains authoritative


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance with detailed standards for project structure, configuration, migrations, runtime behavior, diagnostics, translations, testing, validation, and release practices.
  * Added guidance covering configuration architecture, identity safety, lifecycle and refresh behavior, data contracts, privacy considerations, tooling, and changelog formatting.
  * Consolidated previous development policies into a more comprehensive, consistent reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->