### PR TITLE
docs: clarify pollen retention and statistics

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -265,8 +265,15 @@ terms reviewed do not expressly classify these Home Assistant-derived aggregates
 for retention purposes, so this project does not claim that they are either
 permitted indefinitely or prohibited after 365 days. The Google Cloud project
 and API-key owner remains responsible for the agreement applicable to that
-account. Users seeking a conservative interpretation can configure local
-Recorder and statistics retention accordingly.
+account.
+
+Normal Recorder state history follows the user's configured retention and
+purging. Home Assistant's hourly long-term-statistics aggregates are stored
+separately and are not automatically purged by normal Recorder retention. Users
+seeking a conservative interpretation can exclude the affected entities from
+Recorder to prevent future history and statistics, then manage any existing
+long-term statistics separately under **Developer Tools → Statistics**.
+Excluding an entity does not remove statistics already stored for it.
 
 Pollen Levels does not automatically purge a user's Recorder history or
 long-term-statistics database. See [PRIVACY.md](PRIVACY.md) for more detail.

--- a/FAQ.md
+++ b/FAQ.md
@@ -240,7 +240,7 @@ entities such as `sensor.example_grass_d1` or `sensor.example_grass_d2`.
 
 ---
 
-## 15. Does Home Assistant Recorder store pollen forecast data?
+## 15. How are pollen data, Recorder history, and long-term statistics retained?
 
 Live forecast attributes remain available in Home Assistant for dashboards,
 templates, automations, and compatible custom cards. Future forecast-derived
@@ -250,13 +250,26 @@ attributes such as `forecast`, `tomorrow_*`, `d2_*`, `trend`, and
 Current states and non-forecast attributes may still be recorded according to
 your Home Assistant Recorder configuration.
 
-Under the current Pollen API service-specific terms, today's forecast values may
-be cached for up to 365 consecutive calendar days, and future forecast values may
-be cached for no more than 24 hours. Users with Recorder retention above 365
-days should exclude Pollen Levels entities or otherwise ensure compliant
-retention.
+Pollen Levels does not retain its own stale Pollen API coordinator snapshot
+beyond its fixed 24-hour runtime cache lifetime. This runtime cache is separate
+from Home Assistant Recorder.
 
-Pollen Levels does not automatically purge existing Recorder history.
+Under the current Pollen API service-specific terms, Today's Forecast Google
+Maps Content may be cached for up to 365 consecutive calendar days, while
+Forecast values may be cached for no more than 24 hours.
+
+Home Assistant may also generate long-term statistics such as hourly minimum,
+maximum, and mean values from eligible numeric entity states. These are locally
+generated aggregates, not retained raw Pollen API response payloads. The Google
+terms reviewed do not expressly classify these Home Assistant-derived aggregates
+for retention purposes, so this project does not claim that they are either
+permitted indefinitely or prohibited after 365 days. The Google Cloud project
+and API-key owner remains responsible for the agreement applicable to that
+account. Users seeking a conservative interpretation can configure local
+Recorder and statistics retention accordingly.
+
+Pollen Levels does not automatically purge a user's Recorder history or
+long-term-statistics database. See [PRIVACY.md](PRIVACY.md) for more detail.
 
 ---
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-Last updated: July 10, 2026
+Last updated: August 20, 2026
 
 This policy describes how the Pollen Levels Home Assistant custom integration
 handles data. It is not legal advice and does not state that the project has
