### PR TITLE
docs: document 3.1.0 statistics cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Removed `SensorStateClass.MEASUREMENT` from current-day pollen forecast sensors
   and the overall pollen risk today sensor so forecast-derived values no longer
   claim present-time measurement semantics or generate new long-term statistics.
-  Existing long-term statistics are not removed, and normal Recorder history
+  Existing long-term statistics are not removed automatically. Users upgrading
+  from an earlier version should remove the obsolete forecast-derived statistics
+  from **Settings → Developer Tools → Statistics**. Normal Recorder history
   continues to follow the user's Recorder retention settings.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ Go to **Settings → Devices & Services → Pollen Levels → Configure**.
 
 ---
 
+## Upgrading to 3.1.0: remove obsolete long-term statistics
+
+Pollen Levels 3.1.0 stops generating Home Assistant long-term statistics for
+current-day pollen type and plant forecast sensors and for the
+`overall_pollen_risk_today` sensor.
+
+Earlier versions exposed these forecast-derived values with
+`SensorStateClass.MEASUREMENT`, so Home Assistant may still retain long-term
+statistics created before the upgrade. These values represent forecasts rather
+than actual measurements and should not be kept as historical measurements.
+
+After upgrading to 3.1.0, open **Settings → Developer Tools → Statistics** and
+remove the obsolete statistics for the affected Pollen Levels sensors.
+
+This cleanup only removes the previously generated long-term statistics. Normal
+Recorder history is separate and continues to follow your Recorder retention
+configuration. Pollen Levels 3.1.0 and later will not generate new long-term
+statistics for these forecast-derived sensors.
+
 ## Migrating from per-day forecast sensors
 
 Pollen Levels no longer creates separate per-day pollen type forecast sensors


### PR DESCRIPTION
## Summary

- document the manual removal of obsolete forecast-derived long-term statistics after upgrading to 3.1.0
- clarify that normal Recorder history is separate and does not need to be deleted
- update the existing 3.1.0 changelog entry with the cleanup path

## Impact

Users upgrading from versions before 3.1.0 now have explicit guidance for removing statistics created when forecast-derived sensors used measurement state classes. This is documentation-only and does not change runtime behavior, versions, dependencies, or release metadata.

## Validation

- verified the diff contains only `README.md` and `CHANGELOG.md`
- `git diff --check`
- verified Markdown heading placement and line wrapping
- confirmed no changed line exceeds 100 characters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for version 3.1.0.
  * Clarified that obsolete long-term statistics for forecast-derived sensors must be removed manually.
  * Explained that Recorder history is unaffected and future versions will no longer generate these statistics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->