### PR TITLE
fix(ci): make baseline planner environment self-contained

### DIFF
--- a/.github/workflows/ha-test-baseline-updater.yml
+++ b/.github/workflows/ha-test-baseline-updater.yml
@@ -64,8 +64,33 @@ jobs:
         run: |
           set -euo pipefail
           planner_venv="$RUNNER_TEMP/ha-test-baseline-planner"
-          packaging_requirement="$(rg -o 'packaging==[^\"]+' pyproject.toml)"
-          test -n "$packaging_requirement"
+          packaging_requirement="$(python -c '
+          from pathlib import Path
+          import sys
+          import tomllib
+
+          with Path("pyproject.toml").open("rb") as file:
+              dependency_groups = tomllib.load(file).get("dependency-groups")
+
+          if not isinstance(dependency_groups, dict):
+              raise SystemExit("[dependency-groups] section is missing")
+
+          test_dependencies = dependency_groups.get("test")
+          if not isinstance(test_dependencies, list):
+              raise SystemExit("test dependency group is missing or is not a list")
+
+          packaging_requirements = [
+              requirement
+              for requirement in test_dependencies
+              if isinstance(requirement, str) and requirement.startswith("packaging==")
+          ]
+          if len(packaging_requirements) != 1:
+              raise SystemExit(
+                  "test dependency group must contain exactly one packaging== requirement"
+              )
+
+          sys.stdout.write(packaging_requirements[0])
+          ')"
           uv venv --python "$(command -v python)" "$planner_venv"
           uv pip install --python "$planner_venv/bin/python" "$packaging_requirement"
           printf 'PLANNER_PYTHON=%s\n' "$planner_venv/bin/python" >> "$GITHUB_ENV"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -512,6 +512,7 @@ def test_canary_is_advisory_fresh_resolution_with_no_mutation_actions() -> None:
 def test_ha_test_baseline_updater_keeps_validation_and_publication_separate() -> None:
     """Protect the weekly updater's narrow generated-PR security contract."""
     workflow = _read_text(WORKFLOWS_PATH / "ha-test-baseline-updater.yml")
+    planner_environment = _workflow_step(workflow, "Create planner environment")
     validation = _workflow_step(workflow, "Plan stable baseline update")
     seal = _workflow_step(workflow, "Seal validated publication artifact")
     upload = _workflow_step(workflow, "Upload sealed publication artifact")
@@ -531,6 +532,13 @@ def test_ha_test_baseline_updater_keeps_validation_and_publication_separate() ->
     assert "persist-credentials: false" in workflow
     assert "UV_EXCLUDE_NEWER=false" not in workflow
     assert 'UV_EXCLUDE_NEWER: "false"' not in workflow
+    assert "rg " not in workflow
+    assert "import tomllib" in planner_environment
+    assert 'get("test")' in planner_environment
+    assert (
+        'uv pip install --python "$planner_venv/bin/python" "$packaging_requirement"'
+        in (planner_environment)
+    )
     assert "uv lock --upgrade-package homeassistant" in workflow
     assert "--upgrade-package pytest-homeassistant-custom-component" in workflow
     assert "uv lock --upgrade" not in workflow.replace("uv lock --upgrade-package", "")


### PR DESCRIPTION
Refs #358

The first post-merge workflow_dispatch live run (33300594329) failed in Create planner environment with `rg: command not found` (exit 127). The planner bootstrap now uses Python stdlib TOML parsing to extract the single `packaging==` requirement from `[dependency-groups].test`, avoiding the unavailable ripgrep dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test-baseline validation by reliably checking the configured packaging requirement.
  * Added clearer error reporting when test configuration is missing, invalid, or ambiguous.
  * Ensured the required packaging version is installed consistently during baseline planning.

* **Tests**
  * Expanded automated coverage to verify validation and publication remain separate and that the planner environment uses the correct dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->