### PR TITLE
refactor(config-flow): remove unreachable entry-none guards

### DIFF
--- a/custom_components/pollenlevels/config_flow.py
+++ b/custom_components/pollenlevels/config_flow.py
@@ -797,8 +797,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Prompt for a refreshed API key and validate it."""
         entry = self._get_reauth_entry()
-        if entry is None:
-            return self.async_abort(reason="reauth_failed")
         return await self._async_handle_api_key_confirm(
             entry=entry,
             step_id="reauth_confirm",
@@ -811,8 +809,6 @@ class PollenLevelsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> config_entries.ConfigFlowResult:
         """Prompt for a refreshed API key from the reconfigure UI."""
         entry = self._get_reconfigure_entry()
-        if entry is None:
-            return self.async_abort(reason="reconfigure_failed")
         return await self._async_handle_api_key_confirm(
             entry=entry,
             step_id="reconfigure",


### PR DESCRIPTION
## Summary

Removes the two redundant `entry is None` guards in the reauth and reconfigure flows identified by #304/#306/#313.

## Why these guards are unreachable

The behavior was revalidated against both ends of the supported Home Assistant range relevant to this repository: the minimum supported HACS version (`2026.3.0`) and the currently locked test version (`2026.8.0`). In both versions:

- `ConfigFlow._get_reauth_entry()` returns `ConfigEntry` via `hass.config_entries.async_get_known_entry(...)`;
- `ConfigFlow._get_reconfigure_entry()` does the same;
- `async_get_known_entry()` returns a known `ConfigEntry` or raises `UnknownEntry` when the entry does not exist; it does not return `None`.

The removed branches therefore cannot occur through the supported Home Assistant API across the supported range checked here. Keeping them only creates unreachable statements and fake monkeypatch-only tests would misrepresent supported behavior.

## Scope

- removes only the two unreachable guards;
- no test behavior is changed or weakened;
- no migration, identity, storage, client, diagnostics, entity, translation, CI, dependency, documentation, or release changes.

## Validation

- Based on post-#319 `main`: `9cd2df4e21cb830d4a3564ce8fe19fd99f401041`.
- Current head: `79df5a9c28ddef01e41d4faa9adf57431aa932b9`.
- Diff: 1 file, 0 additions, 4 deletions.
- Home Assistant API contract checked against `2026.3.0` and `2026.8.0`.
- Locked Tests, Lint, Package Test, Workflow Security, hassfest, and HACS validation are green.
- CodeQL reports no new alerts in code changed by this pull request.
- CodeRabbit reviewed the exact current head with no actionable comments and minimal merge risk.
- A fresh literal `config_flow.py` coverage measurement remains part of the #304/#306 follow-up; the normal hosted test workflow does not currently emit a coverage artifact.

## Risk

Low. Supported Home Assistant behavior is unchanged: a valid flow receives a `ConfigEntry`; a missing entry raises upstream instead of returning `None`.

Fixes #313
Progresses #306
Related: #304