### PR TITLE
fix(config-flow): avoid raw exception details in options logs

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -1031,9 +1031,11 @@ class PollenLevelsOptionsFlow(config_entries.OptionsFlowWithReload):
                 )
                 errors[CONF_LANGUAGE_CODE] = _language_error_to_form_key(ve)
             except Exception as err:  # defensive
-                _LOGGER.exception(
-                    "Options validation error: %s",
-                    redact_api_key(err, self.config_entry.data.get(CONF_API_KEY)),
+                _LOGGER.error(
+                    "Options validation error (%s): %s",
+                    type(err).__name__,
+                    redact_api_key(err, self.config_entry.data.get(CONF_API_KEY))
+                    or "no error details",
                 )
                 errors["base"] = "unknown"
 

--- a/tests/test_options_flow_error_handling.py
+++ b/tests/test_options_flow_error_handling.py
@@ -1,0 +1,69 @@
+"""Regression tests for defensive options-flow error handling."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tests import test_options_flow as options_flow_tests
+
+options_flow_env = options_flow_tests.options_flow_env
+
+
+async def test_options_flow_unexpected_error_is_redacted_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+    options_flow_env: options_flow_tests.OptionsFlowEnv,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected validation errors should redact secrets and allow retry."""
+
+    api_key = "synthetic-options-api-key"
+    flow = options_flow_tests._flow(
+        options_flow_env,
+        entry_data={options_flow_env.CONF_API_KEY: api_key},
+    )
+    validation_calls = 0
+
+    def _validate_language(value: str) -> str:
+        nonlocal validation_calls
+        validation_calls += 1
+        if validation_calls == 1:
+            raise RuntimeError(f"validation failed for key={api_key}")
+        return value
+
+    monkeypatch.setattr(
+        options_flow_env.config_flow,
+        "is_valid_language_code",
+        _validate_language,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=options_flow_env.config_flow.__name__):
+        result = await flow.async_step_init(
+            {
+                options_flow_env.CONF_LANGUAGE_CODE: "en",
+                options_flow_env.CONF_UPDATE_INTERVAL: 6,
+            }
+        )
+
+    assert result["errors"] == {"base": "unknown"}
+    assert api_key not in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert "***" in caplog.text
+    assert "Traceback (most recent call last)" not in caplog.text
+
+    result = await flow.async_step_init(
+        {
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+            options_flow_env.CONF_UPDATE_INTERVAL: 6,
+        }
+    )
+
+    assert result == {
+        "title": "",
+        "data": {
+            options_flow_env.CONF_UPDATE_INTERVAL: 6,
+            options_flow_env.CONF_LANGUAGE_CODE: "en",
+        },
+    }
+    assert validation_calls == 2


### PR DESCRIPTION
## Summary

Fixes the defensive options-flow logging path so an unexpected validation exception cannot reintroduce the parent API key through `logger.exception()` traceback output.

- replaces traceback logging with an error log containing only the exception type and redacted message;
- adds a regression test using a synthetic API key;
- verifies the flow reports `unknown` without leaking the raw key or traceback;
- verifies a corrected resubmission succeeds on the same options flow instance.

## Root cause

`redact_api_key()` correctly sanitized the formatted log argument, but `_LOGGER.exception()` appended the original exception traceback. If the exception message contained the API key, the traceback could expose the unredacted value again.

## Scope

Limited to the defensive options-flow logging branch and its focused regression test.

No migration, identity, client, CI, dependency, documentation, release, or normal options-semantics changes.

## Validation

- Branch is based on post-#317 `main` (`d08de6fa21cfffce56b0d94ad292379185792a2e`).
- Current head: `3c99a743de1e6e638e6ef11b0a175cfb589905ad`.
- Compare against `main`: 2 files, 5 runtime additions / 3 runtime deletions, 69 test additions.
- Locked Tests, Lint, Package Test, Workflow Security, hassfest, and HACS validation are green.
- CodeQL reports no new alerts in code changed by this pull request.
- CodeRabbit reviewed the exact current head with no actionable comments and minimal merge risk.

## Risk

Low. The functional flow result remains `unknown`; only unsafe traceback logging is removed.

Fixes #312
Progresses #306