### PR TITLE
release: prepare 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [4.0.0] - 2026-08-18
+
+### Breaking Changes
+
+- **Breaking change:** Raised the minimum supported Home Assistant version from
+  2026.3.0 to 2026.5.0. Upgrade Home Assistant to 2026.5.0 or newer before
+  updating Pollen Levels. Users remaining on Home Assistant 2026.3.x or 2026.4.x
+  should remain on Pollen Levels 3.1.0.
+
+### Changed
+
+- Added a blocking compatibility lane that runs the full test suite against the
+  declared minimum Home Assistant version using a reproducible, hash-verified
+  environment.
+
+### Fixed
+
+- Redacted API keys and precise configured coordinates from Home Assistant Repair
+  placeholders and related setup-failure context.
+
 ## [3.1.0] - 2026-08-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 ## [4.0.0] - 2026-08-18
 
-### Breaking Changes
+### Changed
 
 - **Breaking change:** Raised the minimum supported Home Assistant version from
   2026.3.0 to 2026.5.0. Upgrade Home Assistant to 2026.5.0 or newer before
   updating Pollen Levels. Users remaining on Home Assistant 2026.3.x or 2026.4.x
   should remain on Pollen Levels 3.1.0.
-
-### Changed
 
 - Added a blocking compatibility lane that runs the full test suite against the
   declared minimum Home Assistant version using a reproducible, hash-verified

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "3.1.0"
+    "version": "4.0.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
-# Tooling aligned to the Home Assistant 2026.3 Python floor (>=3.14.2).
+# Tooling aligned to the Home Assistant 2026.5 Python floor (>=3.14.2).
 
 [project]
 name = "pollenlevels"
-version = "3.1.0"
+version = "4.0.0"
 # Keep broad project metadata while the locked HA test environment enforces >=3.14.2.
 requires-python = ">=3.14"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1492,7 +1492,7 @@ wheels = [
 
 [[package]]
 name = "pollenlevels"
-version = "3.1.0"
+version = "4.0.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Prepare Pollen Levels 4.0.0.
- Treat the Home Assistant minimum-version increase from 2026.3.0 to 2026.5.0 as a breaking compatibility change.
- Ship the Repair placeholder privacy fix from #341.
- Publish the reproducible minimum-version compatibility lane from #342.
- Synchronize manifest, project, and lockfile versions.

## Breaking change

Pollen Levels 4.0.0 requires Home Assistant 2026.5.0 or newer.

Users running Home Assistant 2026.3.x or 2026.4.x should upgrade Home Assistant before updating Pollen Levels. Pollen Levels 3.1.0 remains the published release for those installations until Home Assistant is upgraded.

This major version does not introduce another Pollen Levels storage or registry migration. The v3 parent/config-subentry architecture and public entity/device identity contracts remain unchanged.

## Release contents

### Breaking Changes

- Raises the minimum supported Home Assistant version from 2026.3.0 to 2026.5.0.

### Changed

- Adds the blocking, hash-verified minimum Home Assistant compatibility lane.

### Fixed

- Redacts API keys and precise configured coordinates from Home Assistant Repair placeholders and related setup-failure context.

## Versioning decision

PR #343 originally prepared these release contents as 3.1.1. CodeRabbit correctly flagged that dropping support for Home Assistant 2026.3.x and 2026.4.x is an incompatible support-contract change.

The maintainer accepted that finding, closed #343 without merging it, preserved published v3.1.0 unchanged, and prepared this clean 4.0.0 release PR instead.

## Validation

- `uv lock --check`: passed.
- `ruff check .`: passed.
- `ruff format --check .`: passed (`63 files already formatted`).
- Full pytest suite: `680 passed in 16.35s`.
- `python -m compileall -q custom_components tests`: passed.
- `git diff --check`: passed.

`uv.lock` changes only the local `pollenlevels` version from 3.1.0 to 4.0.0; no dependency versions or hashes changed. Production/runtime code is unchanged. Migration and registry identity code are unchanged. Tests and workflows are unchanged. `hacs.json` and README are unchanged because #342 already synchronized the Home Assistant 2026.5.0 support floor. v3.1.0 and its tag remain untouched. No v4.0.0 tag or release has been created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the 4.0.0 release with support for Home Assistant 2026.5.0 and newer.
  - Improved privacy by hiding API keys and precise location details in repair and setup-failure messages.

- **Bug Fixes**
  - Added compatibility validation to help ensure reliable operation with the minimum supported Home Assistant version.

- **Documentation**
  - Updated release information and version details for the 4.0.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->