### PR TITLE
fix(sensor): restore HACS pollen statistics compatibility

### DIFF
--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -277,8 +277,8 @@ class PollenSensor(CoordinatorEntity, SensorEntity):
 
     # Keep forecast attributes available in live state but exclude from Recorder.
     _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
-    # Google exposes this value as current-day forecast data, not a measurement.
-    _attr_state_class: SensorStateClass | None = None
+    # Preserve HACS compatibility with historical pollen statistics.
+    _attr_state_class = SensorStateClass.MEASUREMENT
     # Hint the UI to show integers (does not affect recorder/statistics)
     _attr_suggested_display_precision = 0  # type: ignore[assignment]
     # Modern friendly name composition: Device name + Entity short name
@@ -482,8 +482,8 @@ class OverallPollenRiskTodaySensor(_BaseSummarySensor):
     _unrecorded_attributes = _FORECAST_UNRECORDED_ATTRIBUTES
     _attr_translation_key = "overall_pollen_risk_today"
     _attr_icon = DEFAULT_ICON
-    # This summary is derived from the same current-day forecast values.
-    _attr_state_class: SensorStateClass | None = None
+    # Preserve HACS compatibility with historical pollen statistics.
+    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 0  # type: ignore[assignment]
 
     def __init__(self, coordinator: PollenDataUpdateCoordinator) -> None:

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -7,9 +7,16 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 from aiointercept import aiointercept
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.components.recorder import statistics
+from homeassistant.components.sensor import SensorStateClass
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.components.recorder.common import (
+    async_wait_recording_done,
+    do_adhoc_statistics,
+)
 
 from custom_components.pollenlevels import (
     button as button_platform,
@@ -72,14 +79,14 @@ async def test_ha_platforms_create_entities_for_each_location_subentry(
         )
 
 
-async def test_ha_forecast_derived_current_day_sensors_have_no_state_class(
+async def test_ha_current_day_pollen_sensors_restore_measurement_state_class(
     hass: HomeAssistant,
     enable_custom_integrations: None,
     socket_enabled: None,
     ha_config_entry,
     google_pollen_5_day_payload: dict[str, Any],
 ) -> None:
-    """Current-day forecast values should not claim measurement semantics."""
+    """Current-day pollen values should preserve HACS statistics compatibility."""
     clear_integration_modules()
     entry = ha_config_entry
     entry.add_to_hass(hass)
@@ -98,11 +105,94 @@ async def test_ha_forecast_derived_current_day_sensors_have_no_state_class(
 
     for unique_id in (
         f"{identity_id}_type_grass",
+        f"{identity_id}_plants_birch",
         f"{identity_id}_overall_pollen_risk_today",
     ):
         state = hass.states.get(entity_ids_by_unique_id[unique_id])
         assert state is not None
+        assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+    for unique_id in (
+        f"{identity_id}_plants_in_season_today",
+        f"{identity_id}_top_pollen_types_today",
+        f"{identity_id}_region",
+    ):
+        state = hass.states.get(entity_ids_by_unique_id[unique_id])
+        assert state is not None
         assert "state_class" not in state.attributes
+
+
+async def test_ha_restored_state_class_reconciles_existing_statistics(
+    recorder_mock,
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+) -> None:
+    """Restored measurement metadata should reuse existing statistics identity."""
+    clear_integration_modules()
+    entry = ha_config_entry
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+    registry = er.async_get(hass)
+    identity_id = f"{entry.entry_id}_location-madrid"
+    unique_id = f"{identity_id}_type_grass"
+    registry_entry = next(
+        entity
+        for entity in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if entity.unique_id == unique_id
+    )
+    entity_id = registry_entry.entity_id
+    restored_state = hass.states.get(entity_id)
+    assert restored_state is not None
+    assert restored_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+    await async_wait_recording_done(hass)
+    now = dt_util.utcnow()
+    statistics_start = now.replace(
+        minute=now.minute - now.minute % 5,
+        second=0,
+        microsecond=0,
+    )
+    do_adhoc_statistics(hass, start=statistics_start)
+    await async_wait_recording_done(hass)
+
+    metadata_before = statistics.get_metadata(hass, statistic_ids={entity_id})
+    assert entity_id in metadata_before
+    metadata_id, metadata = metadata_before[entity_id]
+    assert metadata["statistic_id"] == entity_id
+    assert metadata["has_mean"] is True
+    assert metadata["has_sum"] is False
+    assert metadata["unit_of_measurement"] is None
+
+    state_31_attributes = dict(restored_state.attributes)
+    state_31_attributes.pop("state_class")
+    hass.states.async_set(entity_id, restored_state.state, state_31_attributes)
+    await hass.async_add_executor_job(statistics.update_statistics_issues, hass)
+    await hass.async_block_till_done()
+
+    issue_id = f"state_class_removed_{entity_id}"
+    issue_registry = ir.async_get(hass)
+    assert issue_registry.async_get_issue("sensor", issue_id) is not None
+
+    hass.states.async_set(entity_id, restored_state.state, restored_state.attributes)
+    await hass.async_add_executor_job(statistics.update_statistics_issues, hass)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue("sensor", issue_id) is None
+    metadata_after = statistics.get_metadata(hass, statistic_ids={entity_id})
+    assert metadata_after == metadata_before
+    assert metadata_after[entity_id][0] == metadata_id
+
+    current_state = hass.states.get(entity_id)
+    assert current_state is not None
+    assert current_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+    assert current_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
 
 
 async def test_ha_button_press_refreshes_only_location_coordinator(


### PR DESCRIPTION
## Summary

Relates to #346. This PR implements only PR 1 from the approved planning comment on that issue.

It restores `SensorStateClass.MEASUREMENT` on exactly:

- `PollenSensor`, covering the numeric current-day pollen type and plant entities;
- `OverallPollenRiskTodaySensor`.

This reverses the HACS behavior introduced by #311 for #303. It is an intentional Pollen Levels HACS compatibility policy that preserves useful seasonal long-term statistics and continuity for existing users. It is not a claim that Google forecast-derived D0 values satisfy strict Home Assistant Core present-time measurement semantics. A future independent Core integration remains out of scope.

## Expected upgrade behavior

The Home Assistant harness regression test creates real Recorder statistics metadata for an affected entity, reproduces the 3.1.0-shaped numeric state without a state class, and verifies Home Assistant creates `state_class_removed`. It then restores the corrected `measurement` state and verifies Home Assistant's normal statistics reconciliation removes the obsolete Repair.

The same test confirms that the statistic ID, metadata row, unit, and mean/sum compatibility remain unchanged. Pollen Levels does not delete or migrate existing statistics and does not manipulate Recorder Repairs directly.

Entity IDs, unique IDs, statistic IDs, device identifiers, and config-subentry associations are unchanged. Users who retained earlier statistics can continue the same series after the 3.1.0 gap. Users who deleted statistics can begin accumulating a fresh series through Home Assistant's normal behavior.

## Recorder scope

`_FORECAST_UNRECORDED_ATTRIBUTES` is unchanged. Future forecast attributes remain excluded from Recorder, including:

- `forecast`;
- `tomorrow_*`;
- `d2_*`;
- `trend`;
- `expected_peak`.

Unrelated summary and metadata sensors remain without a state class.

## Tests

The real Home Assistant harness now verifies:

- `state_class: measurement` on a representative pollen type entity;
- `state_class: measurement` on a representative plant entity;
- `state_class: measurement` on `OverallPollenRiskTodaySensor`;
- no unintended state class on plants-in-season, top-pollen-types, and region sensors;
- creation and automatic reconciliation of `state_class_removed` with existing Recorder metadata;
- stable statistic identity and compatible metadata before and after restoration.

## Validation

- `uv lock --check`: passed
- `ruff check .`: passed
- `ruff format --check .`: passed (`63 files already formatted`)
- focused Home Assistant harness tests: `2 passed, 5 deselected`
- `python -m compileall -q custom_components tests`: passed
- full pytest suite: `681 passed in 17.40s`
- `git diff --check`: passed

All locked commands used the required uv 0.12.4.

## Explicit non-goals

This PR contains no changes to:

- stale-cache expiry or coordinator behavior;
- summary memoization;
- v2-to-v3 migration, legacy IDs, registry identity, devices, or config subentries;
- config flow or parent/subentry architecture;
- API requests, parsing, retry, cooldown, forecast construction, or offsets;
- `pollenlevels.force_update` or Update now buttons;
- translations, README, FAQ, Terms, Privacy, or changelog;
- dependencies or version metadata;
- Recorder configuration/database or private Recorder APIs;
- release workflows, tags, releases, or publication;
- the future Home Assistant Core implementation.

This PR intentionally does not close #346 because cache hardening, documentation reconciliation, and final 4.0.0 release work remain separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pollen sensor metadata so current-day and overall pollen readings are recognized as measurements.
  * Preserved existing statistics and restored valid statistics tracking when sensor metadata is corrected.
  * Resolved related Home Assistant statistics validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->