### PR TITLE
ci: render baseline updater PR body with real newlines

### DIFF
--- a/.github/workflows/ha-test-baseline-updater.yml
+++ b/.github/workflows/ha-test-baseline-updater.yml
@@ -187,7 +187,7 @@ jobs:
               "- Full pytest: `__PYTEST_RESULT__`", "- Minimum-HA files were untouched.",
               "- No automerge is enabled.",
               "- This PR was created with the repository `GITHUB_TOKEN`; a repository writer must select **Approve workflows to run** for CI."
-            ] | join("\\n")
+            ] | join("\n")
           ' "$RUNNER_TEMP/plan.json" > "$artifact_dir/pr-body.md"
           cp pyproject.toml uv.lock "$RUNNER_TEMP/plan.json" "$artifact_dir/"
           (cd "$artifact_dir" && sha256sum plan.json pr-body.md pyproject.toml uv.lock > SHA256SUMS)


### PR DESCRIPTION
## Summary

Closes #369.

The Home Assistant test baseline updater currently joins generated PR-body lines with `"\\n"`, which makes jq emit the literal characters backslash + `n` instead of real line breaks.

## Change

Change exactly one jq expression:

```jq
] | join("\\n")
```

to:

```jq
] | join("\n")
```

This preserves the existing body text and all publication behavior while producing normal Markdown paragraphs/list items.

## Validation

A focused jq reproduction confirms the behavior:

- `join("\\n")` produces literal `a\n\nb` text;
- `join("\n")` produces three real lines (`a`, blank line, `b`).

Repository comparison confirms exactly one file and one line changed: 1 addition / 1 deletion.

## Scope preserved

Unchanged:

- #368 pytest exit-status semantics and `env.PYTEST_RESULT` replacement;
- `__PYTEST_RESULT__` placeholder flow;
- artifact composition and SHA256 sealing/verification;
- workflow permissions;
- concurrency;
- action pinning;
- dependency selection and lock handling;
- publication gates and branch-safety checks;
- runtime, migration, registry identity, release metadata and documentation.

Hosted workflow/security checks should provide final validation before merge.