### PR TITLE
ci: keep Home Assistant canary on stable harness pairs

### DIFF
--- a/.github/workflows/ha-compatibility-canary.yml
+++ b/.github/workflows/ha-compatibility-canary.yml
@@ -69,16 +69,46 @@ jobs:
               print(f"{name.upper()}_REQUIREMENT={requirement}")
           PY
 
-      - name: Resolve latest stable Home Assistant harness
+      - name: Install stable-harness selection helper requirement
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv pip install --python "$CANARY_PYTHON" "$PACKAGING_REQUIREMENT"
+
+      - name: Select latest stable Home Assistant harness pair
+        shell: bash
+        run: |
+          set -euo pipefail
+          selection_file="$RUNNER_TEMP/ha-harness-selection.json"
+          "$CANARY_PYTHON" scripts/select_ha_harness.py > "$selection_file"
+          "$CANARY_PYTHON" - "$selection_file" <<'PY' >> "$GITHUB_ENV"
+          import json
+          import sys
+
+          with open(sys.argv[1], encoding="utf-8") as file:
+              selection = json.load(file)
+          fields = {
+              "LATEST_HA": selection["latest_homeassistant"],
+              "LATEST_PHACC": selection["latest_phacc"],
+              "SELECTED_HA": selection["selected_homeassistant"],
+              "SELECTED_PHACC": selection["selected_phacc"],
+              "SKIPPED_PRERELEASE_PHACC": ",".join(
+                  selection["skipped_prerelease_phacc"]
+              ),
+          }
+          for name, value in fields.items():
+              print(f"{name}={value}")
+          PY
+
+      - name: Install selected stable Home Assistant harness pair
         shell: bash
         env:
           UV_EXCLUDE_NEWER: "false"
         run: |
           set -euo pipefail
           uv pip install --python "$CANARY_PYTHON" \
-            pytest-homeassistant-custom-component \
-            "$AIOINTERCEPT_REQUIREMENT" \
-            "$PACKAGING_REQUIREMENT"
+            "pytest-homeassistant-custom-component==$SELECTED_PHACC" \
+            "$AIOINTERCEPT_REQUIREMENT"
 
       - name: Report resolved compatibility versions
         shell: bash
@@ -86,15 +116,12 @@ jobs:
           set -euo pipefail
           "$CANARY_PYTHON" - <<'PY'
           import importlib.metadata
-          import json
           import os
           import subprocess
-          import time
-          import urllib.error
-          import urllib.request
 
-          from packaging.requirements import Requirement
-          from packaging.version import InvalidVersion, Version
+          from packaging.version import Version
+
+          from scripts.select_ha_harness import exact_homeassistant_requirement
 
           names = (
               "pytest-homeassistant-custom-component",
@@ -108,81 +135,29 @@ jobs:
               name: importlib.metadata.version(name)
               for name in names
           }
