### PR TITLE
fix: redact HTTP errors before truncation

### DIFF
--- a/custom_components/pollenlevels/client.py
+++ b/custom_components/pollenlevels/client.py
@@ -19,6 +19,7 @@ from .util import extract_error_message, redact_sensitive_values
 _LOGGER = logging.getLogger(__name__)
 _DEFAULT_429_RETRY_DELAY = 2.0
 _MAX_INLINE_RETRY_AFTER = 5.0
+_MAX_HTTP_ERROR_MESSAGE_LENGTH = 300
 
 
 def _format_http_message(status: int, raw_message: str | None) -> str:
@@ -154,13 +155,13 @@ class GooglePollenApiClient:
         latitude: float | str | None,
         longitude: float | str | None,
     ) -> tuple[str, str]:
-        """Extract, redact, and format an HTTP error response message."""
+        """Extract, redact, truncate, and format an HTTP error response message."""
 
         raw_message = self._redact_sensitive_message(
-            await extract_error_message(resp, default=default),
+            await extract_error_message(resp, default=default, max_length=None),
             latitude=latitude,
             longitude=longitude,
-        )
+        )[:_MAX_HTTP_ERROR_MESSAGE_LENGTH]
         return raw_message, _format_http_message(resp.status, raw_message or None)
 
     async def async_fetch_pollen_data(

--- a/custom_components/pollenlevels/util.py
+++ b/custom_components/pollenlevels/util.py
@@ -171,8 +171,13 @@ def normalize_language_code(value: object) -> str | None:
     return normalized
 
 
-async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
-    """Extract and normalize an HTTP error message without secrets."""
+async def extract_error_message(
+    resp: ClientResponse,
+    default: str = "",
+    *,
+    max_length: int | None = 300,
+) -> str:
+    """Extract and normalize an HTTP error message, bounded by default."""
 
     message: str | None = None
     try:
@@ -201,8 +206,8 @@ async def extract_error_message(resp: ClientResponse, default: str = "") -> str:
         (message or "").replace("\r", " ").replace("\n", " ").split()
     ).strip()
 
-    if len(normalized) > 300:
-        normalized = normalized[:300]
+    if max_length is not None and len(normalized) > max_length:
+        normalized = normalized[:max_length]
 
     return normalized or default
 

--- a/tests/test_client_redaction_truncation.py
+++ b/tests/test_client_redaction_truncation.py
@@ -1,0 +1,86 @@
+"""Regression tests for HTTP error redaction before truncation."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+from tests import test_client as client_tests
+
+client_module = client_tests.client_module
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["json", "text"])
+async def test_http_error_redacts_key_before_truncation(
+    client_module: ModuleType,
+    source: str,
+) -> None:
+    """A key crossing the legacy boundary must be removed before truncation."""
+
+    api_key = "synthetic-secret-key-0123456789"
+    prefix = "x" * 290
+    raw_message = f"{prefix}{api_key} trailing context"
+    response = client_tests.FakeResponse(
+        status=400,
+        json_results=(
+            [{"error": {"message": raw_message}}]
+            if source == "json"
+            else [ValueError("invalid JSON")]
+        ),
+        text_body=raw_message if source == "text" else "unused",
+    )
+
+    with pytest.raises(client_module.UpdateFailed) as exc_info:
+        await client_tests._fetch_with_response(
+            client_module,
+            response,
+            api_key=api_key,
+        )
+
+    surfaced = str(exc_info.value)
+    detail = surfaced.removeprefix("HTTP 400: ")
+    assert api_key not in surfaced
+    assert api_key[:10] not in surfaced
+    assert "***" in surfaced
+    assert len(detail) <= client_module._MAX_HTTP_ERROR_MESSAGE_LENGTH
+
+
+@pytest.mark.asyncio
+async def test_http_error_redacts_url_and_coordinates_before_truncation(
+    client_module: ModuleType,
+) -> None:
+    """Long credential-bearing URLs must remain safe at the message boundary."""
+
+    api_key = "synthetic-url-secret-0123456789"
+    latitude = 12.3456
+    longitude = -65.4321
+    url = (
+        "https://pollen.googleapis.com/v1/forecast:lookup?"
+        f"key={api_key}&location.latitude={latitude}&"
+        f"location.longitude={longitude}&days=5"
+    )
+    raw_message = f"{'x' * 245} url={url} trailing context"
+    response = client_tests.FakeResponse(
+        status=400,
+        json_results=[ValueError("invalid JSON")],
+        text_body=raw_message,
+    )
+
+    with pytest.raises(client_module.UpdateFailed) as exc_info:
+        await client_tests._fetch_with_response(
+            client_module,
+            response,
+            api_key=api_key,
+            latitude=latitude,
+            longitude=longitude,
+        )
+
+    surfaced = str(exc_info.value)
+    detail = surfaced.removeprefix("HTTP 400: ")
+    assert api_key not in surfaced
+    assert str(latitude) not in surfaced
+    assert str(longitude) not in surfaced
+    assert "url=***" in surfaced
+    assert len(detail) <= client_module._MAX_HTTP_ERROR_MESSAGE_LENGTH

--- a/tests/test_client_redaction_truncation.py
+++ b/tests/test_client_redaction_truncation.py
@@ -48,6 +48,35 @@ async def test_http_error_redacts_key_before_truncation(
 
 
 @pytest.mark.asyncio
+async def test_http_error_redacts_coordinate_crossing_truncation_boundary(
+    client_module: ModuleType,
+) -> None:
+    """A standalone coordinate crossing the boundary must not leak a fragment."""
+
+    latitude = 12.3456
+    raw_message = f"{'x' * 296}{latitude} trailing context"
+    response = client_tests.FakeResponse(
+        status=400,
+        json_results=[{"error": {"message": raw_message}}],
+    )
+
+    with pytest.raises(client_module.UpdateFailed) as exc_info:
+        await client_tests._fetch_with_response(
+            client_module,
+            response,
+            latitude=latitude,
+        )
+
+    surfaced = str(exc_info.value)
+    detail = surfaced.removeprefix("HTTP 400: ")
+    coordinate_fragment = str(latitude)[:4]
+    assert str(latitude) not in surfaced
+    assert coordinate_fragment not in surfaced
+    assert "***" in surfaced
+    assert len(detail) <= client_module._MAX_HTTP_ERROR_MESSAGE_LENGTH
+
+
+@pytest.mark.asyncio
 async def test_http_error_redacts_url_and_coordinates_before_truncation(
     client_module: ModuleType,
 ) -> None:


### PR DESCRIPTION
## Summary

Fix #366 by ensuring HTTP error text is redacted before the 300-character display bound is applied.

- keep `extract_error_message()` bounded by default for compatibility, while allowing the API client to request the normalized unbounded message;
- redact API keys and precise coordinates first in `_async_redacted_http_message()`;
- only then apply the existing 300-character HTTP error-message limit;
- add focused regression coverage for JSON and text-fallback messages where a synthetic API key crosses the old truncation boundary;
- add coverage for long credential-bearing URLs and precise coordinates at the same boundary.

## Scope

No changes to retry/backoff/cooldown behavior, HTTP status classification, migration, registry identity, entities, services, translations, or release metadata.

## Validation

The normal repository CI is expected to validate Ruff/formatting, pytest and coverage, hassfest/HACS/package checks, workflow security, and CodeQL.

Fixes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for failed API requests by ensuring sensitive information, including API keys, URLs, and location coordinates, is removed before error details are displayed.
  - Limited surfaced HTTP error messages to a manageable length while preserving the most relevant redacted details.
  - Added safeguards covering errors returned in both structured and plain-text formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->