### PR TITLE
ci: keep Home Assistant compatibility canary aligned with latest stable

### DIFF
--- a/.github/workflows/ha-compatibility-canary.yml
+++ b/.github/workflows/ha-compatibility-canary.yml
@@ -116,12 +116,23 @@ jobs:
                       headers={"User-Agent": "pollenlevels-ha-compatibility-canary"},
                   )
                   with urllib.request.urlopen(request, timeout=15) as response:
-                      releases = json.load(response)["releases"]
+                      payload = json.load(response)
+                  if not isinstance(payload, dict):
+                      raise ValueError("PyPI response is not a mapping")
+                  releases = payload.get("releases")
+                  if not isinstance(releases, dict):
+                      raise ValueError("PyPI releases are not a mapping")
+                  if any(
+                      not isinstance(release, str)
+                      or not isinstance(files, list)
+                      or any(not isinstance(file, dict) for file in files)
+                      for release, files in releases.items()
+                  ):
+                      raise ValueError("PyPI release entries have an invalid shape")
                   break
               except (
-                  json.JSONDecodeError,
-                  KeyError,
                   TimeoutError,
+                  ValueError,
                   urllib.error.URLError,
               ) as err:
                   if attempt == 3:

--- a/.github/workflows/ha-compatibility-canary.yml
+++ b/.github/workflows/ha-compatibility-canary.yml
@@ -125,7 +125,11 @@ jobs:
                   if any(
                       not isinstance(release, str)
                       or not isinstance(files, list)
-                      or any(not isinstance(file, dict) for file in files)
+                      or any(
+                          not isinstance(file, dict)
+                          or not isinstance(file.get("yanked", False), bool)
+                          for file in files
+                      )
                       for release, files in releases.items()
                   ):
                       raise ValueError("PyPI release entries have an invalid shape")

--- a/.github/workflows/ha-compatibility-canary.yml
+++ b/.github/workflows/ha-compatibility-canary.yml
@@ -2,7 +2,7 @@ name: Latest Home Assistant Compatibility Canary
 
 on:
   schedule:
-    - cron: "17 5 * * *"
+    - cron: "17 */6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -71,6 +71,8 @@ jobs:
 
       - name: Resolve latest stable Home Assistant harness
         shell: bash
+        env:
+          UV_EXCLUDE_NEWER: "false"
         run: |
           set -euo pipefail
           uv pip install --python "$CANARY_PYTHON" \
@@ -82,10 +84,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$CANARY_PYTHON" - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          "$CANARY_PYTHON" - <<'PY'
           import importlib.metadata
+          import json
           import os
           import subprocess
+          import time
+          import urllib.error
+          import urllib.request
+
+          from packaging.requirements import Requirement
+          from packaging.version import InvalidVersion, Version
 
           names = (
               "pytest-homeassistant-custom-component",
@@ -99,18 +108,102 @@ jobs:
               name: importlib.metadata.version(name)
               for name in names
           }
+          metadata_url = "https://pypi.org/pypi/homeassistant/json"
+          for attempt in range(1, 4):
+              try:
+                  request = urllib.request.Request(
+                      metadata_url,
+                      headers={"User-Agent": "pollenlevels-ha-compatibility-canary"},
+                  )
+                  with urllib.request.urlopen(request, timeout=15) as response:
+                      releases = json.load(response)["releases"]
+                  break
+              except (
+                  json.JSONDecodeError,
+                  KeyError,
+                  TimeoutError,
+                  urllib.error.URLError,
+              ) as err:
+                  if attempt == 3:
+                      raise SystemExit(
+                          "Unable to determine latest stable Home Assistant from PyPI"
+                      ) from err
+                  time.sleep(5)
+
+          stable_releases = []
+          for release, files in releases.items():
+              try:
+                  version = Version(release)
+              except InvalidVersion:
+                  continue
+              if (
+                  not version.is_prerelease
+                  and not version.is_devrelease
+                  and any(not file.get("yanked", False) for file in files)
+              ):
+                  stable_releases.append((version, release))
+          if not stable_releases:
+              raise SystemExit("PyPI returned no stable Home Assistant releases")
+          latest_ha = max(stable_releases)[1]
+
+          phacc_requirements = [
+              Requirement(requirement)
+              for requirement in importlib.metadata.requires(
+                  "pytest-homeassistant-custom-component"
+              ) or ()
+          ]
+          ha_requirements = [
+              requirement
+              for requirement in phacc_requirements
+              if requirement.name == "homeassistant"
+          ]
+          if len(ha_requirements) != 1:
+              raise SystemExit("PHACC must declare exactly one Home Assistant requirement")
+          ha_requirement = ha_requirements[0]
+          expected_ha_specifier = f"=={versions['homeassistant']}"
+          if str(ha_requirement.specifier) != expected_ha_specifier:
+              raise SystemExit(
+                  "PHACC Home Assistant requirement is not the exact resolved version: "
+                  f"{ha_requirement.specifier} != {expected_ha_specifier}"
+              )
+
+          aligned = Version(versions["homeassistant"]) == Version(latest_ha)
+          if aligned:
+              status = "latest stable Home Assistant is covered by the canary"
+          else:
+              status = (
+                  "upstream PHACC has not yet caught up with latest Home Assistant"
+              )
+              print(
+                  "::warning title=Home Assistant harness lag::"
+                  f"Latest stable Home Assistant is {latest_ha}, but PHACC "
+                  f"{versions['pytest-homeassistant-custom-component']} resolves "
+                  f"Home Assistant {versions['homeassistant']}"
+              )
+
           python_version = subprocess.check_output(
               [os.environ["CANARY_PYTHON"], "--version"], text=True
           ).strip()
           uv_version = subprocess.check_output(["uv", "--version"], text=True).strip()
