### PR TITLE
test(config-flow): cover supported form variants and error recovery

### DIFF
--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -1,0 +1,170 @@
+"""Focused coverage tests for supported config-flow helper behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tests import test_config_flow as config_flow_tests
+
+config_flow_stubs = config_flow_tests.config_flow_stubs_fixture
+
+_MISSING = object()
+
+
+@pytest.mark.parametrize("value", [None, 123, "   "])
+def test_language_validator_rejects_invalid_input_types_and_blank_values(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+    value: object,
+) -> None:
+    """Language validation should reject non-strings and blank strings."""
+
+    with pytest.raises(config_flow_stubs.config_flow.vol.Invalid):
+        config_flow_stubs.config_flow.is_valid_language_code(value)
+
+
+def test_user_schema_preserves_submitted_location_default(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redisplayed user form should preserve the submitted location."""
+
+    module = config_flow_stubs.config_flow
+    submitted_location = {
+        config_flow_stubs.CONF_LATITUDE: 12.3456,
+        config_flow_stubs.CONF_LONGITUDE: -65.4321,
+    }
+    captured_defaults: list[object] = []
+    original_required = module.vol.Required
+
+    def _capture_required(key: object, **kwargs: object) -> object:
+        if key == config_flow_stubs.CONF_LOCATION:
+            captured_defaults.append(kwargs.get("default", _MISSING))
+        return original_required(key, **kwargs)
+
+    monkeypatch.setattr(module.vol, "Required", _capture_required)
+    hass = SimpleNamespace(
+        config=SimpleNamespace(
+            latitude=None,
+            longitude=None,
+            language="en",
+            location_name="Home",
+        )
+    )
+
+    module._build_step_user_schema(
+        hass,
+        {config_flow_stubs.CONF_LOCATION: submitted_location},
+    )
+
+    assert captured_defaults == [submitted_location]
+
+
+@pytest.mark.parametrize("builder", ["user", "subentry"])
+def test_location_schema_supports_missing_home_assistant_default(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+    monkeypatch: pytest.MonkeyPatch,
+    builder: str,
+) -> None:
+    """Location forms should render without a Home Assistant coordinate default."""
+
+    module = config_flow_stubs.config_flow
+    captured_defaults: list[object] = []
+    original_required = module.vol.Required
+
+    def _capture_required(key: object, **kwargs: object) -> object:
+        if key == config_flow_stubs.CONF_LOCATION:
+            captured_defaults.append(kwargs.get("default", _MISSING))
+        return original_required(key, **kwargs)
+
+    monkeypatch.setattr(module.vol, "Required", _capture_required)
+    hass = SimpleNamespace(
+        config=SimpleNamespace(
+            latitude=None,
+            longitude=None,
+            language="en",
+            location_name="Home",
+        )
+    )
+
+    if builder == "user":
+        module._build_step_user_schema(hass, {})
+    else:
+        module._build_location_subentry_schema(hass, {})
+
+    assert captured_defaults == [_MISSING]
+
+
+def test_duplicate_location_scan_ignores_unrelated_subentries(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+) -> None:
+    """Duplicate detection should skip non-location subentries and keep scanning."""
+
+    module = config_flow_stubs.config_flow
+    config_subentry = module.config_entries.ConfigSubentry
+    target_unique_id = "12.3456_-65.4321"
+    entry = config_flow_stubs.StubConfigEntry(
+        subentries={
+            "unrelated": config_subentry(
+                subentry_id="unrelated",
+                subentry_type="other",
+                unique_id=target_unique_id,
+            ),
+            "other-location": config_subentry(
+                subentry_id="other-location",
+                subentry_type="location",
+                unique_id="1.0000_2.0000",
+            ),
+            "target-location": config_subentry(
+                subentry_id="target-location",
+                subentry_type="location",
+                unique_id=target_unique_id,
+            ),
+        }
+    )
+
+    assert module._has_duplicate_location(entry, target_unique_id)
+
+
+def test_legacy_coordinate_validation_recovers_after_malformed_input(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy coordinate validation should recover on corrected resubmission."""
+
+    module = config_flow_stubs.config_flow
+    calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
+    flow = config_flow_stubs.PollenLevelsConfigFlow()
+    flow.hass = SimpleNamespace()
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            {
+                config_flow_stubs.CONF_API_KEY: "synthetic-api-key",
+                config_flow_stubs.CONF_LATITUDE: "north",
+                config_flow_stubs.CONF_LONGITUDE: 2.0,
+            }
+        )
+    )
+
+    assert errors == {"base": "invalid_coordinates"}
+    assert normalized is None
+    assert calls == []
+
+    errors, normalized = asyncio.run(
+        flow._async_validate_input(
+            {
+                config_flow_stubs.CONF_API_KEY: "synthetic-api-key",
+                config_flow_stubs.CONF_LATITUDE: 1.0,
+                config_flow_stubs.CONF_LONGITUDE: 2.0,
+            }
+        )
+    )
+
+    assert errors == {}
+    assert normalized is not None
+    assert normalized[config_flow_stubs.CONF_LATITUDE] == 1.0
+    assert normalized[config_flow_stubs.CONF_LONGITUDE] == 2.0
+    assert len(calls) == 1

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -97,6 +97,27 @@ def test_location_schema_supports_missing_home_assistant_default(
     assert captured_defaults == [_MISSING]
 
 
+def test_duplicate_location_scan_ignores_matching_unrelated_subentry(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+) -> None:
+    """A matching non-location subentry should not be treated as a duplicate."""
+
+    module = config_flow_stubs.config_flow
+    config_subentry = module.config_entries.ConfigSubentry
+    target_unique_id = "12.3456_-65.4321"
+    entry = config_flow_stubs.StubConfigEntry(
+        subentries={
+            "unrelated": config_subentry(
+                subentry_id="unrelated",
+                subentry_type="other",
+                unique_id=target_unique_id,
+            )
+        }
+    )
+
+    assert not module._has_duplicate_location(entry, target_unique_id)
+
+
 def test_duplicate_location_scan_ignores_unrelated_subentries(
     config_flow_stubs: config_flow_tests.ConfigFlowStubs,
 ) -> None:

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -134,7 +134,6 @@ def test_legacy_coordinate_validation_recovers_after_malformed_input(
 ) -> None:
     """Legacy coordinate validation should recover on corrected resubmission."""
 
-    module = config_flow_stubs.config_flow
     calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
     flow = config_flow_stubs.PollenLevelsConfigFlow()
     flow.hass = SimpleNamespace()
@@ -167,4 +166,77 @@ def test_legacy_coordinate_validation_recovers_after_malformed_input(
     assert normalized is not None
     assert normalized[config_flow_stubs.CONF_LATITUDE] == 1.0
     assert normalized[config_flow_stubs.CONF_LONGITUDE] == 2.0
+    assert len(calls) == 1
+
+
+def test_location_reconfigure_step_recovers_after_invalid_coordinates(
+    config_flow_stubs: config_flow_tests.ConfigFlowStubs,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defensive reconfigure branch should accept corrected direct input."""
+
+    module = config_flow_stubs.config_flow
+    config_subentry = module.config_entries.ConfigSubentry
+    subentry = config_subentry(
+        subentry_id="location-madrid",
+        subentry_type="location",
+        title="Madrid",
+        unique_id="40.4168_-3.7038",
+        data={
+            config_flow_stubs.CONF_LATITUDE: 40.4168,
+            config_flow_stubs.CONF_LONGITUDE: -3.7038,
+        },
+    )
+    entry = config_flow_stubs.StubConfigEntry(
+        data={config_flow_stubs.CONF_API_KEY: "synthetic-api-key"},
+        subentries={subentry.subentry_id: subentry},
+    )
+    flow = module.PollenLevelsLocationSubentryFlow()
+    flow.hass = SimpleNamespace(
+        config=SimpleNamespace(
+            latitude=40.4168,
+            longitude=-3.7038,
+            language="en",
+            location_name="Home",
+        ),
+        config_entries=SimpleNamespace(async_schedule_reload=lambda _entry_id: None),
+    )
+    flow._get_entry = lambda: entry  # type: ignore[method-assign]
+    flow._get_reconfigure_subentry = lambda: subentry  # type: ignore[method-assign]
+
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                config_flow_stubs.CONF_NAME: "Broken",
+                config_flow_stubs.CONF_LOCATION: {
+                    config_flow_stubs.CONF_LATITUDE: "north",
+                    config_flow_stubs.CONF_LONGITUDE: 2.1686,
+                },
+            }
+        )
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {
+        config_flow_stubs.CONF_LOCATION: "invalid_coordinates"
+    }
+
+    calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
+    result = asyncio.run(
+        flow.async_step_reconfigure(
+            {
+                config_flow_stubs.CONF_NAME: "Barcelona",
+                config_flow_stubs.CONF_LOCATION: {
+                    config_flow_stubs.CONF_LATITUDE: 41.3874,
+                    config_flow_stubs.CONF_LONGITUDE: 2.1686,
+                },
+            }
+        )
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reconfigure_successful"
+    assert subentry.title == "Barcelona"
+    assert subentry.unique_id == "41.3874_2.1686"
     assert len(calls) == 1

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -188,6 +188,8 @@ def test_legacy_coordinate_validation_recovers_after_malformed_input(
     assert normalized[config_flow_stubs.CONF_LATITUDE] == 1.0
     assert normalized[config_flow_stubs.CONF_LONGITUDE] == 2.0
     assert len(calls) == 1
+    assert calls[0]["latitude"] == 1.0
+    assert calls[0]["longitude"] == 2.0
 
 
 def test_location_reconfigure_step_recovers_after_invalid_coordinates(
@@ -213,6 +215,7 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
         subentries={subentry.subentry_id: subentry},
     )
     scheduled_reloads: list[str] = []
+    calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
     flow = module.PollenLevelsLocationSubentryFlow()
     flow.hass = SimpleNamespace(
         config=SimpleNamespace(
@@ -241,8 +244,9 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
     assert result["type"] == "form"
     assert result["step_id"] == "reconfigure"
     assert result["errors"] == {config_flow_stubs.CONF_LOCATION: "invalid_coordinates"}
+    assert calls == []
+    assert scheduled_reloads == []
 
-    calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
     result = asyncio.run(
         flow.async_step_reconfigure(
             {
@@ -265,3 +269,5 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
     }
     assert scheduled_reloads == [entry.entry_id]
     assert len(calls) == 1
+    assert calls[0]["latitude"] == 41.3874
+    assert calls[0]["longitude"] == 2.1686

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -218,9 +218,7 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
 
     assert result["type"] == "form"
     assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {
-        config_flow_stubs.CONF_LOCATION: "invalid_coordinates"
-    }
+    assert result["errors"] == {config_flow_stubs.CONF_LOCATION: "invalid_coordinates"}
 
     calls = config_flow_tests._patch_client_fetch(config_flow_stubs, monkeypatch)
     result = asyncio.run(

--- a/tests/test_config_flow_coverage.py
+++ b/tests/test_config_flow_coverage.py
@@ -191,6 +191,7 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
         data={config_flow_stubs.CONF_API_KEY: "synthetic-api-key"},
         subentries={subentry.subentry_id: subentry},
     )
+    scheduled_reloads: list[str] = []
     flow = module.PollenLevelsLocationSubentryFlow()
     flow.hass = SimpleNamespace(
         config=SimpleNamespace(
@@ -199,7 +200,7 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
             language="en",
             location_name="Home",
         ),
-        config_entries=SimpleNamespace(async_schedule_reload=lambda _entry_id: None),
+        config_entries=SimpleNamespace(async_schedule_reload=scheduled_reloads.append),
     )
     flow._get_entry = lambda: entry  # type: ignore[method-assign]
     flow._get_reconfigure_subentry = lambda: subentry  # type: ignore[method-assign]
@@ -237,4 +238,9 @@ def test_location_reconfigure_step_recovers_after_invalid_coordinates(
     assert result["reason"] == "reconfigure_successful"
     assert subentry.title == "Barcelona"
     assert subentry.unique_id == "41.3874_2.1686"
+    assert subentry.data == {
+        config_flow_stubs.CONF_LATITUDE: 41.3874,
+        config_flow_stubs.CONF_LONGITUDE: 2.1686,
+    }
+    assert scheduled_reloads == [entry.entry_id]
     assert len(calls) == 1

--- a/tests/test_ha_config_flow_coverage.py
+++ b/tests/test_ha_config_flow_coverage.py
@@ -222,54 +222,6 @@ async def test_ha_location_subentry_user_recovers_after_invalid_parent_api_key(
     assert len(entry.subentries) == 1
 
 
-async def test_ha_location_subentry_reconfigure_recovers_after_invalid_coordinates(
-    hass: HomeAssistant,
-    enable_custom_integrations: None,
-    socket_enabled: None,
-    ha_config_entry: Any,
-    google_pollen_5_day_payload: dict[str, Any],
-) -> None:
-    """Location reconfigure should accept corrected coordinates on retry."""
-
-    clear_integration_modules()
-    ha_config_entry.add_to_hass(hass)
-    subentry = ha_config_entry.subentries["location-madrid"]
-
-    result = await hass.config_entries.subentries.async_init(
-        (ha_config_entry.entry_id, SUBENTRY_TYPE_LOCATION),
-        context={
-            "source": SOURCE_RECONFIGURE,
-            "subentry_id": subentry.subentry_id,
-        },
-    )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"],
-        _location_input(name="Broken", latitude="north", longitude=2.1686),
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {CONF_LOCATION: "invalid_coordinates"}
-
-    async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
-        result = await hass.config_entries.subentries.async_configure(
-            result["flow_id"],
-            _location_input(
-                name="Barcelona",
-                latitude=41.3874,
-                longitude=2.1686,
-            ),
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    updated = ha_config_entry.subentries["location-madrid"]
-    assert updated.title == "Barcelona"
-    assert updated.unique_id == "41.3874_2.1686"
-
-
 async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_key(
     hass: HomeAssistant,
     enable_custom_integrations: None,

--- a/tests/test_ha_config_flow_coverage.py
+++ b/tests/test_ha_config_flow_coverage.py
@@ -108,6 +108,7 @@ async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordina
     socket_enabled: None,
     fake_api_key: str,
     google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
     source: str,
     reason: str,
 ) -> None:
@@ -147,6 +148,10 @@ async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordina
         version=6,
     )
     entry.add_to_hass(hass)
+    scheduled_reloads: list[str] = []
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", scheduled_reloads.append
+    )
 
     result = await _start_parent_api_key_flow(entry, hass, source)
     assert result["type"] is FlowResultType.FORM
@@ -162,6 +167,7 @@ async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordina
     assert result["reason"] == reason
     assert entry.data == {CONF_API_KEY: new_api_key}
     assert entry.unique_id == api_key_unique_id(new_api_key)
+    assert scheduled_reloads == [entry.entry_id]
 
 
 @pytest.mark.parametrize(
@@ -229,6 +235,7 @@ async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_ke
     fake_api_key: str,
     sample_location_subentry_data: dict[str, Any],
     google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Location reconfigure should recover after the parent key is repaired."""
 
@@ -245,6 +252,10 @@ async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_ke
     )
     entry.add_to_hass(hass)
     subentry = entry.subentries["location-madrid"]
+    scheduled_reloads: list[str] = []
+    monkeypatch.setattr(
+        hass.config_entries, "async_schedule_reload", scheduled_reloads.append
+    )
 
     result = await hass.config_entries.subentries.async_init(
         (entry.entry_id, SUBENTRY_TYPE_LOCATION),
@@ -279,4 +290,11 @@ async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_ke
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert entry.subentries["location-madrid"].title == "Barcelona"
+    updated = entry.subentries["location-madrid"]
+    assert updated.title == "Barcelona"
+    assert updated.unique_id == "41.3874_2.1686"
+    assert dict(updated.data) == {
+        CONF_LATITUDE: 41.3874,
+        CONF_LONGITUDE: 2.1686,
+    }
+    assert scheduled_reloads == [entry.entry_id]

--- a/tests/test_ha_config_flow_coverage.py
+++ b/tests/test_ha_config_flow_coverage.py
@@ -73,26 +73,45 @@ async def test_ha_user_flow_recovers_after_invalid_language(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input
-    )
+    invalid_params: list[dict[str, Any]] = []
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, invalid_params)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {CONF_LANGUAGE_CODE: "invalid_language_format"}
+    assert invalid_params == []
 
     corrected_input = {**user_input, CONF_LANGUAGE_CODE: "es"}
+    corrected_params: list[dict[str, Any]] = []
     async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        mock_pollen_api(mocked, google_pollen_5_day_payload, corrected_params)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], corrected_input
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert corrected_params
+    assert all(
+        params["location.latitude"] == "40.416800" for params in corrected_params
+    )
+    assert all(
+        params["location.longitude"] == "-3.703800" for params in corrected_params
+    )
     entry = result["result"]
     assert entry.data == {CONF_API_KEY: fake_api_key}
     assert entry.options[CONF_LANGUAGE_CODE] == "es"
     assert len(entry.subentries) == 1
+    subentry = next(iter(entry.subentries.values()))
+    assert subentry.title == "Madrid"
+    assert subentry.unique_id == "40.4168_-3.7038"
+    assert dict(subentry.data) == {
+        CONF_LATITUDE: 40.4168,
+        CONF_LONGITUDE: -3.7038,
+    }
 
 
 @pytest.mark.parametrize(
@@ -208,28 +227,47 @@ async def test_ha_location_subentry_user_recovers_after_invalid_parent_api_key(
         context={"source": SOURCE_USER},
     )
     user_input = _location_input(name="Garden", latitude=41.3874, longitude=2.1686)
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], user_input
-    )
+    invalid_params: list[dict[str, Any]] = []
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, invalid_params)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], user_input
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
     assert result["description_placeholders"] == {"error_message": "Invalid API key."}
+    assert invalid_params == []
 
     hass.config_entries.async_update_entry(
         entry,
         data={CONF_API_KEY: fake_api_key},
         unique_id=api_key_unique_id(fake_api_key),
     )
+    corrected_params: list[dict[str, Any]] = []
     async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        mock_pollen_api(mocked, google_pollen_5_day_payload, corrected_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], user_input
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert corrected_params
+    assert all(
+        params["location.latitude"] == "41.387400" for params in corrected_params
+    )
+    assert all(
+        params["location.longitude"] == "2.168600" for params in corrected_params
+    )
     assert len(entry.subentries) == 1
+    created = next(iter(entry.subentries.values()))
+    assert created.title == "Garden"
+    assert created.unique_id == "41.3874_2.1686"
+    assert dict(created.data) == {
+        CONF_LATITUDE: 41.3874,
+        CONF_LONGITUDE: 2.1686,
+    }
 
 
 async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_key(
@@ -273,27 +311,36 @@ async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_ke
         latitude=41.3874,
         longitude=2.1686,
     )
-    result = await hass.config_entries.subentries.async_configure(
-        result["flow_id"], user_input
-    )
+    invalid_params: list[dict[str, Any]] = []
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload, invalid_params)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], user_input
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
     assert result["description_placeholders"] == {"error_message": "Invalid API key."}
+    assert invalid_params == []
+    assert scheduled_reloads == []
 
     hass.config_entries.async_update_entry(
         entry,
         data={CONF_API_KEY: fake_api_key},
         unique_id=api_key_unique_id(fake_api_key),
     )
+    corrected_params: list[dict[str, Any]] = []
     async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        mock_pollen_api(mocked, google_pollen_5_day_payload, corrected_params)
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], user_input
         )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+    assert len(corrected_params) == 1
+    assert corrected_params[0]["location.latitude"] == "41.387400"
+    assert corrected_params[0]["location.longitude"] == "2.168600"
     updated = entry.subentries["location-madrid"]
     assert updated.title == "Barcelona"
     assert updated.unique_id == "41.3874_2.1686"

--- a/tests/test_ha_config_flow_coverage.py
+++ b/tests/test_ha_config_flow_coverage.py
@@ -157,8 +157,9 @@ async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordina
     assert result["type"] is FlowResultType.FORM
 
     new_api_key = f"{fake_api_key}-{source}"
+    captured_params: list[dict[str, Any]] = []
     async with aiointercept(mock_external_urls=True) as mocked:
-        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        mock_pollen_api(mocked, google_pollen_5_day_payload, captured_params)
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {CONF_API_KEY: new_api_key}
         )
@@ -168,6 +169,9 @@ async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordina
     assert entry.data == {CONF_API_KEY: new_api_key}
     assert entry.unique_id == api_key_unique_id(new_api_key)
     assert scheduled_reloads == [entry.entry_id]
+    assert len(captured_params) == 1
+    assert captured_params[0]["location.latitude"] == "41.387400"
+    assert captured_params[0]["location.longitude"] == "2.168600"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ha_config_flow_coverage.py
+++ b/tests/test_ha_config_flow_coverage.py
@@ -1,0 +1,330 @@
+"""Home Assistant harness coverage for config-flow recovery behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiointercept import aiointercept
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
+from homeassistant.const import CONF_LOCATION, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LANGUAGE_CODE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    SUBENTRY_TYPE_LOCATION,
+)
+from custom_components.pollenlevels.util import api_key_unique_id
+from tests._ha_stubs import clear_integration_modules
+from tests.ha_helpers import mock_pollen_api
+
+
+def _location_input(
+    *,
+    name: str = "Madrid",
+    latitude: float | str = 40.4168,
+    longitude: float | str = -3.7038,
+) -> dict[str, Any]:
+    """Return one location-selector submission."""
+
+    return {
+        CONF_NAME: name,
+        CONF_LOCATION: {
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+        },
+    }
+
+
+async def _start_parent_api_key_flow(entry: Any, hass: HomeAssistant, source: str):
+    """Start a parent API-key flow through Home Assistant."""
+
+    if source == SOURCE_REAUTH:
+        return await entry.start_reauth_flow(hass)
+    if source == SOURCE_RECONFIGURE:
+        return await entry.start_reconfigure_flow(hass)
+    raise AssertionError(f"Unsupported source: {source}")
+
+
+async def test_ha_user_flow_recovers_after_invalid_language(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """User setup should remain usable after a validation error."""
+
+    clear_integration_modules()
+    user_input = {
+        CONF_API_KEY: fake_api_key,
+        CONF_LANGUAGE_CODE: "bad code",
+        CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+        **_location_input(),
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LANGUAGE_CODE: "invalid_language_format"}
+
+    corrected_input = {**user_input, CONF_LANGUAGE_CODE: "es"}
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], corrected_input
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    entry = result["result"]
+    assert entry.data == {CONF_API_KEY: fake_api_key}
+    assert entry.options[CONF_LANGUAGE_CODE] == "es"
+    assert len(entry.subentries) == 1
+
+
+@pytest.mark.parametrize(
+    ("source", "reason"),
+    [
+        (SOURCE_REAUTH, "reauth_successful"),
+        (SOURCE_RECONFIGURE, "reconfigure_successful"),
+    ],
+)
+async def test_ha_parent_api_key_flow_tries_next_location_after_invalid_coordinates(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+    source: str,
+    reason: str,
+) -> None:
+    """Parent key validation should skip a corrupt location and try the next one."""
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id=f"parent-{source}",
+        title="Pollen Levels",
+        data={CONF_API_KEY: "old-key"},
+        unique_id=api_key_unique_id("old-key"),
+        subentries_data=[
+            {
+                "subentry_id": "location-corrupt",
+                "subentry_type": SUBENTRY_TYPE_LOCATION,
+                "title": "Corrupt",
+                "unique_id": "corrupt-location",
+                "data": {
+                    CONF_LATITUDE: "north",
+                    CONF_LONGITUDE: -3.7038,
+                },
+            },
+            {
+                "subentry_id": "location-valid",
+                "subentry_type": SUBENTRY_TYPE_LOCATION,
+                "title": "Valid",
+                "unique_id": "41.3874_2.1686",
+                "data": {
+                    CONF_LATITUDE: 41.3874,
+                    CONF_LONGITUDE: 2.1686,
+                },
+            },
+        ],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    result = await _start_parent_api_key_flow(entry, hass, source)
+    assert result["type"] is FlowResultType.FORM
+
+    new_api_key = f"{fake_api_key}-{source}"
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_API_KEY: new_api_key}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+    assert entry.data == {CONF_API_KEY: new_api_key}
+    assert entry.unique_id == api_key_unique_id(new_api_key)
+
+
+@pytest.mark.parametrize(
+    "stored_data",
+    [
+        pytest.param({}, id="missing-key"),
+        pytest.param({CONF_API_KEY: 123}, id="non-string-key"),
+    ],
+)
+async def test_ha_location_subentry_user_recovers_after_invalid_parent_api_key(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    google_pollen_5_day_payload: dict[str, Any],
+    stored_data: dict[str, Any],
+) -> None:
+    """Location creation should recover after the parent API key is repaired."""
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="parent-location-create",
+        title="Pollen Levels",
+        data=stored_data,
+        version=6,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={"source": SOURCE_USER},
+    )
+    user_input = _location_input(name="Garden", latitude=41.3874, longitude=2.1686)
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["description_placeholders"] == {"error_message": "Invalid API key."}
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data={CONF_API_KEY: fake_api_key},
+        unique_id=api_key_unique_id(fake_api_key),
+    )
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], user_input
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert len(entry.subentries) == 1
+
+
+async def test_ha_location_subentry_reconfigure_recovers_after_invalid_coordinates(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_config_entry: Any,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Location reconfigure should accept corrected coordinates on retry."""
+
+    clear_integration_modules()
+    ha_config_entry.add_to_hass(hass)
+    subentry = ha_config_entry.subentries["location-madrid"]
+
+    result = await hass.config_entries.subentries.async_init(
+        (ha_config_entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "subentry_id": subentry.subentry_id,
+        },
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"],
+        _location_input(name="Broken", latitude="north", longitude=2.1686),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {CONF_LOCATION: "invalid_coordinates"}
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            _location_input(
+                name="Barcelona",
+                latitude=41.3874,
+                longitude=2.1686,
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    updated = ha_config_entry.subentries["location-madrid"]
+    assert updated.title == "Barcelona"
+    assert updated.unique_id == "41.3874_2.1686"
+
+
+async def test_ha_location_subentry_reconfigure_recovers_after_invalid_parent_key(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    fake_api_key: str,
+    sample_location_subentry_data: dict[str, Any],
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Location reconfigure should recover after the parent key is repaired."""
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    clear_integration_modules()
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="parent-location-reconfigure",
+        title="Pollen Levels",
+        data={},
+        subentries_data=[sample_location_subentry_data],
+        version=6,
+    )
+    entry.add_to_hass(hass)
+    subentry = entry.subentries["location-madrid"]
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_LOCATION),
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "subentry_id": subentry.subentry_id,
+        },
+    )
+    user_input = _location_input(
+        name="Barcelona",
+        latitude=41.3874,
+        longitude=2.1686,
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["description_placeholders"] == {"error_message": "Invalid API key."}
+
+    hass.config_entries.async_update_entry(
+        entry,
+        data={CONF_API_KEY: fake_api_key},
+        unique_id=api_key_unique_id(fake_api_key),
+    )
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], user_input
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.subentries["location-madrid"].title == "Barcelona"


