### PR TITLE
chore: remove obsolete DataUpdateCoordinator config_entry fallback

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -170,23 +170,11 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         }
         if config_entry is not None:
             coordinator_kwargs["config_entry"] = config_entry
-        try:
-            super().__init__(
-                hass,
-                _LOGGER,
-                **coordinator_kwargs,
-            )
-        except TypeError as err:
-            if "config_entry" not in coordinator_kwargs or "config_entry" not in str(
-                err
-            ):
-                raise
-            coordinator_kwargs.pop("config_entry")
-            super().__init__(
-                hass,
-                _LOGGER,
-                **coordinator_kwargs,
-            )
+        super().__init__(
+            hass,
+            _LOGGER,
+            **coordinator_kwargs,
+        )
         self.api_key = api_key
         self.lat = lat
         self.lon = lon

--- a/tests/_ha_stubs.py
+++ b/tests/_ha_stubs.py
@@ -287,9 +287,16 @@ def stub_update_coordinator_module(
 ) -> ModuleType:
     """Install a minimal update coordinator module with caller-provided types."""
 
+    class _ConfigEntryAwareDataUpdateCoordinator(data_update_coordinator):
+        """Mirror the supported Home Assistant coordinator config-entry keyword."""
+
+        def __init__(self, *args, config_entry=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.config_entry = config_entry
+
     module = ModuleType("homeassistant.helpers.update_coordinator")
     module.UpdateFailed = update_failed
-    module.DataUpdateCoordinator = data_update_coordinator
+    module.DataUpdateCoordinator = _ConfigEntryAwareDataUpdateCoordinator
     module.CoordinatorEntity = coordinator_entity
     _set_module(
         "homeassistant.helpers.update_coordinator", module, monkeypatch=monkeypatch

--- a/tests/test_coordinator_config_entry.py
+++ b/tests/test_coordinator_config_entry.py
@@ -1,0 +1,30 @@
+"""Tests for coordinator config-entry ownership."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.pollenlevels.coordinator import PollenDataUpdateCoordinator
+
+
+class _StubClient:
+    """Minimal client placeholder for coordinator construction."""
+
+
+def test_coordinator_keeps_explicit_config_entry(
+    hass: HomeAssistant,
+    ha_config_entry: ConfigEntry,
+) -> None:
+    """The coordinator should retain the parent config entry passed by setup."""
+    coordinator = PollenDataUpdateCoordinator(
+        hass=hass,
+        api_key="dummy",
+        lat=0.0,
+        lon=0.0,
+        hours=12,
+        language="en",
+        entry_id=ha_config_entry.entry_id,
+        client=_StubClient(),
+        config_entry=ha_config_entry,
+    )
+
+    assert coordinator.config_entry is ha_config_entry


### PR DESCRIPTION
## Summary

Remove the obsolete `TypeError` compatibility fallback around `DataUpdateCoordinator(..., config_entry=...)` in `PollenDataUpdateCoordinator`.

## Why

Pollen Levels currently supports Home Assistant 2026.3.0 and newer. Home Assistant 2026.3.0 already exposes the public `config_entry` keyword in `DataUpdateCoordinator.__init__`, so retrying construction without that keyword is outside the supported runtime contract.

The fallback was introduced in #183 while adding the real Home Assistant harness, as a compatibility path for older coordinator signatures. It is now technical debt and also masks an outdated lightweight test stub in `tests/test_init.py` that does not model the supported Home Assistant constructor accurately.

## Scope

- Keep the existing behavior where `config_entry` is omitted when the local optional argument is `None`.
- Remove only the `try`/`except TypeError` retry path from `PollenDataUpdateCoordinator.__init__`.
- Update the lightweight `tests/test_init.py` coordinator stub to accept the supported `config_entry` keyword.
- Add or adjust focused regression coverage to verify the parent config entry is passed through on the integration setup path.

## Out of scope

- Migration or registry logic.
- Entity/device identity.
- API client behavior.
- Config/subentry architecture.
- Release/version metadata or changelog changes.
- Unrelated test-stub cleanup.

## Acceptance criteria

- Coordinator construction makes a single `super().__init__()` call.
- Supported `config_entry` behavior is preserved for HA 2026.3+.
- No semantic change when the optional local `config_entry` argument is `None`.
- Focused tests pass.
- Full locked test/lint validation passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordinator initialization to reliably retain the configured Home Assistant entry.
  - Prevented initialization failures caused by differing coordinator configuration handling.

- **Tests**
  - Added coverage verifying that the configured Home Assistant entry is preserved during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->