@@ -55,7 +55,7 @@ Google's handling of this data is governed by the
 [Google Privacy Policy](https://policies.google.com/privacy) and applicable
 Google Maps Platform terms.
 
-## Home Assistant Recorder and retention
+## Runtime cache, Recorder, and long-term statistics
 
 Future forecast-derived attributes such as `forecast`, `tomorrow_*`, `d2_*`,
 `trend`, and `expected_peak` remain available in the live Home Assistant entity
@@ -65,15 +65,23 @@ Pollen Levels marks those attributes as excluded from Recorder persistence.
 Current states and other non-excluded attributes may still be stored by Home
 Assistant Recorder according to your Recorder configuration.
 
-Stale Google Pollen forecast payload reuse by the integration is capped at 24
-hours.
+Pollen Levels does not retain its own stale Pollen API coordinator snapshot
+beyond the fixed 24-hour runtime cache lifetime. This integration-owned runtime
+cache is separate from Home Assistant Recorder history and long-term statistics.
 
-You are responsible for configuring Recorder so today's pollen values are not
-retained for more than 365 days where the applicable Google terms require that
-limit. If your Recorder retention is longer than 365 days, exclude Pollen Levels
-entities or use an equivalent retention strategy.
+Home Assistant may generate long-term-statistics aggregates for the numeric
+Pollen Levels sensors that use `SensorStateClass.MEASUREMENT`. These minimum,
+maximum, and mean values are derived locally from entity states rather than
+stored raw Pollen API response payloads. The cited Google terms specify caching
+periods for Google Maps Content but do not expressly resolve how these
+Home Assistant-derived aggregates should be classified for retention purposes.
+Users remain responsible for the Google agreement applicable to their Google
+Cloud project and API key and control their local Recorder and statistics
+storage. Users seeking a conservative interpretation can configure that local
+retention accordingly.
 
-Pollen Levels cannot centrally delete or control your Recorder database.
+Pollen Levels does not automatically purge and cannot centrally delete or
+control a user's Recorder history or long-term-statistics database.
 
 ## Logs and diagnostics
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -76,9 +76,15 @@ stored raw Pollen API response payloads. The cited Google terms specify caching
 periods for Google Maps Content but do not expressly resolve how these
 Home Assistant-derived aggregates should be classified for retention purposes.
 Users remain responsible for the Google agreement applicable to their Google
-Cloud project and API key and control their local Recorder and statistics
-storage. Users seeking a conservative interpretation can configure that local
-retention accordingly.
+Cloud project and API key and control their local Home Assistant storage.
+
+Normal Recorder state history follows the user's configured retention and
+purging. Home Assistant's hourly long-term-statistics aggregates are stored
+separately and are not automatically purged by normal Recorder retention. Users
+seeking a conservative interpretation can exclude the affected entities from
+Recorder to prevent future history and statistics, then manage any existing
+long-term statistics separately under **Developer Tools → Statistics**.
+Excluding an entity does not remove statistics already stored for it.
 
 Pollen Levels does not automatically purge and cannot centrally delete or
 control a user's Recorder history or long-term-statistics database.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Live forecast attributes remain available to dashboards, templates, automations,
 and compatible custom cards. Pollen Levels excludes `forecast`, `tomorrow_*`,
 `d2_*`, `trend`, and `expected_peak` from Home Assistant Recorder persistence,
 while current states and non-excluded attributes remain subject to your Recorder
-configuration.
+configuration. Its own stale Pollen API coordinator snapshot has a fixed 24-hour
+runtime cache lifetime. Recorder history and Home Assistant-generated long-term
+statistics are separate local storage layers; see [PRIVACY.md](PRIVACY.md) for
+details.
 
 ---
 
@@ -101,24 +104,20 @@ Go to **Settings → Devices & Services → Pollen Levels → Configure**.
 
 ---
 
-## Upgrading to 3.1.0: remove obsolete long-term statistics
+## Upgrading to 4.0.0: long-term statistics restored
 
-Pollen Levels 3.1.0 stops generating Home Assistant long-term statistics for
-current-day pollen type and plant forecast sensors and for the
-`overall_pollen_risk_today` sensor.
+Pollen Levels 4.0.0 restores long-term-statistics eligibility for current-day
+pollen type and plant sensors and `overall_pollen_risk_today`, matching the HACS
+integration behavior available before 3.1.0. If you kept earlier statistics,
+Home Assistant can continue them under the same entity and statistic identity,
+although the period on 3.1.0 may contain a gap. Statistics manually deleted
+after upgrading to 3.1.0 cannot be reconstructed automatically; new statistics
+start after upgrading to 4.0.0.
 
-Earlier versions exposed these forecast-derived values with
-`SensorStateClass.MEASUREMENT`, so Home Assistant may still retain long-term
-statistics created before the upgrade. These values represent forecasts rather
-than actual measurements and should not be kept as historical measurements.
-
-After upgrading to 3.1.0, open **Settings → Developer Tools → Statistics** and
-remove the obsolete statistics for the affected Pollen Levels sensors.
-
-This cleanup only removes the previously generated long-term statistics. Normal
-Recorder history is separate and continues to follow your Recorder retention
-configuration. Pollen Levels 3.1.0 and later will not generate new long-term
-statistics for these forecast-derived sensors.
+No entity ID, unique ID, or device identity changes are involved. These numeric
+states remain based on Google's current-day forecast rather than direct physical
+observations. Future `forecast`, `tomorrow_*`, `d2_*`, `trend`, and
+`expected_peak` attributes remain excluded from Recorder persistence.
 
 ## Migrating from per-day forecast sensors
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -91,8 +91,15 @@ Content, but they do not expressly classify these Home Assistant-generated
 aggregates for retention purposes. This documentation therefore makes no legal
 conclusion that such aggregates are either permitted indefinitely or prohibited
 after 365 days. The Google Cloud project and API-key owner remains responsible
-for the agreement applicable to that account. Users seeking a conservative
-interpretation can configure Recorder and statistics retention accordingly.
+for the agreement applicable to that account.
+
+Normal Recorder state history follows the user's configured retention and
+purging. Home Assistant's hourly long-term-statistics aggregates are stored
+separately and are not automatically purged by normal Recorder retention. Users
+seeking a conservative interpretation can exclude the affected entities from
+Recorder to prevent future history and statistics, then manage any existing
+long-term statistics separately under **Developer Tools → Statistics**.
+Excluding an entity does not remove statistics already stored for it.
 
 Pollen Levels does not automatically purge Home Assistant Recorder history or
 long-term statistics and cannot control the user's local database.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,6 +1,6 @@
 # Terms of Use
 
-Last updated: July 10, 2026
+Last updated: August 20, 2026
 
 These terms are provided for the Pollen Levels Home Assistant custom integration.
 They are not legal advice and do not state that the project has received legal
@@ -15,10 +15,12 @@ sponsored by, or endorsed by Google or the Home Assistant project.
 
 ## Google Maps features and content
 
-Pollen Levels includes Google Maps features and content supplied through the
-Google Maps Pollen API. Use of those features and content is subject to the
-current [Google Maps End User Additional Terms](https://maps.google.com/help/terms_maps/)
-and the [Google Privacy Policy](https://policies.google.com/privacy).
+By using Pollen Levels and Google Maps features and content exposed through the
+integration, you acknowledge that such use is subject to the applicable
+[Google Maps End User Additional Terms](https://maps.google.com/help/terms_maps/)
+and [Google Privacy Policy](https://policies.google.com/privacy). The owner of
+the Google Cloud project and API key is responsible for complying with the
+Google Maps Platform agreement applicable to that account.
 
 Google Maps Platform terms and service-specific terms may also apply to your
 Google Cloud account and use of the API, including:
@@ -29,9 +31,10 @@ Google Cloud account and use of the API, including:
 - [Google Maps Platform EEA Terms](https://cloud.google.com/terms/maps-platform/eea)
 - [Google Maps Platform EEA Service Specific Terms](https://cloud.google.com/terms/maps-platform/eea/maps-service-terms)
 
-The Google agreement applicable to you can depend on your Google Cloud account,
-billing address, and relationship with Google. These terms do not replace or
-reinterpret Google's terms.
+The applicable Google agreement can depend on the Google Cloud account, billing
+address, and relationship with Google. Installing Pollen Levels is not itself
+presented as acceptance of a Google Maps Platform customer agreement. These
+terms do not replace or reinterpret Google's terms.
 
 ## Attribution
 
@@ -71,11 +74,28 @@ Under the current Pollen API service-specific caching terms:
 
 Pollen Levels does not use Pollen API heatmap tiles.
 
-Pollen Levels excludes future forecast-derived attributes from Home Assistant
-Recorder persistence, but it does not automatically purge Home Assistant
-Recorder history. Users configuring Home Assistant Recorder retention beyond 365
-days must exclude Pollen Levels entities or otherwise prevent current pollen data
-from being retained beyond the applicable limit.
+Pollen Levels does not retain its own stale Pollen API coordinator snapshot
+beyond the fixed 24-hour runtime cache lifetime. This integration-owned cache is
+separate from Home Assistant's local storage.
+
+Pollen Levels excludes future `forecast`, `tomorrow_*`, `d2_*`, `trend`, and
+`expected_peak` attributes from Home Assistant Recorder persistence. Recorder
+may store current states and other non-excluded attributes according to the
+user's configuration.
+
+Home Assistant may independently generate long-term statistics, including
+minimum, maximum, and mean aggregates, from eligible numeric entity states.
+These locally derived statistics are not stored raw Pollen API response
+payloads. The cited Google terms specify caching periods for Google Maps
+Content, but they do not expressly classify these Home Assistant-generated
+aggregates for retention purposes. This documentation therefore makes no legal
+conclusion that such aggregates are either permitted indefinitely or prohibited
+after 365 days. The Google Cloud project and API-key owner remains responsible
+for the agreement applicable to that account. Users seeking a conservative
+interpretation can configure Recorder and statistics retention accordingly.
+
+Pollen Levels does not automatically purge Home Assistant Recorder history or
+long-term statistics and cannot control the user's local database.
 
 You must not use the integration to scrape, bulk-export, rehost, resell, or
 create an independent historical pollen database from Google Maps Content.

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -595,11 +595,20 @@ def test_documentation_distinguishes_runtime_cache_and_home_assistant_storage() 
         assert "Recorder" in document, name
         assert "long-term statistics" in document, name
         assert "locally" in document and "derived" in document, name
+        assert "not automatically purged by normal Recorder retention" in document, name
+        assert "Developer Tools → Statistics" in document, name
+        assert (
+            "Excluding an entity does not remove statistics already stored" in document
+        ), name
 
     old_blanket_guidance = (
         "Recorder retention beyond 365 days must exclude Pollen Levels entities"
     )
     assert all(old_blanket_guidance not in document for document in documents.values())
+    misleading_retention_guidance = "configure Recorder and statistics retention"
+    assert all(
+        misleading_retention_guidance not in document for document in documents.values()
+    )
 
 
 def test_faq_documents_privacy_and_retention_guidance() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -583,12 +583,32 @@ def test_google_maps_retention_limits_are_documented() -> None:
     ) in terms
 
 
+def test_documentation_distinguishes_runtime_cache_and_home_assistant_storage() -> None:
+    """Keep runtime cache, Recorder, and derived statistics clearly separated."""
+    documents = {
+        path.name: " ".join(_read_text(path).split())
+        for path in (FAQ_PATH, TERMS_PATH, PRIVACY_PATH)
+    }
+
+    for name, document in documents.items():
+        assert "fixed 24-hour runtime cache" in document, name
+        assert "Recorder" in document, name
+        assert "long-term statistics" in document, name
+        assert "locally" in document and "derived" in document, name
+
+    old_blanket_guidance = (
+        "Recorder retention beyond 365 days must exclude Pollen Levels entities"
+    )
+    assert all(old_blanket_guidance not in document for document in documents.values())
+
+
 def test_faq_documents_privacy_and_retention_guidance() -> None:
     """Ensure FAQ keeps its privacy and retention guidance."""
     faq = " ".join(_read_text(FAQ_PATH).split())
 
     assert "[PRIVACY.md](PRIVACY.md)" in faq
     assert (
-        "today's forecast values may be cached for up to 365 consecutive calendar days"
+        "Today's Forecast Google Maps Content may be cached for up to "
+        "365 consecutive calendar days"
     ) in faq
-    assert "future forecast values may be cached for no more than 24 hours" in faq
+    assert "Forecast values may be cached for no more than 24 hours" in faq

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -583,6 +583,20 @@ def test_google_maps_retention_limits_are_documented() -> None:
     ) in terms
 
 
+def test_readme_documents_4_0_statistics_restoration_and_runtime_cache() -> None:
+    """Keep the README upgrade and runtime-cache guidance current."""
+    readme = " ".join(_read_text(README_PATH).split())
+
+    assert "fixed 24-hour runtime cache lifetime" in readme
+    assert "Upgrading to 4.0.0: long-term statistics restored" in readme
+    assert "same entity and statistic identity" in readme
+    assert (
+        "Statistics manually deleted after upgrading to 3.1.0 cannot be "
+        "reconstructed automatically"
+    ) in readme
+    assert "Upgrading to 3.1.0: remove obsolete long-term statistics" not in readme
+
+
 def test_documentation_distinguishes_runtime_cache_and_home_assistant_storage() -> None:
     """Keep runtime cache, Recorder, and derived statistics clearly separated."""
     documents = {


### PR DESCRIPTION
## Summary

Documentation follow-up to #346 after the merged runtime changes in #347 and #348.

- replaces the obsolete 3.1.0 statistics-deletion guidance with 4.0.0 upgrade guidance describing restored long-term-statistics eligibility and continuity
- distinguishes Google Maps Content retention, Pollen Levels' fixed 24-hour runtime coordinator cache, Home Assistant Recorder history, and Home Assistant-generated long-term statistics
- records the current Google Pollen API caching periods for Today's Forecast and Forecast values without assigning an unsupported legal classification to locally derived Home Assistant statistics
- clarifies Google end-user terms, API-key/project-owner responsibility, local storage, privacy, and user control
- adds focused metadata tests protecting these documentation distinctions

## Compatibility and scope

The restored `MEASUREMENT` policy from #347 is documented as an intentional HACS compatibility/statistics-continuity choice; the source states remain Google's current-day forecast values rather than direct physical observations. Future forecast attributes remain excluded from Recorder.

This PR changes documentation and documentation-consistency tests only. It includes no runtime, state-class, Recorder, migration, entity or registry identity, dependency, version, changelog, workflow, or release changes. It does not modify the cache implementation delivered by #348.

## Official-source review

The current Google Maps Platform and EEA service-specific terms continue to list 365 consecutive calendar days for Today's Forecast Google Maps Content and 24 hours for Forecast and Heatmap values. Pollen Levels does not use heatmap tiles. Current Home Assistant documentation describes `MEASUREMENT` statistics as locally generated minimum, maximum, and mean aggregates and separately documents unrecorded attributes.

The reviewed Google terms do not expressly classify Home Assistant-generated long-term-statistics aggregates for retention purposes. The docs therefore state that ambiguity without claiming express permission or prohibition and retain responsibility with the owner of the applicable Google Cloud project/API key agreement. This is not legal advice.

## Validation

- `uv lock --check`
- `uv run --locked --no-sync ruff check .`
- `uv run --locked --no-sync ruff format --check .`
- `uv run --locked --no-sync python -m pytest -q tests/test_metadata.py`
- `PYTHONPATH=. uv run --locked --no-sync python -m pytest -q` — 692 passed
- `uv run --locked --no-sync python -m compileall -q custom_components tests`
- `git diff --check`

Follow-up context only: #346. This PR does not reopen or close that issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded privacy, terms, FAQ, and README guidance on 24-hour runtime caching, Recorder history, and long-term statistics.
  * Clarified retention controls, exclusions, statistics management, and data-purging limitations.
  * Updated upgrade guidance for restoring long-term-statistics eligibility and handling continuity or gaps.
  * Updated document dates and clarified Google Maps terms applicability.

* **Tests**
  * Added consistency checks to ensure retention and caching documentation remains accurate and aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->