### PR DESCRIPTION
## Summary

Continues #306 with focused regression coverage for reachable Home Assistant config-flow behavior identified by #304.

- covers non-string and whitespace language validation;
- covers submitted and absent coordinate defaults in user/location schemas;
- covers malformed legacy coordinate recovery and verifies the corrected coordinates used for API validation;
- covers duplicate scanning across unrelated subentries, including the false-positive case where only an unrelated subentry shares the target unique ID;
- verifies user setup recovers after language validation errors;
- verifies reauth/reconfigure try a later valid location when an earlier stored location has invalid coordinates;
- verifies location creation and reconfiguration recover after a corrupt/missing parent API key;
- verifies location reconfiguration recovers after invalid coordinates, with no API validation or reload on the invalid submission and the corrected coordinates used on retry;
- isolates invalid Home Assistant submissions from the network and proves they do not call the pollen API;
- verifies corrected recovery submissions validate and persist the intended location.

## Scope

Tests only. No runtime, migration, client, CI, dependency, documentation, or release changes.

Two follow-ups are intentionally separate:

- #312 owns the options-flow raw-traceback privacy defect discovered while implementing the remaining defensive options error path. Encoding the current leak as expected behavior here would be wrong.
- #313 owns the two redundant `entry is None` guards that #304 proved unreachable through supported Home Assistant behavior. This PR does not add fake monkeypatch-only tests for them.

