### PR TITLE
release: prepare 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.1.1] - 2026-08-17
+
+### Changed
+
+- Raised the minimum supported Home Assistant version to 2026.5.0 and added a
+  blocking compatibility lane that runs the full test suite against the declared
+  minimum version using a reproducible, hash-verified environment.
+
+### Fixed
+
+- Redacted API keys and precise configured coordinates from Home Assistant Repair
+  placeholders and related setup-failure context.
+
 ## [3.1.0] - 2026-08-17
 
 ### Changed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.1.0"
+    "version": "3.1.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
-# Tooling aligned to the Home Assistant 2026.3 Python floor (>=3.14.2).
+# Tooling aligned to the Home Assistant 2026.5 Python floor (>=3.14.2).
 
 [project]
 name = "pollenlevels"
-version = "3.1.0"
+version = "3.1.1"
 # Keep broad project metadata while the locked HA test environment enforces >=3.14.2.
 requires-python = ">=3.14"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "pollenlevels"
-version = "3.1.0"
+version = "3.1.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Prepare Pollen Levels 3.1.1.
- Ship the Home Assistant Repair placeholder privacy fix from #341.
- Publish the Home Assistant 2026.5.0 minimum-support contract and minimum-version CI work from #342.
- Synchronize manifest, project, and lockfile versions.

## Release contents

### Fixed

- Redacts API keys and precise configured coordinates from Home Assistant Repair placeholders and related setup-failure context.

### Changed

- Raises the minimum supported Home Assistant version to 2026.5.0.
- Adds the blocking hash-verified minimum Home Assistant compatibility lane.

## Validation

- `uv lock --check`: passed.
- `ruff check .`: passed.
- `ruff format --check .`: passed (`63 files already formatted`).
- Full pytest suite: `680 passed in 16.46s`.
- `python -m compileall -q custom_components tests`: passed.
- `git diff --check`: passed.

`uv.lock` changes only the local `pollenlevels` version from 3.1.0 to 3.1.1; no dependency versions or hashes changed. Production code and migration are unchanged. Tests and workflows are unchanged. `hacs.json` is unchanged and already declares Home Assistant 2026.5.0. README is unchanged because its minimum-version text was already synchronized in #342.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Home Assistant 2026.5 and newer.
  * Improved privacy by removing API keys and precise coordinates from repair and setup-failure details.
* **Documentation**
  * Added release notes for version 3.1.1, including compatibility requirements and validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->