### PR TITLE
release: prepare 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [4.0.1] - 2026-09-12
+
+### Changed
+
+- Removed the obsolete parent-coordinate runtime fallback so normal runtime
+  operation relies only on configured location subentries, while preserving the
+  pre-migration config-flow validation fallback used for legacy recovery.
+
+### Fixed
+
+- Redacted sensitive HTTP error data before truncation so bounded upstream error
+  messages cannot retain fragments of API keys or precise configured
+  coordinates.
+- Revalidated captured `pollenlevels.force_update` targets immediately before
+  refresh so locations removed while a global service call is already running
+  are skipped safely.
+
 ## [4.0.0] - 2026-08-20
 
 ### Changed

--- a/custom_components/pollenlevels/manifest.json
+++ b/custom_components/pollenlevels/manifest.json
@@ -7,5 +7,5 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/eXPerience83/pollenlevels/issues",
-    "version": "4.0.0"
+    "version": "4.0.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pollenlevels"
-version = "4.0.0"
+version = "4.0.1"
 # Keep broad project metadata while the locked HA test environment enforces >=3.14.2.
 requires-python = ">=3.14"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1551,7 +1551,7 @@ wheels = [
 
 [[package]]
 name = "pollenlevels"
-version = "4.0.0"
+version = "4.0.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Prepare Pollen Levels 4.0.1.
- Ship the HTTP error redaction ordering fix from #366 / #371.
- Ship stale `pollenlevels.force_update` target revalidation from #367 / #375.
- Include the normal-runtime parent-coordinate fallback cleanup from #378 / #381.
- Synchronize manifest, project, and local lockfile versions.

## Release contents

### Changed

- Removed the obsolete parent-coordinate runtime fallback so normal runtime
  operation relies only on configured location subentries, while retaining the
  pre-migration config-flow validation fallback used for legacy recovery.

### Fixed

- Redacts sensitive HTTP error data before truncation so bounded upstream error
  messages cannot retain fragments of API keys or precise configured coordinates.
- Revalidates captured `pollenlevels.force_update` targets immediately before
  refresh so locations removed while a global service call is already running
  are skipped safely.

## Scope

This is a release-only PR. It changes only `CHANGELOG.md`,
`custom_components/pollenlevels/manifest.json`, `pyproject.toml`, and `uv.lock`.
No runtime, migration, entity-identity, dependency, workflow, translation, or
public-contract changes are introduced in this PR; the shipped runtime changes
are already merged on `main`.

`uv.lock` changes only the local `pollenlevels` version from 4.0.0 to 4.0.1.

Closes #382.

## Validation

CI should run the repository's normal release gates. Before merge verify:

- `uv lock --check`
- Ruff check and format
- `python -m compileall -q custom_components tests`
- full pytest
- Minimum Home Assistant Compatibility
- hassfest
- HACS validation
- Package Test
- Workflow Security
- CodeQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Removed the obsolete runtime fallback for parent coordinates; normal operation now uses configured location entries.
  - Legacy configuration recovery continues to support validation fallback during migration.

- **Bug Fixes**
  - Sensitive details, including API-key fragments and precise coordinates, are now redacted from bounded HTTP error messages.
  - Global refresh operations recheck locations immediately before updating them, safely skipping locations removed during processing.

- **Chores**
  - Updated the integration version to 4.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->