### PR TITLE
fix(repairs): redact sensitive placeholder values

### DIFF
--- a/custom_components/pollenlevels/__init__.py
+++ b/custom_components/pollenlevels/__init__.py
@@ -469,6 +469,21 @@ async def async_setup_entry(
     client = GooglePollenApiClient(session, api_key)
 
     location_configs = _iter_location_subentries(entry)
+    coordinate_pairs: list[tuple[Any, Any]] = []
+    parent_data = dict(entry.data or {})
+    if CONF_LATITUDE in parent_data or CONF_LONGITUDE in parent_data:
+        coordinate_pairs.append(
+            (parent_data.get(CONF_LATITUDE), parent_data.get(CONF_LONGITUDE))
+        )
+    for subentry in (getattr(entry, "subentries", {}) or {}).values():
+        subentry_data = dict(getattr(subentry, "data", {}) or {})
+        if CONF_LATITUDE in subentry_data or CONF_LONGITUDE in subentry_data:
+            coordinate_pairs.append(
+                (
+                    subentry_data.get(CONF_LATITUDE),
+                    subentry_data.get(CONF_LONGITUDE),
+                )
+            )
     active_subentry_ids = active_location_subentry_ids(entry)
     delete_stale_location_subentry_issues(
         hass,
@@ -493,6 +508,8 @@ async def async_setup_entry(
                 entry_title=entry.title,
                 location_title=title,
                 subentry_id=issue_subentry_id,
+                api_key=api_key,
+                coordinate_pairs=coordinate_pairs,
             )
             if issue_subentry_id is None:
                 has_legacy_invalid_location_issue = True
@@ -671,6 +688,8 @@ async def async_setup_entry(
             subentry_id=failure.subentry_id,
             error_type=failure.error_type,
             reason=failure.reason,
+            api_key=api_key,
+            coordinate_pairs=coordinate_pairs,
         )
 
     if retry_reload_needed:

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -10,13 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from .const import (
-    CONF_API_KEY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     DEFAULT_ENTRY_TITLE,
     DOMAIN,
 )
-from .util import redact_sensitive_values
+from .util import entry_api_key, redact_sensitive_values
 
 PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
 LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
@@ -45,7 +44,6 @@ def _entry_repair_privacy_context(
 ) -> tuple[str | None, list[tuple[Any, Any]]]:
     """Return the parent API key and stored coordinates for Repair redaction."""
     data = dict(entry.data or {})
-    api_key = data.get(CONF_API_KEY)
     coordinate_pairs: list[tuple[Any, Any]] = []
     if CONF_LATITUDE in data or CONF_LONGITUDE in data:
         coordinate_pairs.append((data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE)))
@@ -60,7 +58,7 @@ def _entry_repair_privacy_context(
                 )
             )
 
-    return api_key if isinstance(api_key, str) else None, coordinate_pairs
+    return entry_api_key(entry), coordinate_pairs
 
 
 def _location_issue_prefixes(entry_id: str) -> tuple[str, str]:

--- a/custom_components/pollenlevels/issue_helpers.py
+++ b/custom_components/pollenlevels/issue_helpers.py
@@ -3,16 +3,64 @@
 from __future__ import annotations
 
 from collections.abc import Collection
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
-from .const import DEFAULT_ENTRY_TITLE, DOMAIN
+from .const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    DEFAULT_ENTRY_TITLE,
+    DOMAIN,
+)
+from .util import redact_sensitive_values
 
 PER_DAY_FORECAST_SENSORS_REMOVED_ISSUE_ID = "per_day_forecast_sensors_removed"
 LOCATION_SETUP_FAILED_TRANSLATION_KEY = "location_setup_failed"
 _LOCATION_REPAIR_ISSUES_DATA_KEY = "location_repair_issue_ids"
