### PR TITLE
refactor(coordinator): remove obsolete config entry fallback

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -170,23 +170,11 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         }
         if config_entry is not None:
             coordinator_kwargs["config_entry"] = config_entry
-        try:
-            super().__init__(
-                hass,
-                _LOGGER,
-                **coordinator_kwargs,
-            )
-        except TypeError as err:
-            if "config_entry" not in coordinator_kwargs or "config_entry" not in str(
-                err
-            ):
-                raise
-            coordinator_kwargs.pop("config_entry")
-            super().__init__(
-                hass,
-                _LOGGER,
-                **coordinator_kwargs,
-            )
+        super().__init__(
+            hass,
+            _LOGGER,
+            **coordinator_kwargs,
+        )
         self.api_key = api_key
         self.lat = lat
         self.lon = lon

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -62,6 +62,12 @@ async def test_ha_setup_unload_reload_smoke(
 
         assert ha_config_entry.state is ConfigEntryState.LOADED
         assert set(ha_config_entry.runtime_data.locations) == {"location-madrid"}
+        assert (
+            ha_config_entry.runtime_data.locations[
+                "location-madrid"
+            ].coordinator.config_entry
+            is ha_config_entry
+        )
         assert_fixed_forecast_days(captured_params)
 
         registry = er.async_get(hass)
@@ -80,6 +86,12 @@ async def test_ha_setup_unload_reload_smoke(
         assert await hass.config_entries.async_setup(ha_config_entry.entry_id)
         await hass.async_block_till_done()
         assert ha_config_entry.state is ConfigEntryState.LOADED
+        assert (
+            ha_config_entry.runtime_data.locations[
+                "location-madrid"
+            ].coordinator.config_entry
+            is ha_config_entry
+        )
 
 
 async def test_ha_expired_api_key_reload_preserves_registry_identity(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -176,9 +176,10 @@ class _StubCoordinatorEntity:
 
 
 class _StubDataUpdateCoordinator:
-    def __init__(self, hass, logger, *, name: str, update_interval):
+    def __init__(self, hass, logger, *, config_entry=None, name: str, update_interval):
         self.hass = hass
         self.logger = logger
+        self.config_entry = config_entry
         self.name = name
         self.update_interval = update_interval
         self.data = {"date": {}, "region": {}}
@@ -697,6 +698,7 @@ def test_setup_entry_numeric_string_coordinates_are_allowed(
     coordinator = entry.runtime_data.locations[entry.entry_id].coordinator
     assert coordinator.lat == pytest.approx(1.5)
     assert coordinator.lon == pytest.approx(2.5)
+    assert coordinator.config_entry is entry
 
 
 def test_setup_entry_boundary_coordinates_are_allowed(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -698,7 +698,6 @@ def test_setup_entry_numeric_string_coordinates_are_allowed(
     coordinator = entry.runtime_data.locations[entry.entry_id].coordinator
     assert coordinator.lat == pytest.approx(1.5)
     assert coordinator.lon == pytest.approx(2.5)
-    assert coordinator.config_entry is entry
 
 
 def test_setup_entry_boundary_coordinates_are_allowed(


### PR DESCRIPTION
## Summary

- Remove the unsupported-version `TypeError` retry around `DataUpdateCoordinator` initialization.
- Keep the existing behavior that omits `config_entry` when the integration argument is `None`.
- Align the local setup stub with the supported Home Assistant constructor and verify parent entry ownership through real setup and reload.

## Why

Pollen Levels supports Home Assistant 2026.3.0 and newer, where `DataUpdateCoordinator.__init__()` publicly accepts `config_entry`. The fallback originated with the HA harness work and continued to support an outdated lightweight test stub rather than a supported runtime.

## Impact

No user-facing behavior, migration, entity/device identity, API, config flow, metadata, or release changes.

## Validation

- `uv lock --check`
- `uv run --locked --no-sync ruff check .`
- `uv run --locked --no-sync ruff format --check .`
- `uv run --locked --no-sync python -m compileall -q custom_components tests`
- `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q tests/test_init.py tests/test_ha_init.py tests/test_sensor.py` — 178 passed
- `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q` — 641 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when setting up and reloading pollen level locations.
  * Ensured location data remains correctly associated with its configuration after initialization and reloads.
* **Tests**
  * Added coverage for configuration association during initial setup, unloading, and reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->