## Validation

- Branch is based on current `main` after #310 (`9e3c6dd8681556eeeb97963fedb1c1599292115e`).
- Latest head: `9eca5d0cc4dbc880fec54c692feb4ff8897f00a6`.
- Locked GitHub CI is green on the latest head: Tests, Lint, Package Test, Workflow Security, hassfest, HACS validation, and CodeQL.
- CodeQL reports no new alerts in code changed by this pull request.
- CodeRabbit findings have been verified individually and addressed with behavioral assertions rather than cosmetic rewrites; all review threads are resolved.
- Final CodeRabbit full review completed on the exact current head (`9eca5d0cc4dbc880fec54c692feb4ff8897f00a6`) with no actionable comments.
- Coverage will be remeasured after the reachable tests and #312 are complete.

## Risk

Low. The PR adds tests only and exercises existing public flow behavior. Any runtime defect exposed by these tests should be split into a focused fix rather than silently expanding this PR.

Related: #304
Progresses #306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded configuration-flow coverage for language validation and location defaults.
  - Added checks for duplicate locations and unrelated entries.
  - Verified recovery from invalid coordinates, missing credentials, malformed API keys, and other invalid input.
  - Added coverage for correcting errors during setup, reconfiguration, and location management.
  - Confirmed corrected submissions complete successfully across standard and Home Assistant configuration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->