+
+
+def _redact_repair_placeholder(
+    value: Any,
+    *,
+    api_key: str | None,
+    coordinate_pairs: Collection[tuple[Any, Any]],
+) -> str:
+    """Redact sensitive values immediately before creating a Repair."""
+    redacted = redact_sensitive_values(value, api_key=api_key)
+    for latitude, longitude in coordinate_pairs:
+        redacted = redact_sensitive_values(
+            redacted,
+            latitude=latitude,
+            longitude=longitude,
+        )
+    return redacted
+
+
+def _entry_repair_privacy_context(
+    entry: ConfigEntry,
+) -> tuple[str | None, list[tuple[Any, Any]]]:
+    """Return the parent API key and stored coordinates for Repair redaction."""
+    data = dict(entry.data or {})
+    api_key = data.get(CONF_API_KEY)
+    coordinate_pairs: list[tuple[Any, Any]] = []
+    if CONF_LATITUDE in data or CONF_LONGITUDE in data:
+        coordinate_pairs.append((data.get(CONF_LATITUDE), data.get(CONF_LONGITUDE)))
+
+    for subentry in (getattr(entry, "subentries", {}) or {}).values():
+        subentry_data = dict(getattr(subentry, "data", {}) or {})
+        if CONF_LATITUDE in subentry_data or CONF_LONGITUDE in subentry_data:
+            coordinate_pairs.append(
+                (
+                    subentry_data.get(CONF_LATITUDE),
+                    subentry_data.get(CONF_LONGITUDE),
+                )
+            )
+
+    return api_key if isinstance(api_key, str) else None, coordinate_pairs
 
 
 def _location_issue_prefixes(entry_id: str) -> tuple[str, str]:
@@ -93,12 +141,20 @@ def create_invalid_stored_location_issue(
     entry_id: str,
     entry_title: str | None,
     location_title: str | None,
+    api_key: str | None,
+    coordinate_pairs: Collection[tuple[Any, Any]],
     subentry_id: str | None = None,
 ) -> None:
     """Create a Repair issue for an invalid stored location."""
     issue_id = invalid_stored_location_issue_id(entry_id, subentry_id)
     entry_title = (entry_title or "").strip() or DEFAULT_ENTRY_TITLE
     location_title = (location_title or "").strip() or entry_title