-          metadata_url = "https://pypi.org/pypi/homeassistant/json"
-          for attempt in range(1, 4):
-              try:
-                  request = urllib.request.Request(
-                      metadata_url,
-                      headers={"User-Agent": "pollenlevels-ha-compatibility-canary"},
-                  )
-                  with urllib.request.urlopen(request, timeout=15) as response:
-                      payload = json.load(response)
-                  if not isinstance(payload, dict):
-                      raise ValueError("PyPI response is not a mapping")
-                  releases = payload.get("releases")
-                  if not isinstance(releases, dict):
-                      raise ValueError("PyPI releases are not a mapping")
-                  if any(
-                      not isinstance(release, str)
-                      or not isinstance(files, list)
-                      or any(
-                          not isinstance(file, dict)
-                          or not isinstance(file.get("yanked", False), bool)
-                          for file in files
-                      )
-                      for release, files in releases.items()
-                  ):
-                      raise ValueError("PyPI release entries have an invalid shape")
-                  break
-              except (
-                  TimeoutError,
-                  ValueError,
-                  urllib.error.URLError,
-              ) as err:
-                  if attempt == 3:
-                      raise SystemExit(
-                          "Unable to determine latest stable Home Assistant from PyPI"
-                      ) from err
-                  time.sleep(5)
-
-          stable_releases = []
-          for release, files in releases.items():
-              try:
-                  version = Version(release)
-              except InvalidVersion:
-                  continue
-              if (
-                  not version.is_prerelease
-                  and not version.is_devrelease
-                  and any(not file.get("yanked", False) for file in files)
-              ):
-                  stable_releases.append((version, release))
-          if not stable_releases:
-              raise SystemExit("PyPI returned no stable Home Assistant releases")
-          latest_ha = max(stable_releases)[1]
-
-          phacc_requirements = [
-              Requirement(requirement)
-              for requirement in importlib.metadata.requires(
-                  "pytest-homeassistant-custom-component"
-              ) or ()
-          ]
-          ha_requirements = [
-              requirement
-              for requirement in phacc_requirements
-              if requirement.name == "homeassistant"
-          ]
-          if len(ha_requirements) != 1:
-              raise SystemExit("PHACC must declare exactly one Home Assistant requirement")
-          ha_requirement = ha_requirements[0]
-          expected_ha_specifier = f"=={versions['homeassistant']}"
-          if str(ha_requirement.specifier) != expected_ha_specifier:
+          installed_phacc = versions["pytest-homeassistant-custom-component"]
+          installed_homeassistant = versions["homeassistant"]
+          if installed_phacc != os.environ["SELECTED_PHACC"]:
               raise SystemExit(
-                  "PHACC Home Assistant requirement is not the exact resolved version: "
-                  f"{ha_requirement.specifier} != {expected_ha_specifier}"
+                  f"Installed PHACC {installed_phacc} does not match selected "
+                  f"{os.environ['SELECTED_PHACC']}"
+              )
+          if installed_homeassistant != os.environ["SELECTED_HA"]:
+              raise SystemExit(
+                  f"Installed Home Assistant {installed_homeassistant} does not match "
+                  f"selected {os.environ['SELECTED_HA']}"
+              )
+          required_homeassistant = exact_homeassistant_requirement(
+              importlib.metadata.requires("pytest-homeassistant-custom-component")
+          )
+          if required_homeassistant != installed_homeassistant:
+              raise SystemExit(
+                  "PHACC Home Assistant requirement is not the exact installed version: "
+                  f"{required_homeassistant} != {installed_homeassistant}"
               )
 
-          aligned = Version(versions["homeassistant"]) == Version(latest_ha)
+          latest_ha = os.environ["LATEST_HA"]
+          aligned = Version(installed_homeassistant) == Version(latest_ha)
           if aligned:
               status = "latest stable Home Assistant is covered by the canary"
           else:
@@ -192,9 +167,13 @@ jobs:
               print(
                   "::warning title=Home Assistant harness lag::"
                   f"Latest stable Home Assistant is {latest_ha}, but PHACC "
-                  f"{versions['pytest-homeassistant-custom-component']} resolves "
-                  f"Home Assistant {versions['homeassistant']}"
+                  f"{installed_phacc} selects Home Assistant {installed_homeassistant}"
               )
+
+          skipped = os.environ["SKIPPED_PRERELEASE_PHACC"]
+          skipped_summary = (
+              f"`{skipped}` (target HA prerelease)" if skipped else "None"
+          )
 
           python_version = subprocess.check_output(
               [os.environ["CANARY_PYTHON"], "--version"], text=True
@@ -204,9 +183,10 @@ jobs:
               "## Latest Home Assistant compatibility canary",
               "",
               f"- Latest stable HA: `{latest_ha}`",
-              "- Resolved PHACC: "
-              f"`{versions['pytest-homeassistant-custom-component']}`",
-              f"- HA resolved by PHACC: `{versions['homeassistant']}`",
+              f"- Latest stable-versioned PHACC: `{os.environ['LATEST_PHACC']}`",
+              f"- Selected stable-pair PHACC: `{installed_phacc}`",
+              f"- HA selected by PHACC: `{installed_homeassistant}`",
+              f"- Newer PHACC releases skipped: {skipped_summary}",
               f"- Status: {status}",
               "",
               "| Component | Resolved version |",
@@ -214,7 +194,10 @@ jobs:
           ]
           for name in names:
               summary.append(f"| {name} | `{versions[name]}` |")
