### PR TITLE
fix(coordinator): discard expired stale pollen data

### DIFF
--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -245,6 +245,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
     def _schedule_cache_expiry(self) -> None:
         """Schedule removal of the current snapshot at the fixed TTL boundary."""
         self._cancel_cache_expiry()
+        if not self.data:
+            self.last_updated = None
+            return
         if self.last_updated is None or getattr(self, "config_entry", None) is None:
             return
 

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -205,6 +205,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.last_updated: datetime | None = None
         self.using_stale_data: bool = False
         self.last_payload_valid: bool | None = None
+        self._cache_expiry_handle: asyncio.TimerHandle | None = None
 
     def _utcnow(self) -> datetime:
         """Return the current UTC time."""
@@ -218,10 +219,68 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         """Return whether cached data is still within the stale-data tolerance."""
         if not self.data or self.last_updated is None:
             return False
-        return self._utcnow() - self.last_updated <= self._stale_data_ttl()
+        return self._utcnow() - self.last_updated < self._stale_data_ttl()
+
+    def _cancel_cache_expiry(self) -> None:
+        """Cancel the scheduled cache expiry callback."""
+        if self._cache_expiry_handle is not None:
+            self._cache_expiry_handle.cancel()
+            self._cache_expiry_handle = None
+
+    def _discard_expired_cache(self) -> bool:
+        """Discard the integration-owned snapshot once its TTL is reached."""
+        if (
+            not self.data
+            or self.last_updated is None
+            or self._utcnow() - self.last_updated < self._stale_data_ttl()
+        ):
+            return False
+
+        self._cancel_cache_expiry()
+        self.data = {}
+        self.last_updated = None
+        self.using_stale_data = False
+        self.last_payload_valid = False
+        return True
+
+    def _schedule_cache_expiry(self) -> None:
+        """Schedule removal of the current snapshot at the fixed TTL boundary."""
+        self._cancel_cache_expiry()
+        if self.last_updated is None or getattr(self, "config_entry", None) is None:
+            return
+
+        delay = max(
+            0.0,
+            (
+                self.last_updated + self._stale_data_ttl() - self._utcnow()
+            ).total_seconds(),
+        )
+        self._cache_expiry_handle = self.hass.loop.call_later(
+            delay, self._handle_cache_expiry, self.last_updated
+        )
+
+    def _handle_cache_expiry(self, expected_last_updated: datetime) -> None:
+        """Expire a snapshot without reporting an empty successful update."""
+        self._cache_expiry_handle = None
+        if self.last_updated != expected_last_updated:
+            return
+        if not self._discard_expired_cache():
+            self._schedule_cache_expiry()
+            return
+
+        was_successful = self.last_update_success
+        self.async_set_update_error(UpdateFailed("Cached pollen data expired"))
+        if not was_successful:
+            self.async_update_listeners()
+
+    async def async_shutdown(self) -> None:
+        """Cancel snapshot expiry and shut down coordinator scheduling."""
+        self._cancel_cache_expiry()
+        await super().async_shutdown()
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Fetch pollen data and extract sensors for current day and forecast."""
+        cache_expired = self._discard_expired_cache()
         try:
             payload = await self._client.async_fetch_pollen_data(
                 latitude=self.lat,
@@ -274,7 +333,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
                     self._missing_dailyinfo_warned = True
                 return self.data
             self.using_stale_data = False
-            if self.data:
+            if self.data or cache_expired:
                 if not self._stale_dailyinfo_warned:
                     _LOGGER.warning(
                         "API response missing or invalid dailyInfo; cached data expired"
@@ -432,6 +491,7 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.data = new_data
         self.last_updated = self._utcnow()
         self.using_stale_data = False
+        self._schedule_cache_expiry()
         if _LOGGER.isEnabledFor(logging.DEBUG):
             total = len(new_data)
             types = 0

--- a/custom_components/pollenlevels/coordinator.py
+++ b/custom_components/pollenlevels/coordinator.py
@@ -240,7 +240,6 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
         self.data = {}
         self.last_updated = None
         self.using_stale_data = False
-        self.last_payload_valid = False
         return True
 
     def _schedule_cache_expiry(self) -> None:
@@ -268,9 +267,9 @@ class PollenDataUpdateCoordinator(DataUpdateCoordinator):
             self._schedule_cache_expiry()
             return
 
-        was_successful = self.last_update_success
-        self.async_set_update_error(UpdateFailed("Cached pollen data expired"))
-        if not was_successful:
+        if self.last_update_success:
+            self.async_set_update_error(UpdateFailed("Cached pollen data expired"))
+        else:
             self.async_update_listeners()
 
     async def async_shutdown(self) -> None:

--- a/custom_components/pollenlevels/sensor.py
+++ b/custom_components/pollenlevels/sensor.py
@@ -437,6 +437,14 @@ class _BaseSummarySensor(CoordinatorEntity, SensorEntity):
 
         return self._summary_cache[key]
 
+    def _handle_coordinator_update(self) -> None:
+        """Release memoized data before writing an unavailable state."""
+        data = self.coordinator.data
+        if data is not self._summary_data_ref:
+            self._summary_data_ref = data
+            self._summary_cache = _daily_summary(data or {})
+        super()._handle_coordinator_update()
+
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose public attribution on all daily summary sensors."""

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -11,7 +12,11 @@ from homeassistant.components.recorder import statistics
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import (
+    entity_platform,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.components.recorder.common import (
     async_wait_recording_done,
@@ -193,6 +198,77 @@ async def test_ha_restored_state_class_reconciles_existing_statistics(
     assert current_state is not None
     assert current_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
     assert current_state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+
+async def test_ha_expired_snapshot_notifies_entities_and_releases_summary_cache(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    socket_enabled: None,
+    ha_two_location_config_entry,
+    google_pollen_5_day_payload: dict[str, Any],
+    monkeypatch,
+) -> None:
+    """Snapshot expiry should make one location unavailable and release summaries."""
+    clear_integration_modules()
+    entry = ha_two_location_config_entry
+    entry.add_to_hass(hass)
+
+    async with aiointercept(mock_external_urls=True) as mocked:
+        mock_pollen_api(mocked, google_pollen_5_day_payload)
+        await async_setup_config_entry(hass, entry)
+
+    madrid = entry.runtime_data.locations["location-madrid"].coordinator
+    barcelona = entry.runtime_data.locations["location-barcelona"].coordinator
+    old_madrid_data = madrid.data
+    old_barcelona_data = barcelona.data
+    summary = next(
+        entity
+        for platform in entity_platform.async_get_platforms(hass, DOMAIN)
+        for entity in platform.entities.values()
+        if type(entity).__name__ == "PlantsInSeasonTodaySensor"
+        and entity.coordinator is madrid
+    )
+    assert summary.native_value is not None
+    assert summary._summary_data_ref is old_madrid_data
+
+    expires_at = madrid.last_updated + madrid._stale_data_ttl()
+    monkeypatch.setattr(madrid, "_utcnow", lambda: expires_at)
+    madrid._cache_expiry_handle.cancel()
+    madrid._cache_expiry_handle = None
+    madrid._handle_cache_expiry(madrid.last_updated)
+    await hass.async_block_till_done()
+
+    assert madrid.data == {}
+    assert madrid.last_updated is None
+    assert madrid.using_stale_data is False
+    assert madrid.last_update_success is False
+    assert hass.states.get(summary.entity_id).state == STATE_UNAVAILABLE
+    assert summary._summary_data_ref is madrid.data
+    assert summary._summary_data_ref is not old_madrid_data
+    assert barcelona.data is old_barcelona_data
+    assert barcelona.last_update_success is True
+
+    recovery_time = expires_at + timedelta(minutes=1)
+    monkeypatch.setattr(madrid, "_utcnow", lambda: recovery_time)
+
+    async def _valid_response(**_kwargs: Any) -> dict[str, Any]:
+        return google_pollen_5_day_payload
+
+    monkeypatch.setattr(madrid._client, "async_fetch_pollen_data", _valid_response)
+    await madrid.async_refresh()
+    await hass.async_block_till_done()
+
+    assert madrid.data
+    assert madrid.last_updated == recovery_time
+    assert madrid.using_stale_data is False
+    assert madrid.last_update_success is True
+    assert hass.states.get(summary.entity_id).state != STATE_UNAVAILABLE
+
+    expiry_handles = (madrid._cache_expiry_handle, barcelona._cache_expiry_handle)
+    assert all(handle is not None for handle in expiry_handles)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert all(handle.cancelled() for handle in expiry_handles if handle is not None)
 
 
 async def test_ha_button_press_refreshes_only_location_coordinator(

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.components.recorder.common import (
     async_wait_recording_done,
@@ -241,6 +242,7 @@ async def test_ha_expired_snapshot_notifies_entities_and_releases_summary_cache(
     assert madrid.data == {}
     assert madrid.last_updated is None
     assert madrid.using_stale_data is False
+    assert madrid.last_payload_valid is True
     assert madrid.last_update_success is False
     assert hass.states.get(summary.entity_id).state == STATE_UNAVAILABLE
     assert summary._summary_data_ref is madrid.data
@@ -264,8 +266,25 @@ async def test_ha_expired_snapshot_notifies_entities_and_releases_summary_cache(
     assert madrid.last_update_success is True
     assert hass.states.get(summary.entity_id).state != STATE_UNAVAILABLE
 
+    existing_failure = UpdateFailed("existing transport failure")
+    barcelona.async_set_update_error(existing_failure)
+    assert barcelona.last_update_success is False
+    assert barcelona.last_exception is existing_failure
+
+    barcelona_expires_at = barcelona.last_updated + barcelona._stale_data_ttl()
+    monkeypatch.setattr(barcelona, "_utcnow", lambda: barcelona_expires_at)
+    barcelona._cache_expiry_handle.cancel()
+    barcelona._cache_expiry_handle = None
+    barcelona._handle_cache_expiry(barcelona.last_updated)
+    await hass.async_block_till_done()
+
+    assert barcelona.data == {}
+    assert barcelona.last_updated is None
+    assert barcelona.last_payload_valid is True
+    assert barcelona.last_exception is existing_failure
+
     expiry_handles = (madrid._cache_expiry_handle, barcelona._cache_expiry_handle)
-    assert all(handle is not None for handle in expiry_handles)
+    assert madrid._cache_expiry_handle is not None
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert all(handle.cancelled() for handle in expiry_handles if handle is not None)

--- a/tests/test_ha_platforms.py
+++ b/tests/test_ha_platforms.py
@@ -283,11 +283,12 @@ async def test_ha_expired_snapshot_notifies_entities_and_releases_summary_cache(
     assert barcelona.last_payload_valid is True
     assert barcelona.last_exception is existing_failure
 
-    expiry_handles = (madrid._cache_expiry_handle, barcelona._cache_expiry_handle)
-    assert madrid._cache_expiry_handle is not None
+    madrid_handle = madrid._cache_expiry_handle
+    assert madrid_handle is not None
+    assert barcelona._cache_expiry_handle is None
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert all(handle.cancelled() for handle in expiry_handles if handle is not None)
+    assert madrid_handle.cancelled()
 
 
 async def test_ha_button_press_refreshes_only_location_coordinator(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1434,16 +1434,18 @@ def test_coordinator_stale_cached_data_raises_after_ttl(
     finally:
         loop.close()
 
-    assert coordinator.data == first_data
+    assert first_data
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
     assert coordinator.using_stale_data is False
     assert coordinator.last_payload_valid is False
 
 
-def test_coordinator_stale_cached_data_accepted_at_exactly_24_hours(
+def test_coordinator_stale_cached_data_expires_at_exactly_24_hours(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cached data at exactly the 24-hour TTL boundary is still accepted."""
+    """Cached data expires at the exact 24-hour TTL boundary."""
 
     start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
     now = start
@@ -1462,11 +1464,50 @@ def test_coordinator_stale_cached_data_accepted_at_exactly_24_hours(
     try:
         first_data = loop.run_until_complete(coordinator._async_update_data())
         now = start + datetime.timedelta(hours=24)
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="cached data expired"
+        ):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert first_data
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is False
+
+
+def test_coordinator_stale_cached_data_is_fresh_just_before_ttl(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached data remains reusable immediately before the TTL boundary."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload()),
+            ResponseSpec(status=200, payload={}),
+        ]
+    )
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client, hours=24)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        first_updated = coordinator.last_updated
+        now = start + datetime.timedelta(hours=24) - datetime.timedelta(microseconds=1)
         second_data = loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
-    assert second_data == first_data
+    assert second_data is first_data
+    assert coordinator.data is first_data
+    assert coordinator.last_updated == first_updated
     assert coordinator.using_stale_data is True
     assert coordinator.last_payload_valid is False
 
@@ -1596,18 +1637,21 @@ def test_coordinator_preserves_stale_provenance_after_later_processing_failure(
 
 
 @pytest.mark.parametrize("exception_name", ["update_failed", "auth_failed"])
-def test_coordinator_transport_failures_leave_payload_state_unchanged(
+def test_coordinator_transport_failures_discard_expired_payload(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
     exception_name: str,
 ) -> None:
-    """Failures before dailyInfo validation must keep the retained-data state."""
+    """Failures before dailyInfo validation must not retain expired data."""
 
-    client = sensor_modules.client_mod.GooglePollenApiClient(FakeSession({}), "test")
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    client = sensor_modules.client_mod.GooglePollenApiClient(
+        FakeSession(_minimal_valid_payload()), "test"
+    )
     loop = asyncio.new_event_loop()
     coordinator = _make_coordinator(sensor_modules, loop, client)
-    coordinator.using_stale_data = True
-    coordinator.last_payload_valid = False
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
 
     exception_type = (
         sensor_modules.client_mod.UpdateFailed
@@ -1618,15 +1662,141 @@ def test_coordinator_transport_failures_leave_payload_state_unchanged(
     async def _raise_before_validation(**_kwargs: Any) -> dict[str, Any]:
         raise exception_type("request failed")
 
-    monkeypatch.setattr(client, "async_fetch_pollen_data", _raise_before_validation)
-
     try:
+        loop.run_until_complete(coordinator._async_update_data())
+        monkeypatch.setattr(client, "async_fetch_pollen_data", _raise_before_validation)
+        now = start + datetime.timedelta(hours=24)
         with pytest.raises(exception_type, match="request failed"):
             loop.run_until_complete(coordinator._async_update_data())
     finally:
         loop.close()
 
-    assert coordinator.using_stale_data is True
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is False
+
+
+def test_coordinator_transport_failure_before_ttl_preserves_snapshot(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport failure before expiry should leave the snapshot scheduled."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    client = sensor_modules.client_mod.GooglePollenApiClient(
+        FakeSession(_minimal_valid_payload()), "test"
+    )
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    async def _raise_before_validation(**_kwargs: Any) -> dict[str, Any]:
+        raise sensor_modules.client_mod.UpdateFailed("request failed")
+
+    try:
+        first_data = loop.run_until_complete(coordinator._async_update_data())
+        first_updated = coordinator.last_updated
+        monkeypatch.setattr(client, "async_fetch_pollen_data", _raise_before_validation)
+        now = start + datetime.timedelta(hours=23)
+        with pytest.raises(
+            sensor_modules.client_mod.UpdateFailed, match="request failed"
+        ):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert coordinator.data is first_data
+    assert coordinator.last_updated == first_updated
+
+
+@pytest.mark.parametrize("exception_name", ["unexpected", "cancelled"])
+def test_coordinator_other_failures_discard_expired_payload(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_name: str,
+) -> None:
+    """Unexpected errors and cancellation keep their classification after expiry."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    client = sensor_modules.client_mod.GooglePollenApiClient(
+        FakeSession(_minimal_valid_payload()), "test"
+    )
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    async def _raise_before_validation(**_kwargs: Any) -> dict[str, Any]:
+        if exception_name == "cancelled":
+            raise asyncio.CancelledError
+        raise RuntimeError("unexpected request failure")
+
+    expected_exception = (
+        asyncio.CancelledError
+        if exception_name == "cancelled"
+        else sensor_modules.client_mod.UpdateFailed
+    )
+
+    try:
+        loop.run_until_complete(coordinator._async_update_data())
+        monkeypatch.setattr(client, "async_fetch_pollen_data", _raise_before_validation)
+        now = start + datetime.timedelta(hours=24)
+        with pytest.raises(expected_exception):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.using_stale_data is False
+    assert coordinator.last_payload_valid is False
+
+
+@pytest.mark.parametrize("status", [429, 500])
+def test_coordinator_exhausted_retry_discards_expired_payload(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+) -> None:
+    """An exhausted HTTP retry path must not retain an expired snapshot."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    error_payload = {"error": {"message": "request failed"}}
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload()),
+            ResponseSpec(status=status, payload=error_payload),
+            ResponseSpec(status=status, payload=error_payload),
+        ]
+    )
+
+    async def _fast_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(sensor_modules.client_mod.asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(
+        sensor_modules.client_mod.random, "uniform", lambda *_args, **_kwargs: 0.0
+    )
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        loop.run_until_complete(coordinator._async_update_data())
+        now = start + datetime.timedelta(hours=24)
+        with pytest.raises(sensor_modules.client_mod.UpdateFailed):
+            loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert session.calls == 3
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.using_stale_data is False
     assert coordinator.last_payload_valid is False
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1583,6 +1583,29 @@ def test_coordinator_stale_data_ttl_is_fixed_24_hours(
     assert twenty_four_hour._stale_data_ttl() == datetime.timedelta(hours=24)
 
 
+def test_coordinator_empty_valid_payload_does_not_schedule_expiry(
+    sensor_modules: SensorModules,
+) -> None:
+    """An empty valid payload should not retain a timestamp or arm a timer."""
+
+    session = FakeSession({"dailyInfo": [{}]})
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    coordinator.config_entry = object()
+
+    try:
+        data = loop.run_until_complete(coordinator._async_update_data())
+    finally:
+        loop.close()
+
+    assert data == {}
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.last_payload_valid is True
+    assert coordinator._cache_expiry_handle is None
+
+
 def test_coordinator_success_after_malformed_response_updates_last_updated(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
@@ -1715,7 +1738,7 @@ def test_coordinator_transport_failure_before_ttl_preserves_snapshot(
     sensor_modules: SensorModules,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A transport failure before expiry should leave the snapshot scheduled."""
+    """A transport failure before the TTL should preserve the cached snapshot."""
 
     start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
     now = start

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1512,6 +1512,40 @@ def test_coordinator_stale_cached_data_is_fresh_just_before_ttl(
     assert coordinator.last_payload_valid is False
 
 
+def test_coordinator_expiry_preserves_previous_malformed_payload_status(
+    sensor_modules: SensorModules,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expiry should preserve the previous malformed-payload status."""
+
+    start = datetime.datetime(2025, 5, 9, 12, tzinfo=datetime.UTC)
+    now = start
+    session = SequenceSession(
+        [
+            ResponseSpec(status=200, payload=_minimal_valid_payload()),
+            ResponseSpec(status=200, payload={}),
+        ]
+    )
+    client = sensor_modules.client_mod.GooglePollenApiClient(session, "test")
+    loop = asyncio.new_event_loop()
+    coordinator = _make_coordinator(sensor_modules, loop, client)
+    monkeypatch.setattr(coordinator, "_utcnow", lambda: now)
+
+    try:
+        loop.run_until_complete(coordinator._async_update_data())
+        now = start + datetime.timedelta(hours=1)
+        loop.run_until_complete(coordinator._async_update_data())
+        assert coordinator.last_payload_valid is False
+        now = start + datetime.timedelta(hours=24)
+        assert coordinator._discard_expired_cache() is True
+    finally:
+        loop.close()
+
+    assert coordinator.data == {}
+    assert coordinator.last_updated is None
+    assert coordinator.last_payload_valid is False
+
+
 def test_coordinator_stale_data_ttl_is_fixed_24_hours(
     sensor_modules: SensorModules,
 ) -> None:
@@ -1674,7 +1708,7 @@ def test_coordinator_transport_failures_discard_expired_payload(
     assert coordinator.data == {}
     assert coordinator.last_updated is None
     assert coordinator.using_stale_data is False
-    assert coordinator.last_payload_valid is False
+    assert coordinator.last_payload_valid is True
 
 
 def test_coordinator_transport_failure_before_ttl_preserves_snapshot(
@@ -1751,7 +1785,7 @@ def test_coordinator_other_failures_discard_expired_payload(
     assert coordinator.data == {}
     assert coordinator.last_updated is None
     assert coordinator.using_stale_data is False
-    assert coordinator.last_payload_valid is False
+    assert coordinator.last_payload_valid is True
 
 
 @pytest.mark.parametrize("status", [429, 500])
@@ -1797,7 +1831,7 @@ def test_coordinator_exhausted_retry_discards_expired_payload(
     assert coordinator.data == {}
     assert coordinator.last_updated is None
     assert coordinator.using_stale_data is False
-    assert coordinator.last_payload_valid is False
+    assert coordinator.last_payload_valid is True
 
 
 def test_coordinator_rejects_removed_forecast_day_arguments(


### PR DESCRIPTION
## Summary

Follow-up context: #346. This implements only PR 2 from the approved planning work; it does not reopen or close the issue.

The #346 analysis found that Pollen Levels stopped *reusing* malformed-response cache data after 24 hours but could keep the expired coordinator mapping referenced until a later valid refresh or unload. Failures before `dailyInfo` validation could also leave that reference in place.

This PR makes the integration-owned snapshot expire at a strict boundary:

- age `< 24 hours`: malformed `dailyInfo` may reuse the previous successful snapshot without extending `last_updated`;
- age `>= 24 hours`: the snapshot is cleared, `last_updated` is cleared, stale-use markers are reset, and the coordinator follows normal failed-update semantics.

An empty payload is never reported as a successful refresh.

## Design

A small coordinator-owned asyncio expiry handle is scheduled after each successful refresh. A scheduled mechanism is required because the configured update interval may itself be 24 hours, and a failed manual refresh or delayed scheduled refresh could otherwise leave the snapshot retained beyond its TTL. A refresh-entry expiry check provides a conservative fallback if the callback is delayed.

The expiry handle is replaced after each successful refresh and cancelled through the coordinator's normal config-entry shutdown lifecycle. It applies per coordinator, so one location's expiry does not affect siblings.

The same expiry postcondition applies before malformed payload validation and before client transport, exhausted 429/5xx retry, authentication, unexpected-error, or cancellation propagation. Existing exception classification, redaction, retry, cooldown, and cancellation behavior remain unchanged.

On scheduled expiry, Home Assistant's public `DataUpdateCoordinator` error/listener behavior marks entities unavailable. A later valid response restores data, `last_updated`, successful availability, and normal state.

## Summary memoization evidence

A real Home Assistant lifecycle regression test demonstrated that an unavailable entity does not evaluate its native value. Consequently, `_BaseSummarySensor._summary_data_ref` retained the old coordinator mapping after expiry.

The smallest necessary `sensor.py` change refreshes the summary memoization reference in the existing coordinator listener before Home Assistant writes state. The test now proves the old mapping is released, the entity becomes unavailable, and recovery works. No broader summary-cache redesign is included.

## Tests

Coverage includes:

- malformed `dailyInfo` reuse immediately before the TTL without extending `last_updated`;
- exact-boundary and after-boundary expiration;
- actual snapshot/timestamp/marker clearing;
- client `UpdateFailed`, authentication failure, exhausted 429/5xx retry, unexpected error, and `CancelledError` paths;
- unchanged pre-expiry transport behavior;
- later successful recovery;
- real Home Assistant listener/availability behavior;
- summary memoization reference release;
- multiple-location isolation;
- expiry-handle cancellation on unload.

## Validation

- `uv lock --check`: passed
- `ruff check .`: passed
- `ruff format --check .`: passed (`63 files already formatted`)
- focused cache/failure tests: `11 passed, 90 deselected`
- focused Home Assistant lifecycle test: `1 passed, 7 deselected`
- full pytest suite: `689 passed in 17.02s`
- `python -m compileall -q custom_components tests`: passed
- `git diff --check`: passed

All locked commands used the required uv 0.12.4.

## Explicit non-goals

This PR does not change:

- the state-class/statistics compatibility restored by #347;
- Home Assistant Recorder history, long-term statistics, or their databases;
- API parsing, retries, backoff, cooldowns, request serialization, or forecast construction;
- migration, legacy IDs, entity/unique/device/registry identity, or config subentries;
- config flow, update interval limits, forecast offsets, public forecast attributes, or Recorder exclusions;
- `pollenlevels.force_update` or Update now behavior;
- translations, dependencies, documentation, changelog, version metadata, release workflows, tags, releases, or publication.

No migration, identity, release, documentation, or Recorder/LTS/history changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pollen data now expires after 24 hours, preventing outdated readings from being shown.
  * Expired readings are cleared and affected sensors are marked unavailable until fresh data is retrieved.
  * Data refreshes automatically restore sensor availability when successful.
  * Daily pollen summaries now refresh correctly when updated data becomes available.
  * Existing error states are preserved while expired or unavailable data is handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->