-          print("## Latest Home Assistant compatibility canary")
-          print()
-          print("| Component | Resolved version |")
-          print("| --- | --- |")
+          summary = [
+              "## Latest Home Assistant compatibility canary",
+              "",
+              f"- Latest stable HA: `{latest_ha}`",
+              "- Resolved PHACC: "
+              f"`{versions['pytest-homeassistant-custom-component']}`",
+              f"- HA resolved by PHACC: `{versions['homeassistant']}`",
+              f"- Status: {status}",
+              "",
+              "| Component | Resolved version |",
+              "| --- | --- |",
+          ]
           for name in names:
-              print(f"| {name} | `{versions[name]}` |")
-          print(f"| Python | `{python_version}` |")
-          print(f"| uv | `{uv_version}` |")
+              summary.append(f"| {name} | `{versions[name]}` |")
+          summary.append(f"| PHACC Home Assistant requirement | `{ha_requirement}` |")
+          summary.append(f"| Python | `{python_version}` |")
+          summary.append(f"| uv | `{uv_version}` |")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as file:
+              file.write("\n".join(summary) + "\n")
           PY
 
       - name: Run full test suite

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -484,6 +484,7 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
         "isinstance(release, str)",
         "isinstance(files, list)",
         "isinstance(file, dict)",
+        'isinstance(file.get("yanked", False), bool)',
     ):
         assert schema_check in report
     assert "ValueError," in report

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -477,6 +477,16 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
         "Home Assistant harness lag",
     ):
         assert evidence in canary
+    report = _workflow_step(canary, "Report resolved compatibility versions")
+    for schema_check in (
+        "isinstance(payload, dict)",
+        "isinstance(releases, dict)",
+        "isinstance(release, str)",
+        "isinstance(files, list)",
+        "isinstance(file, dict)",
+    ):
+        assert schema_check in report
+    assert "ValueError," in report
     assert '"$CANARY_PYTHON" -m pytest -q -p no:cacheprovider' in canary
     assert 'HA_COMPATIBILITY_CANARY: "1"' in canary
     assert "continue-on-error" not in canary

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -428,7 +428,7 @@ def test_workflows_do_not_duplicate_python_or_uv_executable_pins() -> None:
 def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
     """Protect the latest-HA canary's isolated, non-blocking contract."""
     canary = _read_text(WORKFLOWS_PATH / "ha-compatibility-canary.yml")
-    assert 'cron: "17 5 * * *"' in canary
+    assert 'cron: "17 */6 * * *"' in canary
     assert "workflow_dispatch:" in canary
     assert "contents: read" in canary
     assert "group: ha-compatibility-canary" in canary
@@ -445,6 +445,12 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
     assert "$RUNNER_TEMP/ha-compatibility-canary-venv" in canary
     assert "uv lock" not in canary
     assert "uv sync" not in canary
+    resolver = _workflow_step(canary, "Resolve latest stable Home Assistant harness")
+    assert canary.count("UV_EXCLUDE_NEWER") == 1
+    assert 'UV_EXCLUDE_NEWER: "false"' in resolver
+    assert "UV_EXCLUDE_NEWER" not in canary.split("jobs:", maxsplit=1)[0]
+    project = _read_text(PYPROJECT_PATH)
+    assert 'exclude-newer = "3 days"' in project
     assert "pytest-homeassistant-custom-component" in canary
     assert "pytest-homeassistant-custom-component==" not in canary
     assert '"$AIOINTERCEPT_REQUIREMENT"' in canary
@@ -463,6 +469,14 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
         "uv",
     ):
         assert name in canary
+    for evidence in (
+        "Latest stable HA",
+        "Resolved PHACC",
+        "HA resolved by PHACC",
+        "Status",
+        "Home Assistant harness lag",
+    ):
+        assert evidence in canary
     assert '"$CANARY_PYTHON" -m pytest -q -p no:cacheprovider' in canary
     assert 'HA_COMPATIBILITY_CANARY: "1"' in canary
     assert "continue-on-error" not in canary


### PR DESCRIPTION
Closes #353

## Summary

- fix the confirmed root cause by disabling the repository `exclude-newer = "3 days"` cooldown only for the disposable latest-PHACC resolver step
- keep the repository cooldown and normal locked dependency behavior unchanged
- run the compatibility canary approximately every six hours instead of daily
- compare the latest stable, non-yanked Home Assistant release published on PyPI with the exact Home Assistant version required and resolved by latest stable PHACC
- report upstream PHACC lag as a visible warning without turning it into a false Pollen Levels compatibility failure
- continue to fail normally when the full pytest suite fails against the resolved PHACC/Home Assistant pair

## Resolver validation

Validated with uv 0.12.5 using disposable environments and the canary install inputs:

- normal repository cooldown: PHACC 0.13.356 -> Home Assistant 2026.8.2
- `UV_EXCLUDE_NEWER=false`: PHACC 0.13.357 -> Home Assistant 2026.8.3
- PHACC 0.13.357 requires exactly `homeassistant==2026.8.3`
- latest stable Home Assistant observed on PyPI: 2026.8.3

## Validation

- `uv lock --check`
- Ruff check and format check
- compileall
- pytest: 692 passed
- actionlint 1.7.12 with ShellCheck 0.11.0
- zizmor 1.29.0
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compatibility checks now run every six hours.
  * Reports the latest stable Home Assistant version, resolved versions, requirement details, and environment information.
  * Clearly indicates whether the resolved version is current and warns when updates are available.
  * Includes expanded compatibility evidence and status details in workflow reports.

* **Bug Fixes**
  * Improved version detection with retries and filtering for prerelease, development, and withdrawn versions.
  * Added validation that the resolved version meets the exact Home Assistant requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->