-          summary.append(f"| PHACC Home Assistant requirement | `{ha_requirement}` |")
+          summary.append(
+              "| PHACC Home Assistant requirement | "
+              f"`homeassistant=={required_homeassistant}` |"
+          )
           summary.append(f"| Python | `{python_version}` |")
           summary.append(f"| uv | `{uv_version}` |")
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as file:

--- a/.github/workflows/ha-compatibility-canary.yml
+++ b/.github/workflows/ha-compatibility-canary.yml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Check out current main
+      - name: Check out workflow revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: main
           fetch-depth: 1
           persist-credentials: false
 

--- a/scripts/select_ha_harness.py
+++ b/scripts/select_ha_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -209,7 +210,7 @@ def main() -> None:
             "pytest-homeassistant-custom-component", version
         ),
     )
-    print(json.dumps(asdict(selection), sort_keys=True))
+    sys.stdout.write(json.dumps(asdict(selection), sort_keys=True) + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/select_ha_harness.py
+++ b/scripts/select_ha_harness.py
@@ -44,23 +44,27 @@ def _stable_releases(
 
     stable_releases: list[tuple[Version, str]] = []
     for release, artifacts in releases.items():
-        if not isinstance(release, str) or not isinstance(artifacts, Sequence):
+        if not isinstance(release, str) or not isinstance(artifacts, list):
             raise SelectionError(
                 f"PyPI metadata for {package} has an invalid release entry"
             )
+        for artifact in artifacts:
+            if not isinstance(artifact, Mapping):
+                raise SelectionError(
+                    f"PyPI metadata for {package} has an invalid artifact"
+                )
+            if not isinstance(artifact.get("yanked"), bool):
+                raise SelectionError(
+                    f"PyPI metadata for {package} has an invalid artifact yanked value"
+                )
         try:
             version = Version(release)
         except InvalidVersion:
             continue
         if version.is_prerelease or version.is_devrelease:
             continue
-        if any(
-            isinstance(artifact, Mapping) and artifact.get("yanked") is False
-            for artifact in artifacts
-        ):
+        if any(artifact["yanked"] is False for artifact in artifacts):
             stable_releases.append((version, release))
-        elif any(not isinstance(artifact, Mapping) for artifact in artifacts):
-            raise SelectionError(f"PyPI metadata for {package} has an invalid artifact")
     return stable_releases
 
 

--- a/scripts/select_ha_harness.py
+++ b/scripts/select_ha_harness.py
@@ -1,0 +1,212 @@
+"""Select the newest compatible stable Home Assistant test harness pair."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+PYPI_URL = "https://pypi.org/pypi/{package}{version}/json"
+USER_AGENT = "pollenlevels-ha-harness-selector"
+
+
+class SelectionError(ValueError):
+    """Raised when PyPI metadata cannot safely produce a stable harness pair."""
+
+
+@dataclass(frozen=True)
+class HarnessSelection:
+    """The stable Home Assistant harness versions selected from PyPI metadata."""
+
+    latest_homeassistant: str
+    latest_phacc: str
+    selected_phacc: str
+    selected_homeassistant: str
+    skipped_prerelease_phacc: tuple[str, ...]
+
+
+def _stable_releases(
+    metadata: Mapping[str, object], package: str
+) -> list[tuple[Version, str]]:
+    """Return non-yanked, stable releases from one PyPI project response."""
+    releases = metadata.get("releases")
+    if not isinstance(releases, Mapping):
+        raise SelectionError(f"PyPI metadata for {package} has no releases mapping")
+
+    stable_releases: list[tuple[Version, str]] = []
+    for release, artifacts in releases.items():
+        if not isinstance(release, str) or not isinstance(artifacts, Sequence):
+            raise SelectionError(
+                f"PyPI metadata for {package} has an invalid release entry"
+            )
+        try:
+            version = Version(release)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease or version.is_devrelease:
+            continue
+        if any(
+            isinstance(artifact, Mapping) and artifact.get("yanked") is False
+            for artifact in artifacts
+        ):
+            stable_releases.append((version, release))
+        elif any(not isinstance(artifact, Mapping) for artifact in artifacts):
+            raise SelectionError(f"PyPI metadata for {package} has an invalid artifact")
+    return stable_releases
+
+
+def latest_stable_release(metadata: Mapping[str, object], package: str) -> str:
+    """Return the newest stable non-yanked release from PyPI project metadata."""
+    stable_releases = _stable_releases(metadata, package)
+    if not stable_releases:
+        raise SelectionError(f"PyPI returned no stable non-yanked {package} releases")
+    return max(stable_releases)[1]
+
+
+def exact_homeassistant_requirement(requires_dist: object) -> str:
+    """Return PHACC's exact unconditional Home Assistant requirement."""
+    if not isinstance(requires_dist, Sequence) or isinstance(requires_dist, str):
+        raise SelectionError("PHACC metadata has no requires_dist list")
+
+    requirements: list[Requirement] = []
+    for requirement_text in requires_dist:
+        if not isinstance(requirement_text, str):
+            raise SelectionError("PHACC metadata has an invalid dependency requirement")
+        try:
+            requirement = Requirement(requirement_text)
+        except InvalidRequirement as err:
+            raise SelectionError(
+                "PHACC metadata has an invalid dependency requirement"
+            ) from err
+        if canonicalize_name(requirement.name) == "homeassistant":
+            requirements.append(requirement)
+
+    if len(requirements) != 1:
+        raise SelectionError(
+            "PHACC must declare exactly one Home Assistant requirement"
+        )
+    requirement = requirements[0]
+    specifiers = list(requirement.specifier)
+    if (
+        requirement.extras
+        or requirement.marker is not None
+        or len(specifiers) != 1
+        or specifiers[0].operator != "=="
+        or specifiers[0].version.endswith(".*")
+    ):
+        raise SelectionError(
+            "PHACC Home Assistant requirement must be one exact version"
+        )
+    return specifiers[0].version
+
+
+def select_stable_harness(
+    homeassistant_metadata: Mapping[str, object],
+    phacc_metadata: Mapping[str, object],
+    phacc_release_metadata: Callable[[str], Mapping[str, object]],
+) -> HarnessSelection:
+    """Select the newest PHACC release that targets a usable stable HA release."""
+    latest_homeassistant = latest_stable_release(
+        homeassistant_metadata, "Home Assistant"
+    )
+    latest_phacc = latest_stable_release(
+        phacc_metadata, "pytest-homeassistant-custom-component"
+    )
+    stable_homeassistant = {
+        release
+        for _, release in _stable_releases(homeassistant_metadata, "Home Assistant")
+    }
+    phacc_releases = sorted(
+        _stable_releases(phacc_metadata, "pytest-homeassistant-custom-component"),
+        reverse=True,
+    )
+    skipped_prerelease_phacc: list[str] = []
+
+    for _, phacc_version in phacc_releases:
+        metadata = phacc_release_metadata(phacc_version)
+        info = metadata.get("info")
+        if not isinstance(info, Mapping):
+            raise SelectionError(f"PHACC {phacc_version} metadata has no info mapping")
+        homeassistant_version = exact_homeassistant_requirement(
+            info.get("requires_dist")
+        )
+        try:
+            parsed_homeassistant = Version(homeassistant_version)
+        except InvalidVersion as err:
+            raise SelectionError(
+                f"PHACC {phacc_version} targets an invalid Home Assistant version"
+            ) from err
+        if parsed_homeassistant.is_prerelease or parsed_homeassistant.is_devrelease:
+            skipped_prerelease_phacc.append(phacc_version)
+            continue
+        if homeassistant_version not in stable_homeassistant:
+            raise SelectionError(
+                f"PHACC {phacc_version} targets unavailable or yanked Home Assistant "
+                f"{homeassistant_version}"
+            )
+        return HarnessSelection(
+            latest_homeassistant=latest_homeassistant,
+            latest_phacc=latest_phacc,
+            selected_phacc=phacc_version,
+            selected_homeassistant=homeassistant_version,
+            skipped_prerelease_phacc=tuple(skipped_prerelease_phacc),
+        )
+
+    raise SelectionError("PyPI returned no eligible stable PHACC/Home Assistant pair")
+
+
+def fetch_pypi_metadata(
+    package: str, version: str | None = None
+) -> Mapping[str, object]:
+    """Fetch one PyPI JSON response with bounded retries and a timeout."""
+    version_path = f"/{version}" if version is not None else ""
+    url = PYPI_URL.format(package=package, version=version_path)
+    for attempt in range(1, 4):
+        try:
+            request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(request, timeout=15) as response:
+                payload: Any = json.load(response)
+            if not isinstance(payload, Mapping):
+                raise SelectionError(f"PyPI metadata for {package} is not a mapping")
+            return payload
+        except (
+            OSError,
+            TimeoutError,
+            json.JSONDecodeError,
+            urllib.error.URLError,
+        ) as err:
+            if attempt == 3:
+                raise SelectionError(
+                    f"Unable to fetch PyPI metadata for {package}"
+                ) from err
+            time.sleep(5)
+    raise AssertionError("unreachable")
+
+
+def main() -> None:
+    """Print the selected stable harness pair as JSON for CI consumers."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    homeassistant_metadata = fetch_pypi_metadata("homeassistant")
+    phacc_metadata = fetch_pypi_metadata("pytest-homeassistant-custom-component")
+    selection = select_stable_harness(
+        homeassistant_metadata,
+        phacc_metadata,
+        lambda version: fetch_pypi_metadata(
+            "pytest-homeassistant-custom-component", version
+        ),
+    )
+    print(json.dumps(asdict(selection), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -433,7 +433,8 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
     assert "contents: read" in canary
     assert "group: ha-compatibility-canary" in canary
     assert "cancel-in-progress: true" in canary
-    assert "ref: main" in canary
+    checkout = _workflow_step(canary, "Check out workflow revision")
+    assert "ref: main" not in checkout
     setup_python = _workflow_step(canary, "Set up Python")
     assert "python-version-file: .python-version" in setup_python
     assert re.search(r"(?m)^\s+cache\s*:", setup_python) is None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -445,17 +445,29 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
     assert "$RUNNER_TEMP/ha-compatibility-canary-venv" in canary
     assert "uv lock" not in canary
     assert "uv sync" not in canary
-    resolver = _workflow_step(canary, "Resolve latest stable Home Assistant harness")
+    selector_requirements = _workflow_step(
+        canary, "Install stable-harness selection helper requirement"
+    )
+    selector = _workflow_step(
+        canary, "Select latest stable Home Assistant harness pair"
+    )
+    harness = _workflow_step(
+        canary, "Install selected stable Home Assistant harness pair"
+    )
     assert canary.count("UV_EXCLUDE_NEWER") == 1
-    assert 'UV_EXCLUDE_NEWER: "false"' in resolver
+    assert 'UV_EXCLUDE_NEWER: "false"' in harness
     assert "UV_EXCLUDE_NEWER" not in canary.split("jobs:", maxsplit=1)[0]
     project = _read_text(PYPROJECT_PATH)
     assert 'exclude-newer = "3 days"' in project
+    assert "contents: write" not in canary
+    assert "pull-requests: write" not in canary
+    assert '"$PACKAGING_REQUIREMENT"' in selector_requirements
+    assert "scripts/select_ha_harness.py" in selector
+    assert '"pytest-homeassistant-custom-component==$SELECTED_PHACC"' in harness
+    assert "homeassistant==" not in harness
     assert "pytest-homeassistant-custom-component" in canary
-    assert "pytest-homeassistant-custom-component==" not in canary
     assert '"$AIOINTERCEPT_REQUIREMENT"' in canary
     assert '"$PACKAGING_REQUIREMENT"' in canary
-    assert "homeassistant==" not in canary
     assert "pytest==" not in canary
     assert "pytest-asyncio==" not in canary
     for name in (
@@ -471,28 +483,27 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
         assert name in canary
     for evidence in (
         "Latest stable HA",
-        "Resolved PHACC",
-        "HA resolved by PHACC",
+        "Latest stable-versioned PHACC",
+        "Selected stable-pair PHACC",
+        "HA selected by PHACC",
+        "Newer PHACC releases skipped",
         "Status",
         "Home Assistant harness lag",
     ):
         assert evidence in canary
     report = _workflow_step(canary, "Report resolved compatibility versions")
-    for schema_check in (
-        "isinstance(payload, dict)",
-        "isinstance(releases, dict)",
-        "isinstance(release, str)",
-        "isinstance(files, list)",
-        "isinstance(file, dict)",
-        'isinstance(file.get("yanked", False), bool)',
-    ):
-        assert schema_check in report
-    assert "ValueError," in report
+    assert "exact_homeassistant_requirement" in report
+    assert "SELECTED_PHACC" in report
+    assert "SELECTED_HA" in report
+    assert "does not match selected" in report
+    assert "exact installed version" in report
     assert '"$CANARY_PYTHON" -m pytest -q -p no:cacheprovider' in canary
     assert 'HA_COMPATIBILITY_CANARY: "1"' in canary
     assert "continue-on-error" not in canary
     assert "upload-artifact" not in canary
     assert "action-gh-release" not in canary
+    assert "git push" not in canary
+    assert "gh pr create" not in canary
     release = _read_text(WORKFLOWS_PATH / "release.yml")
     assert "ha-compatibility-canary" not in release
 

--- a/tests/test_select_ha_harness.py
+++ b/tests/test_select_ha_harness.py
@@ -7,6 +7,7 @@ import pytest
 from scripts.select_ha_harness import (
     SelectionError,
     exact_homeassistant_requirement,
+    latest_stable_release,
     select_stable_harness,
 )
 
@@ -104,6 +105,33 @@ def test_yanked_phacc_release_is_ignored() -> None:
 
     assert selection.latest_phacc == "0.13.357"
     assert selection.selected_phacc == "0.13.357"
+
+
+def test_mixed_valid_and_malformed_artifacts_fail() -> None:
+    """One malformed artifact invalidates an otherwise usable release."""
+    with pytest.raises(SelectionError, match="invalid artifact"):
+        latest_stable_release(
+            {"releases": {"2026.8.3": [{"yanked": False}, "invalid artifact"]}},
+            "Home Assistant",
+        )
+
+
+def test_non_boolean_artifact_yanked_value_fails() -> None:
+    """PyPI artifact yanked values must be booleans."""
+    with pytest.raises(SelectionError, match="invalid artifact yanked value"):
+        latest_stable_release(
+            {"releases": {"2026.8.3": [{"yanked": "false"}]}},
+            "Home Assistant",
+        )
+
+
+def test_non_list_artifacts_collection_fails() -> None:
+    """PyPI release artifact collections must be lists."""
+    with pytest.raises(SelectionError, match="invalid release entry"):
+        latest_stable_release(
+            {"releases": {"2026.8.3": {"yanked": False}}},
+            "Home Assistant",
+        )
 
 
 @pytest.mark.parametrize("homeassistant_releases", [(), (("2026.8.3", True),)])

--- a/tests/test_select_ha_harness.py
+++ b/tests/test_select_ha_harness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from scripts.select_ha_harness import (
+    HarnessSelection,
     SelectionError,
     exact_homeassistant_requirement,
     latest_stable_release,
@@ -24,7 +25,7 @@ def _select(
     homeassistant_releases: tuple[tuple[str, bool], ...],
     phacc_releases: tuple[tuple[str, bool], ...],
     requirements: dict[str, list[str]],
-):
+) -> HarnessSelection:
     return select_stable_harness(
         _project(*homeassistant_releases),
         _project(*phacc_releases),

--- a/tests/test_select_ha_harness.py
+++ b/tests/test_select_ha_harness.py
@@ -1,0 +1,149 @@
+"""Tests for stable Home Assistant harness selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.select_ha_harness import (
+    SelectionError,
+    exact_homeassistant_requirement,
+    select_stable_harness,
+)
+
+
+def _project(*releases: tuple[str, bool]) -> dict[str, object]:
+    return {"releases": {version: [{"yanked": yanked}] for version, yanked in releases}}
+
+
+def _phacc_release(requirements: list[str]) -> dict[str, object]:
+    return {"info": {"requires_dist": requirements}}
+
+
+def _select(
+    homeassistant_releases: tuple[tuple[str, bool], ...],
+    phacc_releases: tuple[tuple[str, bool], ...],
+    requirements: dict[str, list[str]],
+):
+    return select_stable_harness(
+        _project(*homeassistant_releases),
+        _project(*phacc_releases),
+        lambda version: _phacc_release(requirements[version]),
+    )
+
+
+def test_latest_phacc_targeting_latest_stable_ha_is_selected() -> None:
+    """The current stable PHACC/HA pair is selected."""
+    selection = _select(
+        (("2026.8.2", False), ("2026.8.3", False)),
+        (("0.13.356", False), ("0.13.357", False)),
+        {
+            "0.13.357": ["homeassistant==2026.8.3"],
+        },
+    )
+
+    assert selection.selected_phacc == "0.13.357"
+    assert selection.selected_homeassistant == "2026.8.3"
+    assert selection.latest_homeassistant == "2026.8.3"
+    assert selection.latest_phacc == "0.13.357"
+
+
+@pytest.mark.parametrize("target", ["2026.9.0b1", "2026.9.0rc1", "2026.9.0.dev0"])
+def test_prerelease_ha_target_is_skipped(target: str) -> None:
+    """PHACC packages targeting beta, RC, and dev Home Assistant are skipped."""
+    selection = _select(
+        (("2026.8.3", False), (target, False)),
+        (("0.13.357", False), ("0.13.359", False)),
+        {
+            "0.13.359": [f"homeassistant=={target}"],
+            "0.13.357": ["homeassistant==2026.8.3"],
+        },
+    )
+
+    assert selection.selected_phacc == "0.13.357"
+    assert selection.selected_homeassistant == "2026.8.3"
+    assert selection.skipped_prerelease_phacc == ("0.13.359",)
+
+
+def test_latest_ha_ahead_of_selected_pair_is_preserved() -> None:
+    """Selection exposes genuine upstream harness lag to the workflow."""
+    selection = _select(
+        (("2026.8.3", False), ("2026.9.0", False)),
+        (("0.13.357", False),),
+        {"0.13.357": ["homeassistant==2026.8.3"]},
+    )
+
+    assert selection.latest_homeassistant == "2026.9.0"
+    assert selection.selected_homeassistant == "2026.8.3"
+
+
+def test_exact_homeassistant_requirement_is_required() -> None:
+    """Only one exact, unconditional Home Assistant requirement is accepted."""
+    assert exact_homeassistant_requirement(["homeassistant==2026.8.3"]) == "2026.8.3"
+
+    for requirements in (
+        ["homeassistant>=2026.8.3"],
+        ["homeassistant==2026.8.*"],
+        ["homeassistant==not-a-version"],
+        ["homeassistant[extra]==2026.8.3"],
+        ["homeassistant==2026.8.3; python_version >= '3.14'"],
+        ["homeassistant==2026.8.3", "homeassistant==2026.8.2"],
+    ):
+        with pytest.raises(
+            SelectionError, match="invalid dependency|exactly one|exact version"
+        ):
+            exact_homeassistant_requirement(requirements)
+
+
+def test_yanked_phacc_release_is_ignored() -> None:
+    """A yanked newer PHACC package cannot be selected."""
+    selection = _select(
+        (("2026.8.3", False),),
+        (("0.13.357", False), ("0.13.358", True)),
+        {"0.13.357": ["homeassistant==2026.8.3"]},
+    )
+
+    assert selection.latest_phacc == "0.13.357"
+    assert selection.selected_phacc == "0.13.357"
+
+
+@pytest.mark.parametrize("homeassistant_releases", [(), (("2026.8.3", True),)])
+def test_unavailable_or_yanked_stable_ha_target_fails(
+    homeassistant_releases: tuple[tuple[str, bool], ...],
+) -> None:
+    """PHACC cannot select a Home Assistant release without usable artifacts."""
+    with pytest.raises(SelectionError, match="no stable|unavailable or yanked"):
+        _select(
+            homeassistant_releases,
+            (("0.13.357", False),),
+            {"0.13.357": ["homeassistant==2026.8.3"]},
+        )
+
+
+def test_missing_stable_ha_target_fails() -> None:
+    """PHACC cannot select a stable HA version absent from PyPI metadata."""
+    with pytest.raises(SelectionError, match="unavailable or yanked"):
+        _select(
+            (("2026.8.2", False),),
+            (("0.13.357", False),),
+            {"0.13.357": ["homeassistant==2026.8.3"]},
+        )
+
+
+def test_yanked_stable_ha_target_fails() -> None:
+    """PHACC cannot select a yanked stable HA release when another one exists."""
+    with pytest.raises(SelectionError, match="unavailable or yanked"):
+        _select(
+            (("2026.8.2", False), ("2026.8.3", True)),
+            (("0.13.357", False),),
+            {"0.13.357": ["homeassistant==2026.8.3"]},
+        )
+
+
+def test_no_eligible_stable_pair_fails_clearly() -> None:
+    """A PHACC catalog with only prerelease HA targets fails safely."""
+    with pytest.raises(SelectionError, match="no eligible stable"):
+        _select(
+            (("2026.8.3", False), ("2026.9.0b1", False)),
+            (("0.13.359", False),),
+            {"0.13.359": ["homeassistant==2026.9.0b1"]},
+        )


### PR DESCRIPTION
Refs #358

## Summary

- add a reusable, tested PyPI selector for the newest non-yanked PHACC release whose exact Home Assistant requirement is a usable stable release
- keep PHACC as the compatibility authority; the canary installs the exact selected PHACC version and never independently forces Home Assistant
- skip PHACC releases targeting Home Assistant beta, RC, dev, or other prerelease versions before harness installation
- retain read-only canary permissions and scope `UV_EXCLUDE_NEWER=false` solely to the disposable fresh harness install
- retain the repository-wide three-day `exclude-newer` cooldown unchanged

## Confirmed edge case

PHACC 0.13.359 targets Home Assistant 2026.9.0b1. It is therefore not upstream harness lag and cannot become the stable canary candidate. Current live PyPI validation selected PHACC 0.13.357 with Home Assistant 2026.8.3; it skipped 0.13.358 through 0.13.360 because they target HA prereleases.

## Validation

- `uv lock --check`
- Ruff check and format check
- `python -m compileall -q custom_components tests scripts`
- `PYTHONPATH=. python -m pytest -q` — 707 passed
- live selector validation against PyPI
- actionlint 1.7.12 with ShellCheck 0.11.0
- zizmor 1.29.0
- package ZIP validation
- `git diff --check`

The canary remains read-only and actual pytest failures remain blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic selection of a stable, compatible Home Assistant and test harness version pair.
  * Canary reports now include selected and latest versions, skipped prereleases, and exact compatibility requirements.
  * Added validation that installed versions match the selected compatibility pair.

* **Bug Fixes**
  * Excluded yanked, prerelease-only, and incompatible releases from canary testing.
  * Added warnings when testing uses an older stable Home Assistant version.

* **Tests**
  * Expanded coverage for release selection, compatibility validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->