+    entry_title = _redact_repair_placeholder(
+        entry_title, api_key=api_key, coordinate_pairs=coordinate_pairs
+    )
+    location_title = _redact_repair_placeholder(
+        location_title, api_key=api_key, coordinate_pairs=coordinate_pairs
+    )
     ir.async_create_issue(
         hass,
         DOMAIN,
@@ -178,6 +234,8 @@ def create_location_setup_failed_issue(
     subentry_id: str,
     error_type: str,
     reason: str,
+    api_key: str | None,
+    coordinate_pairs: Collection[tuple[Any, Any]],
 ) -> None:
     """Create a Repair issue for an isolated location setup failure."""
     issue_id = location_setup_failed_issue_id(entry_id, subentry_id)
@@ -185,6 +243,20 @@ def create_location_setup_failed_issue(
     location_title = (location_title or "").strip() or entry_title
     error_type = (error_type or "").strip() or "UnknownError"
     reason = (reason or "").strip() or "Location setup failed"
+    placeholders = {
+        "entry_title": entry_title,
+        "location_title": location_title,
+        "error_type": error_type,
+        "reason": reason,
+    }
+    placeholders = {
+        key: _redact_repair_placeholder(
+            value,
+            api_key=api_key,
+            coordinate_pairs=coordinate_pairs,
+        )
+        for key, value in placeholders.items()
+    }
     ir.async_create_issue(
         hass,
         DOMAIN,
@@ -193,12 +265,7 @@ def create_location_setup_failed_issue(
         is_persistent=True,
         severity=ir.IssueSeverity.WARNING,
         translation_key=LOCATION_SETUP_FAILED_TRANSLATION_KEY,
-        translation_placeholders={
-            "entry_title": entry_title,
-            "location_title": location_title,
-            "error_type": error_type,
-            "reason": reason,
-        },
+        translation_placeholders=placeholders,
     )
     _remember_location_issue(hass, entry_id, issue_id)
 
@@ -208,12 +275,15 @@ def create_entry_invalid_stored_location_issue(
     entry: ConfigEntry,
 ) -> None:
     """Create a Repair issue for an invalid stored location on a config entry."""
+    api_key, coordinate_pairs = _entry_repair_privacy_context(entry)
     create_invalid_stored_location_issue(
         hass,
         entry_id=entry.entry_id,
         entry_title=entry.title,
         location_title=entry.title,
         subentry_id=None,
+        api_key=api_key,
+        coordinate_pairs=coordinate_pairs,
     )
 
 

--- a/tests/test_ha_init.py
+++ b/tests/test_ha_init.py
@@ -23,7 +23,12 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from custom_components.pollenlevels.const import CONF_API_KEY, DOMAIN
+from custom_components.pollenlevels.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    DOMAIN,
+)
 from custom_components.pollenlevels.util import api_key_unique_id
 from tests._ha_stubs import clear_integration_modules
 from tests.ha_helpers import (
@@ -78,6 +83,47 @@ def _create_test_repair(
         severity=ir.IssueSeverity.WARNING,
         translation_key="location_setup_failed",
     )
+
+
+async def test_ha_invalid_location_repair_stores_redacted_placeholders(
+    hass: HomeAssistant,
+) -> None:
+    """The real issue registry should store only redacted dynamic placeholders."""
+    clear_integration_modules()
+    from custom_components.pollenlevels.issue_helpers import (
+        create_entry_invalid_stored_location_issue,
+        invalid_stored_location_issue_id,
+    )
+
+    synthetic_key = "SYNTHETIC-HA-REPAIR-KEY"
+    latitude = 12.345678
+    longitude = -45.678912
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry-private-repair",
+        title=f"Safe Home {synthetic_key} {latitude} {longitude}",
+        data={
+            CONF_API_KEY: synthetic_key,
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+        },
+        version=6,
+    )
+
+    create_entry_invalid_stored_location_issue(hass, entry)
+
+    issue = ir.async_get(hass).async_get_issue(
+        DOMAIN, invalid_stored_location_issue_id(entry.entry_id)
+    )
+    assert issue is not None
+    assert issue.translation_placeholders == {
+        "entry_title": "Safe Home *** *** ***",
+        "location_title": "Safe Home *** *** ***",
+    }
+    assert issue.translation_key == "invalid_stored_location"
+    assert issue.severity is ir.IssueSeverity.ERROR
+    assert issue.is_persistent is False
+    assert issue.is_fixable is False
 
 
 async def test_ha_setup_unload_reload_smoke(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1287,6 +1287,7 @@ async def test_setup_entry_non_transport_outcome_resets_transport_failure_counte
 def test_setup_entry_creates_repair_after_retryable_failure_repeats(
     integration_modules: _InitModules,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Repeated retryable partial setup failures should create a Repair warning."""
     integration = integration_modules.integration
@@ -1296,13 +1297,21 @@ def test_setup_entry_creates_repair_after_retryable_failure_repeats(
         data={integration.CONF_LATITUDE: 1.0, integration.CONF_LONGITUDE: 2.0},
         subentry_id="first-location",
     )
+    synthetic_key = "SYNTHETIC-REPAIR-KEY"
+    second_latitude = 3.123456
+    second_longitude = 4.654321
     second = integration.ConfigSubentry(
-        data={integration.CONF_LATITUDE: 3.0, integration.CONF_LONGITUDE: 4.0},
+        data={
+            integration.CONF_LATITUDE: second_latitude,
+            integration.CONF_LONGITUDE: second_longitude,
+        },
         subentry_id="second-location",
+        title=f"Garden {synthetic_key} {second_latitude}",
     )
     entry = _FakeEntry(
         integration,
-        data={integration.CONF_API_KEY: "key"},
+        title=f"My Home {synthetic_key} {second_longitude}",
+        data={integration.CONF_API_KEY: synthetic_key},
         subentries={first.subentry_id: first, second.subentry_id: second},
     )
     hass = _FakeHass()
@@ -1319,13 +1328,16 @@ def test_setup_entry_creates_repair_after_retryable_failure_repeats(
 
         async def async_config_entry_first_refresh(self):
             if self.subentry_id == "second-location":
-                raise integration.ConfigEntryNotReady("retry later")
+                raise integration.ConfigEntryNotReady(
+                    f"retry later {synthetic_key} {second_latitude} {second_longitude}"
+                )
 
     monkeypatch.setattr(
         integration, "PollenDataUpdateCoordinator", _PartiallyReadyCoordinator
     )
 
-    assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
+    with caplog.at_level("WARNING", logger=integration.__name__):
+        assert asyncio.run(integration.async_setup_entry(hass, entry)) is True
 
     issue_id = integration.issue_helpers.location_setup_failed_issue_id(
         entry.entry_id, "second-location"
@@ -1336,6 +1348,16 @@ def test_setup_entry_creates_repair_after_retryable_failure_repeats(
     assert issue["translation_placeholders"]["error_type"].endswith(
         "ConfigEntryNotReady"
     )
+    placeholders = issue["translation_placeholders"]
+    assert placeholders["entry_title"] == "My Home *** ***"
+    assert placeholders["location_title"] == "Garden *** ***"
+    assert placeholders["reason"] == "retry later *** *** ***"
+    assert synthetic_key not in str(placeholders)
+    assert str(second_latitude) not in str(placeholders)
+    assert str(second_longitude) not in str(placeholders)
+    assert synthetic_key not in caplog.text
+    assert str(second_latitude) not in caplog.text
+    assert str(second_longitude) not in caplog.text
     assert hass.config_entries.reload_calls == []
 
 
@@ -1355,6 +1377,8 @@ def test_create_location_setup_failed_repair_is_persistent(
         subentry_id="location-garden",
         error_type="UpdateFailed",
         reason="API response missing usable pollen data",
+        api_key=None,
+        coordinate_pairs=(),
     )
 
     issue_id = integration.issue_helpers.location_setup_failed_issue_id(
@@ -4136,19 +4160,20 @@ def test_setup_entry_creates_repair_issue_for_invalid_location_coordinates(
     integration = integration_modules.integration
     registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
+    synthetic_key = "SYNTHETIC-INVALID-LOCATION-KEY"
     bad_subentry = integration.ConfigSubentry(
         data={
             integration.CONF_LATITUDE: 91.123456,
             integration.CONF_LONGITUDE: 2.654321,
         },
         subentry_id="bad-location",
-        title="Bad Location",
+        title=f"Bad Location {synthetic_key} 2.654321",
     )
     entry = _FakeEntry(
         integration,
         entry_id="entry-invalid",
-        title="My Home",
-        data={integration.CONF_API_KEY: "secret-key"},
+        title=f"My Home {synthetic_key} 91.123456",
+        data={integration.CONF_API_KEY: synthetic_key},
         subentries={bad_subentry.subentry_id: bad_subentry},
     )
     hass = _FakeHass()
@@ -4174,10 +4199,12 @@ def test_setup_entry_creates_repair_issue_for_invalid_location_coordinates(
     )
     assert issue["is_fixable"] is False
     assert issue["is_persistent"] is False
-    assert issue["translation_placeholders"]["entry_title"] == "My Home"
-    assert issue["translation_placeholders"]["location_title"] == "Bad Location"
-    assert "secret-key" not in caplog.text
+    assert issue["translation_placeholders"]["entry_title"] == "My Home *** ***"
+    assert issue["translation_placeholders"]["location_title"] == "Bad Location *** ***"
+    assert synthetic_key not in str(issue["translation_placeholders"])
+    assert synthetic_key not in caplog.text
     assert "91.123456" not in caplog.text
+    assert "2.654321" not in caplog.text
 
 
 def test_setup_entry_loads_valid_location_when_later_subentry_is_invalid(
@@ -4424,6 +4451,8 @@ def test_setup_entry_clears_location_repairs_for_deleted_subentries(
         entry_title="Stale Home",
         location_title="Deleted",
         subentry_id="deleted-location",
+        api_key=None,
+        coordinate_pairs=(),
     )
     integration.issue_helpers.create_location_setup_failed_issue(
         hass,
@@ -4433,6 +4462,8 @@ def test_setup_entry_clears_location_repairs_for_deleted_subentries(
         subentry_id="deleted-location",
         error_type="UpdateFailed",
         reason="old failure",
+        api_key=None,
+        coordinate_pairs=(),
     )
 
     class _StubCoordinator:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -499,7 +499,7 @@ def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
     entry = _FakeEntry(
         integration,
         entry_id="legacy-corrupt",
-        title="Corrupt Legacy",
+        title="Corrupt Legacy secret-key at 2.000000",
         data={
             integration.CONF_API_KEY: "secret-key",
             integration.CONF_LATITUDE: "not-a-number",
@@ -526,7 +526,10 @@ def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
     issue = registry.issues[expected_issue_id]
     assert issue["domain"] == integration.DOMAIN
     assert issue["translation_key"] == "invalid_stored_location"
-    assert issue["translation_placeholders"]["entry_title"] == "Corrupt Legacy"
+    assert issue["translation_placeholders"] == {
+        "entry_title": "Corrupt Legacy *** at ***",
+        "location_title": "Corrupt Legacy *** at ***",
+    }
     assert "secret-key" not in caplog.text
     assert "not-a-number" not in caplog.text
 
@@ -549,7 +552,7 @@ def test_migration_creates_repair_issue_for_unmigratable_location_subentries(
     entry = _FakeEntry(
         integration,
         entry_id="legacy-corrupt",
-        title="Corrupt Entry",
+        title="Corrupt Entry secret-key",
         data={integration.CONF_API_KEY: "secret-key"},
         options={},
         version=integration.TARGET_ENTRY_VERSION - 1,
@@ -573,7 +576,10 @@ def test_migration_creates_repair_issue_for_unmigratable_location_subentries(
     issue = registry.issues[expected_issue_id]
     assert issue["domain"] == integration.DOMAIN
     assert issue["translation_key"] == "invalid_stored_location"
-    assert issue["translation_placeholders"]["entry_title"] == "Corrupt Entry"
+    assert issue["translation_placeholders"] == {
+        "entry_title": "Corrupt Entry ***",
+        "location_title": "Corrupt Entry ***",
+    }
     assert "secret-key" not in caplog.text
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -496,12 +496,14 @@ def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
     integration = migration_modules.integration
     registry = sys.modules["homeassistant.helpers.issue_registry"].registry
 
+    raw_api_key = "  SYNTHETIC-MIGRATION-REPAIR-KEY  "
+    effective_api_key = raw_api_key.strip()
     entry = _FakeEntry(
         integration,
         entry_id="legacy-corrupt",
-        title="Corrupt Legacy secret-key at 2.000000",
+        title=f"Corrupt Legacy {effective_api_key} at 2.000000",
         data={
-            integration.CONF_API_KEY: "secret-key",
+            integration.CONF_API_KEY: raw_api_key,
             integration.CONF_LATITUDE: "not-a-number",
             integration.CONF_LONGITUDE: 2.0,
         },
@@ -530,7 +532,8 @@ def test_migration_creates_repair_issue_for_invalid_legacy_coordinates(
         "entry_title": "Corrupt Legacy *** at ***",
         "location_title": "Corrupt Legacy *** at ***",
     }
-    assert "secret-key" not in caplog.text
+    assert effective_api_key not in str(issue["translation_placeholders"])
+    assert effective_api_key not in caplog.text
     assert "not-a-number" not in caplog.text
 
 


### PR DESCRIPTION
Closes #339

Makes `issue_helpers.py` the final Repair privacy boundary for `invalid_stored_location` and `location_setup_failed`, reusing `redact_sensitive_values()` with the parent API key and every relevant configured coordinate pair. The config-entry wrapper covers legacy migration callers without changing `migration.py` or migration behavior.

Changed production files: `custom_components/pollenlevels/issue_helpers.py`, `custom_components/pollenlevels/__init__.py`.

Changed tests: `tests/test_init.py`, `tests/test_migration.py`, `tests/test_ha_init.py`. Coverage includes synthetic keys in entry/location titles, exact configured coordinates, both Repair families, legacy wrapper protection, safe-text preservation, log hygiene, unchanged Repair metadata/lifecycle, and actual Home Assistant issue-registry placeholders.

Validation with `uv 0.12.4`: focused modules 103 passed; full suite 678 passed; lock check, Ruff check/format, compileall, and diff check passed. An initial combined validation invocation was interrupted during environment sync; all affected commands were rerun successfully.

Residual risk is low. Helper signatures require privacy context and all production callers supply it; no new redaction algorithm or public contract was introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Sensitive API keys and stored location coordinates are now redacted from repair notices, setup-failure messages, and warning logs.
  * Redaction also applies to entries and subentries with incomplete location data.

* **Bug Fixes**
  * Improved protection of sensitive details when invalid locations or setup failures generate repair issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->