### PR TITLE
fix(sensor): align forecast state class with Home Assistant Core

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -277,8 +277,8 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
 
     # Keep forecast attributes available in live state but exclude from Recorder.
     _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
-    # Enable long-term statistics for numeric pollen index values
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    # Google exposes this value as current-day forecast data, not a measurement.
+    _attr_state_class: SensorStateClass | None = None
     # Hint the UI to show integers (does not affect recorder/statistics)
     _attr_suggested_display_precision = 0  # type: ignore[assignment]
     # Modern friendly name composition: Device name + Entity short name
@@ -482,7 +482,8 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
     _attr_translation_key = "overall_pollen_risk_today"
     _attr_icon = DEFAULT_ICON
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    # This summary is derived from the same current-day forecast values.
+    _attr_state_class: SensorStateClass | None = None
     _attr_suggested_display_precision = 0  # type: ignore[assignment]
 
     def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -72,6 +72,39 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
         )
 
 
+async def test_ha_forecast_derived_current_day_sensors_have_no_state_class(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Current-day forecast values should not claim measurement semantics."""
+    clear_integration_modules()
+    entry = ha_config_entry
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+    registry = er.async_get(hass)
+    entity_ids_by_unique_id = {
+        entity.unique_id: entity.entity_id
+        for entity in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if entity.domain == "sensor" and entity.config_subentry_id == "location-madrid"
+    }
+    identity_id = f"{entry.entry_id}_location-madrid"
+
+    for unique_id in (
+        f"{identity_id}_type_grass",
+        f"{identity_id}_overall_pollen_risk_today",
+    ):
+        state = hass.states.get(entity_ids_by_unique_id[unique_id])
+        assert state is not None
+        assert "state_class" not in state.attributes
+
+
 async def test_ha_button_press_refreshes_only_location_coordinator(
     hass: HomeAssistant,
     enable_custom_integrations: None,


### PR DESCRIPTION
## Summary

Align current-day pollen forecast sensors with Home Assistant Core sensor semantics.

Google Pollen API exposes these values through the daily forecast endpoint. Home Assistant defines `SensorStateClass.MEASUREMENT` for present-time measurements and explicitly excludes forecast/prediction values from that state class. The closest Core precedent, AccuWeather daily pollen forecast sensors, also leaves forecast day 0 without a state class.

Fixes #303.

## Changes

- Set `PollenSensor` state class explicitly to `None`.
- Set `OverallPollenRiskTodaySensor` state class explicitly to `None` because it is derived from the same current-day forecast values.
- Add a Home Assistant harness regression test proving both entity types expose no `state_class` attribute in live HA state.
- Preserve `_FORECAST_UNRECORDED_ATTRIBUTES` unchanged.

## User impact

- New Home Assistant long-term statistics will no longer be generated for these forecast-derived pollen states after this change.
- Ordinary Recorder state history remains subject to the user's Recorder configuration and retention policy.
- Existing long-term statistics are not deleted or modified by the integration.
- Home Assistant's native history visualization may change because state class influences frontend/statistics behavior.
- Entity IDs, unique IDs, device associations, forecast attributes, dashboard/template state values, and automations are unchanged.

## Scope protection

This PR intentionally does not change:

- v2-to-v3 migration or registry identity;
- coordinator/API parsing behavior;
- parent/subentry architecture;
- forecast offsets or public attributes;
- `pollenlevels.force_update` or per-location Update now buttons;
- Recorder configuration or existing statistics cleanup;
- release metadata or changelog.

Documentation/release notes for the LTS transition remain separate in accordance with the repository's focused-PR policy.

## Upstream references

- Home Assistant sensor state classes: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
- Home Assistant long-term statistics: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics
- Home Assistant Core AccuWeather sensor platform: https://github.com/home-assistant/core/blob/dev/homeassistant/components/accuweather/sensor.py
- Google Pollen forecast endpoint: https://developers.google.com/maps/documentation/pollen/reference/rest/v1/forecast/lookup

## Validation

- Added a real Home Assistant harness regression test in `tests/test_ha_platforms.py`.
- Branch diff is limited to `custom_components/pollenlevels/sensor.py` and `tests/test_ha_platforms.py`.
- Full hosted CI is expected to provide the locked repository validation before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected pollen forecast sensors so they no longer report an inapplicable measurement state class.
  - Improved compatibility with Home Assistant’s sensor metadata and statistics handling.

- **Tests**
  - Added coverage confirming current-day derived forecast sensors do not expose a state class after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->